### PR TITLE
Add classification pipeline with dirty detection

### DIFF
--- a/src/classification.rs
+++ b/src/classification.rs
@@ -1,1 +1,330 @@
-// Classification pipeline — implemented in PR 2.
+use std::path::Path;
+
+use crate::dirty;
+use crate::error::Error;
+use crate::git::GitOps;
+use crate::types::{Annotations, Classification, WorktreeInfo};
+
+/// Detect the default branch for a repo.
+/// 1. Try `git symbolic-ref refs/remotes/origin/HEAD`
+/// 2. Probe for `origin/main`, then `origin/master`
+/// 3. Return error if neither exists
+pub fn detect_default_branch(git: &dyn GitOps, repo: &Path) -> Result<String, Error> {
+    // Method 1: symbolic-ref
+    if let Some(branch) = git.symbolic_ref_origin_head(repo)? {
+        return Ok(branch);
+    }
+
+    // Method 2: probe for origin/main
+    if git.rev_parse_verify(repo, "refs/remotes/origin/main")? {
+        return Ok("main".to_string());
+    }
+
+    // Method 3: probe for origin/master
+    if git.rev_parse_verify(repo, "refs/remotes/origin/master")? {
+        return Ok("master".to_string());
+    }
+
+    Err(Error::NoDefaultBranch {
+        repo: repo.to_path_buf(),
+    })
+}
+
+/// Classify a single worktree.
+pub fn classify_worktree(
+    git: &dyn GitOps,
+    worktree_path: &Path,
+    parent_repo: &Path,
+    default_branch: &str,
+    behind_threshold: usize,
+) -> Result<WorktreeInfo, Error> {
+    let branch = git.worktree_branch(worktree_path)?;
+    let origin_default = format!("origin/{default_branch}");
+
+    // Determine the ref to compare against
+    let branch_ref = match &branch {
+        Some(b) => b.clone(),
+        None => {
+            // Detached HEAD — use the HEAD commit directly
+            git.rev_parse(worktree_path, "HEAD")?
+        }
+    };
+
+    // Check remote tracking branch
+    let remote_ref = branch
+        .as_ref()
+        .map(|b| format!("refs/remotes/origin/{b}"));
+    let has_remote = match &remote_ref {
+        Some(rr) => git.rev_parse_verify(parent_repo, rr)?,
+        None => false,
+    };
+
+    // Remote deleted: had a tracking branch that no longer exists after fetch --prune
+    // (We check after fetch, so if it doesn't exist, it was pruned)
+    let remote_deleted = branch.is_some() && !has_remote;
+
+    // Ahead/behind counts
+    let (behind, ahead) = git.rev_list_left_right_count(
+        parent_repo,
+        &origin_default,
+        &branch_ref,
+    )?;
+
+    // Dirty detection
+    let dirty_result = dirty::check_dirty(git, worktree_path)?;
+
+    // Check if merged
+    let is_merged = git.is_ancestor(parent_repo, &branch_ref, &origin_default)?;
+
+    let classification = if is_merged {
+        Classification::Merged
+    } else {
+        // Check for landed commits (basic: just count exclusive commits for now)
+        // Full landed detection will be implemented in PR 3
+        let unique_commits = git.log_exclusive(parent_repo, &origin_default, &branch_ref)?;
+
+        if unique_commits.is_empty() {
+            // No unique commits — effectively merged
+            Classification::Merged
+        } else if has_remote {
+            Classification::Active
+        } else {
+            Classification::Local
+        }
+    };
+
+    let annotations = Annotations {
+        remote_deleted,
+        diverged: behind > behind_threshold,
+        dirty: !dirty_result.meaningful_files.is_empty(),
+        dirty_file_count: dirty_result.meaningful_files.len(),
+    };
+
+    Ok(WorktreeInfo {
+        path: worktree_path.to_path_buf(),
+        parent_repo: parent_repo.to_path_buf(),
+        branch,
+        default_branch: default_branch.to_string(),
+        classification,
+        annotations,
+        remote_tracking: has_remote,
+        ahead,
+        behind,
+        dirty_files: dirty_result.all_files,
+        meaningful_dirty_files: dirty_result.meaningful_files,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::git::tests::MockGitBuilder;
+
+    fn repo() -> PathBuf {
+        PathBuf::from("/repo")
+    }
+
+    fn wt() -> PathBuf {
+        PathBuf::from("/worktree")
+    }
+
+    #[test]
+    fn detect_default_branch_symbolic_ref() {
+        let git = MockGitBuilder::new()
+            .with_symbolic_ref(&repo(), Some("main"))
+            .build();
+        let result = detect_default_branch(&git, &repo()).unwrap();
+        assert_eq!(result, "main");
+    }
+
+    #[test]
+    fn detect_default_branch_probe_main() {
+        let git = MockGitBuilder::new()
+            .with_symbolic_ref(&repo(), None)
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/main", true)
+            .build();
+        let result = detect_default_branch(&git, &repo()).unwrap();
+        assert_eq!(result, "main");
+    }
+
+    #[test]
+    fn detect_default_branch_probe_master() {
+        let git = MockGitBuilder::new()
+            .with_symbolic_ref(&repo(), None)
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/main", false)
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/master", true)
+            .build();
+        let result = detect_default_branch(&git, &repo()).unwrap();
+        assert_eq!(result, "master");
+    }
+
+    #[test]
+    fn detect_default_branch_none() {
+        let git = MockGitBuilder::new()
+            .with_symbolic_ref(&repo(), None)
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/main", false)
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/master", false)
+            .build();
+        let result = detect_default_branch(&git, &repo());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn classify_merged_branch() {
+        let git = MockGitBuilder::new()
+            .with_worktree_branch(&wt(), Some("feature/done"))
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/feature/done", true)
+            .with_rev_list_counts(&repo(), "origin/main", "feature/done", (0, 0))
+            .with_is_ancestor(&repo(), "feature/done", "origin/main", true)
+            .with_status_porcelain(&wt(), vec![])
+            .build();
+
+        let info = classify_worktree(&git, &wt(), &repo(), "main", 100).unwrap();
+        assert_eq!(info.classification, Classification::Merged);
+        assert!(!info.annotations.dirty);
+        assert!(!info.annotations.remote_deleted);
+    }
+
+    #[test]
+    fn classify_active_branch() {
+        let git = MockGitBuilder::new()
+            .with_worktree_branch(&wt(), Some("feature/wip"))
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/feature/wip", true)
+            .with_rev_list_counts(&repo(), "origin/main", "feature/wip", (5, 3))
+            .with_is_ancestor(&repo(), "feature/wip", "origin/main", false)
+            .with_log_exclusive(
+                &repo(),
+                "origin/main",
+                "feature/wip",
+                vec![("abc".into(), "add feature".into())],
+            )
+            .with_status_porcelain(&wt(), vec![])
+            .build();
+
+        let info = classify_worktree(&git, &wt(), &repo(), "main", 100).unwrap();
+        assert_eq!(info.classification, Classification::Active);
+        assert_eq!(info.ahead, 3);
+        assert_eq!(info.behind, 5);
+    }
+
+    #[test]
+    fn classify_local_branch() {
+        let git = MockGitBuilder::new()
+            .with_worktree_branch(&wt(), Some("feature/local"))
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/feature/local", false)
+            .with_rev_list_counts(&repo(), "origin/main", "feature/local", (10, 2))
+            .with_is_ancestor(&repo(), "feature/local", "origin/main", false)
+            .with_log_exclusive(
+                &repo(),
+                "origin/main",
+                "feature/local",
+                vec![("def".into(), "local work".into())],
+            )
+            .with_status_porcelain(&wt(), vec![])
+            .build();
+
+        let info = classify_worktree(&git, &wt(), &repo(), "main", 100).unwrap();
+        assert_eq!(info.classification, Classification::Local);
+        assert!(!info.remote_tracking);
+    }
+
+    #[test]
+    fn classify_dirty_branch() {
+        let git = MockGitBuilder::new()
+            .with_worktree_branch(&wt(), Some("feature/dirty"))
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/feature/dirty", true)
+            .with_rev_list_counts(&repo(), "origin/main", "feature/dirty", (0, 1))
+            .with_is_ancestor(&repo(), "feature/dirty", "origin/main", false)
+            .with_log_exclusive(
+                &repo(),
+                "origin/main",
+                "feature/dirty",
+                vec![("ghi".into(), "wip".into())],
+            )
+            .with_status_porcelain(
+                &wt(),
+                vec![
+                    " M src/main.rs".to_string(),
+                    "?? .DS_Store".to_string(),
+                ],
+            )
+            .build();
+
+        let info = classify_worktree(&git, &wt(), &repo(), "main", 100).unwrap();
+        assert!(info.annotations.dirty);
+        assert_eq!(info.annotations.dirty_file_count, 1); // .DS_Store filtered
+    }
+
+    #[test]
+    fn classify_diverged_branch() {
+        let git = MockGitBuilder::new()
+            .with_worktree_branch(&wt(), Some("feature/old"))
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/feature/old", true)
+            .with_rev_list_counts(&repo(), "origin/main", "feature/old", (150, 5))
+            .with_is_ancestor(&repo(), "feature/old", "origin/main", false)
+            .with_log_exclusive(
+                &repo(),
+                "origin/main",
+                "feature/old",
+                vec![("jkl".into(), "old work".into())],
+            )
+            .with_status_porcelain(&wt(), vec![])
+            .build();
+
+        let info = classify_worktree(&git, &wt(), &repo(), "main", 100).unwrap();
+        assert!(info.annotations.diverged);
+        assert_eq!(info.behind, 150);
+    }
+
+    #[test]
+    fn classify_remote_deleted() {
+        let git = MockGitBuilder::new()
+            .with_worktree_branch(&wt(), Some("feature/gone"))
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/feature/gone", false)
+            .with_rev_list_counts(&repo(), "origin/main", "feature/gone", (0, 0))
+            .with_is_ancestor(&repo(), "feature/gone", "origin/main", true)
+            .with_status_porcelain(&wt(), vec![])
+            .build();
+
+        let info = classify_worktree(&git, &wt(), &repo(), "main", 100).unwrap();
+        assert_eq!(info.classification, Classification::Merged);
+        assert!(info.annotations.remote_deleted);
+    }
+
+    #[test]
+    fn classify_detached_head_merged() {
+        let git = MockGitBuilder::new()
+            .with_worktree_branch(&wt(), None) // detached HEAD
+            .with_rev_parse(&wt(), "HEAD", "abc123def")
+            .with_rev_list_counts(&repo(), "origin/main", "abc123def", (0, 0))
+            .with_is_ancestor(&repo(), "abc123def", "origin/main", true)
+            .with_status_porcelain(&wt(), vec![])
+            .build();
+
+        let info = classify_worktree(&git, &wt(), &repo(), "main", 100).unwrap();
+        assert_eq!(info.classification, Classification::Merged);
+        assert!(info.branch.is_none());
+    }
+
+    #[test]
+    fn classify_detached_head_local() {
+        let git = MockGitBuilder::new()
+            .with_worktree_branch(&wt(), None)
+            .with_rev_parse(&wt(), "HEAD", "def456abc")
+            .with_rev_list_counts(&repo(), "origin/main", "def456abc", (10, 3))
+            .with_is_ancestor(&repo(), "def456abc", "origin/main", false)
+            .with_log_exclusive(
+                &repo(),
+                "origin/main",
+                "def456abc",
+                vec![("xyz".into(), "detached work".into())],
+            )
+            .with_status_porcelain(&wt(), vec![])
+            .build();
+
+        let info = classify_worktree(&git, &wt(), &repo(), "main", 100).unwrap();
+        assert_eq!(info.classification, Classification::Local);
+    }
+}

--- a/src/dirty.rs
+++ b/src/dirty.rs
@@ -1,1 +1,194 @@
-// Dirty detection — implemented in PR 2.
+use std::path::Path;
+
+use crate::error::Error;
+use crate::git::GitOps;
+
+/// Files that are always considered noise regardless of gitignore status.
+const NOISE_PATTERNS: &[&str] = &[
+    ".DS_Store",
+    "*.pyc",
+    "__pycache__",
+    "uv.lock",
+    "package-lock.json",
+    "Podfile.lock",
+    "yarn.lock",
+];
+
+/// Result of dirty detection on a worktree.
+#[derive(Debug, Clone)]
+pub struct DirtyResult {
+    /// All dirty file paths from `git status --porcelain`.
+    pub all_files: Vec<String>,
+    /// Only the meaningful dirty files (not noise).
+    pub meaningful_files: Vec<String>,
+}
+
+/// Check a worktree for dirty (uncommitted) files, filtering out noise.
+pub fn check_dirty(git: &dyn GitOps, worktree_path: &Path) -> Result<DirtyResult, Error> {
+    let lines = git.status_porcelain(worktree_path)?;
+
+    let mut all_files = Vec::new();
+    let mut meaningful_files = Vec::new();
+
+    for line in &lines {
+        if line.len() < 4 {
+            continue;
+        }
+        let status_code = &line[..2];
+        let file_path = line[3..].trim();
+
+        if file_path.is_empty() {
+            continue;
+        }
+
+        all_files.push(file_path.to_string());
+
+        // Untracked files that match noise patterns are not meaningful
+        if status_code == "??" && is_noise(file_path) {
+            continue;
+        }
+
+        // All other dirty files (modified tracked, staged, untracked non-noise) are meaningful
+        meaningful_files.push(file_path.to_string());
+    }
+
+    Ok(DirtyResult {
+        all_files,
+        meaningful_files,
+    })
+}
+
+/// Check if a file path matches any noise pattern.
+fn is_noise(file_path: &str) -> bool {
+    let basename = Path::new(file_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(file_path);
+
+    for pattern in NOISE_PATTERNS {
+        if let Some(suffix) = pattern.strip_prefix('*') {
+            // Suffix match: *.pyc matches any file ending in .pyc
+            if basename.ends_with(suffix) {
+                return true;
+            }
+        } else {
+            // Exact basename match
+            if basename == *pattern {
+                return true;
+            }
+            // Also match as a directory component
+            if file_path.contains(&format!("{pattern}/")) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::git::tests::MockGitBuilder;
+
+    #[test]
+    fn is_noise_ds_store() {
+        assert!(is_noise(".DS_Store"));
+        assert!(is_noise("subdir/.DS_Store"));
+    }
+
+    #[test]
+    fn is_noise_pyc() {
+        assert!(is_noise("module.pyc"));
+        assert!(is_noise("src/module.pyc"));
+    }
+
+    #[test]
+    fn is_noise_pycache() {
+        assert!(is_noise("__pycache__"));
+        assert!(is_noise("src/__pycache__/module.cpython-39.pyc"));
+    }
+
+    #[test]
+    fn is_noise_lockfiles() {
+        assert!(is_noise("uv.lock"));
+        assert!(is_noise("package-lock.json"));
+        assert!(is_noise("Podfile.lock"));
+        assert!(is_noise("yarn.lock"));
+    }
+
+    #[test]
+    fn is_not_noise_regular_files() {
+        assert!(!is_noise("main.rs"));
+        assert!(!is_noise("src/lib.rs"));
+        assert!(!is_noise("Cargo.toml"));
+        assert!(!is_noise("README.md"));
+    }
+
+    #[test]
+    fn check_dirty_all_noise() {
+        let path = PathBuf::from("/worktree");
+        let git = MockGitBuilder::new()
+            .with_status_porcelain(
+                &path,
+                vec![
+                    "?? .DS_Store".to_string(),
+                    "?? __pycache__/".to_string(),
+                    "?? uv.lock".to_string(),
+                ],
+            )
+            .build();
+
+        let result = check_dirty(&git, &path).unwrap();
+        assert_eq!(result.all_files.len(), 3);
+        assert!(result.meaningful_files.is_empty());
+    }
+
+    #[test]
+    fn check_dirty_mixed() {
+        let path = PathBuf::from("/worktree");
+        let git = MockGitBuilder::new()
+            .with_status_porcelain(
+                &path,
+                vec![
+                    " M src/main.rs".to_string(),
+                    "?? .DS_Store".to_string(),
+                    "?? new_file.txt".to_string(),
+                ],
+            )
+            .build();
+
+        let result = check_dirty(&git, &path).unwrap();
+        assert_eq!(result.all_files.len(), 3);
+        assert_eq!(result.meaningful_files.len(), 2);
+        assert!(result.meaningful_files.contains(&"src/main.rs".to_string()));
+        assert!(result.meaningful_files.contains(&"new_file.txt".to_string()));
+    }
+
+    #[test]
+    fn check_dirty_staged_changes() {
+        let path = PathBuf::from("/worktree");
+        let git = MockGitBuilder::new()
+            .with_status_porcelain(
+                &path,
+                vec!["M  src/lib.rs".to_string(), "A  new.rs".to_string()],
+            )
+            .build();
+
+        let result = check_dirty(&git, &path).unwrap();
+        assert_eq!(result.meaningful_files.len(), 2);
+    }
+
+    #[test]
+    fn check_dirty_empty() {
+        let path = PathBuf::from("/worktree");
+        let git = MockGitBuilder::new()
+            .with_status_porcelain(&path, vec![])
+            .build();
+
+        let result = check_dirty(&git, &path).unwrap();
+        assert!(result.all_files.is_empty());
+        assert!(result.meaningful_files.is_empty());
+    }
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -327,8 +327,475 @@ impl GitOps for RealGit {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
     use super::*;
+
+    /// Builder for constructing a MockGit with canned responses.
+    #[derive(Default)]
+    pub struct MockGitBuilder {
+        symbolic_ref: HashMap<PathBuf, Option<String>>,
+        rev_parse_verify: HashMap<(PathBuf, String), bool>,
+        is_ancestor: HashMap<(PathBuf, String, String), bool>,
+        rev_list_counts: HashMap<(PathBuf, String, String), (usize, usize)>,
+        log_exclusive: HashMap<(PathBuf, String, String), Vec<(String, String)>>,
+        log_grep: HashMap<(PathBuf, String, String), Vec<(String, String)>>,
+        diff_commit: HashMap<(PathBuf, String), String>,
+        diff_commit_files: HashMap<(PathBuf, String), Vec<String>>,
+        log_touching_files: HashMap<(PathBuf, String), Vec<(String, String)>>,
+        diff_commit_on_ref: HashMap<(PathBuf, String), String>,
+        status_porcelain: HashMap<PathBuf, Vec<String>>,
+        worktree_branch: HashMap<PathBuf, Option<String>>,
+        rev_parse: HashMap<(PathBuf, String), String>,
+        is_branch_checked_out: HashMap<(PathBuf, String), bool>,
+        log_file_history: HashMap<(PathBuf, String, String), Vec<(String, String)>>,
+        fetch_prune_calls: std::cell::RefCell<Vec<PathBuf>>,
+        remove_calls: std::cell::RefCell<Vec<(PathBuf, PathBuf)>>,
+        remove_force_calls: std::cell::RefCell<Vec<(PathBuf, PathBuf)>>,
+        prune_calls: std::cell::RefCell<Vec<PathBuf>>,
+        branch_delete_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+        worktree_remove_errors: HashMap<PathBuf, String>,
+        worktree_remove_force_errors: HashMap<PathBuf, String>,
+    }
+
+    impl MockGitBuilder {
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        pub fn with_symbolic_ref(mut self, repo: &Path, branch: Option<&str>) -> Self {
+            self.symbolic_ref
+                .insert(repo.to_path_buf(), branch.map(|s| s.to_string()));
+            self
+        }
+
+        pub fn with_rev_parse_verify(mut self, repo: &Path, refspec: &str, exists: bool) -> Self {
+            self.rev_parse_verify
+                .insert((repo.to_path_buf(), refspec.to_string()), exists);
+            self
+        }
+
+        pub fn with_is_ancestor(
+            mut self,
+            repo: &Path,
+            branch: &str,
+            target: &str,
+            result: bool,
+        ) -> Self {
+            self.is_ancestor.insert(
+                (repo.to_path_buf(), branch.to_string(), target.to_string()),
+                result,
+            );
+            self
+        }
+
+        pub fn with_rev_list_counts(
+            mut self,
+            repo: &Path,
+            left: &str,
+            right: &str,
+            counts: (usize, usize),
+        ) -> Self {
+            self.rev_list_counts.insert(
+                (repo.to_path_buf(), left.to_string(), right.to_string()),
+                counts,
+            );
+            self
+        }
+
+        pub fn with_log_exclusive(
+            mut self,
+            repo: &Path,
+            base: &str,
+            branch: &str,
+            commits: Vec<(String, String)>,
+        ) -> Self {
+            self.log_exclusive.insert(
+                (repo.to_path_buf(), base.to_string(), branch.to_string()),
+                commits,
+            );
+            self
+        }
+
+        #[allow(dead_code)]
+        pub fn with_log_grep(
+            mut self,
+            repo: &Path,
+            ref_spec: &str,
+            needle: &str,
+            results: Vec<(String, String)>,
+        ) -> Self {
+            self.log_grep.insert(
+                (repo.to_path_buf(), ref_spec.to_string(), needle.to_string()),
+                results,
+            );
+            self
+        }
+
+        pub fn with_status_porcelain(mut self, path: &Path, lines: Vec<String>) -> Self {
+            self.status_porcelain.insert(path.to_path_buf(), lines);
+            self
+        }
+
+        pub fn with_worktree_branch(mut self, path: &Path, branch: Option<&str>) -> Self {
+            self.worktree_branch
+                .insert(path.to_path_buf(), branch.map(|s| s.to_string()));
+            self
+        }
+
+        pub fn with_rev_parse(mut self, repo: &Path, refspec: &str, hash: &str) -> Self {
+            self.rev_parse
+                .insert((repo.to_path_buf(), refspec.to_string()), hash.to_string());
+            self
+        }
+
+        #[allow(dead_code)]
+        pub fn with_is_branch_checked_out(
+            mut self,
+            repo: &Path,
+            branch: &str,
+            checked_out: bool,
+        ) -> Self {
+            self.is_branch_checked_out
+                .insert((repo.to_path_buf(), branch.to_string()), checked_out);
+            self
+        }
+
+        #[allow(dead_code)]
+        pub fn with_diff_commit_files(
+            mut self,
+            repo: &Path,
+            commit: &str,
+            files: Vec<String>,
+        ) -> Self {
+            self.diff_commit_files
+                .insert((repo.to_path_buf(), commit.to_string()), files);
+            self
+        }
+
+        #[allow(dead_code)]
+        pub fn with_diff_commit(mut self, repo: &Path, commit: &str, diff: &str) -> Self {
+            self.diff_commit
+                .insert((repo.to_path_buf(), commit.to_string()), diff.to_string());
+            self
+        }
+
+        #[allow(dead_code)]
+        pub fn with_log_touching_files(
+            mut self,
+            repo: &Path,
+            ref_spec: &str,
+            results: Vec<(String, String)>,
+        ) -> Self {
+            self.log_touching_files
+                .insert((repo.to_path_buf(), ref_spec.to_string()), results);
+            self
+        }
+
+        #[allow(dead_code)]
+        pub fn with_diff_commit_on_ref(mut self, repo: &Path, commit: &str, diff: &str) -> Self {
+            self.diff_commit_on_ref
+                .insert((repo.to_path_buf(), commit.to_string()), diff.to_string());
+            self
+        }
+
+        #[allow(dead_code)]
+        pub fn with_log_file_history(
+            mut self,
+            repo: &Path,
+            ref_spec: &str,
+            file: &str,
+            results: Vec<(String, String)>,
+        ) -> Self {
+            self.log_file_history.insert(
+                (repo.to_path_buf(), ref_spec.to_string(), file.to_string()),
+                results,
+            );
+            self
+        }
+
+        #[allow(dead_code)]
+        pub fn with_worktree_remove_error(mut self, path: &Path, error: &str) -> Self {
+            self.worktree_remove_errors
+                .insert(path.to_path_buf(), error.to_string());
+            self
+        }
+
+        #[allow(dead_code)]
+        pub fn with_worktree_remove_force_error(mut self, path: &Path, error: &str) -> Self {
+            self.worktree_remove_force_errors
+                .insert(path.to_path_buf(), error.to_string());
+            self
+        }
+
+        pub fn build(self) -> MockGit {
+            MockGit {
+                symbolic_ref: self.symbolic_ref,
+                rev_parse_verify: self.rev_parse_verify,
+                is_ancestor: self.is_ancestor,
+                rev_list_counts: self.rev_list_counts,
+                log_exclusive: self.log_exclusive,
+                log_grep: self.log_grep,
+                diff_commit: self.diff_commit,
+                diff_commit_files: self.diff_commit_files,
+                log_touching_files: self.log_touching_files,
+                diff_commit_on_ref: self.diff_commit_on_ref,
+                status_porcelain: self.status_porcelain,
+                worktree_branch: self.worktree_branch,
+                rev_parse: self.rev_parse,
+                is_branch_checked_out: self.is_branch_checked_out,
+                log_file_history: self.log_file_history,
+                fetch_prune_calls: self.fetch_prune_calls,
+                remove_calls: self.remove_calls,
+                remove_force_calls: self.remove_force_calls,
+                prune_calls: self.prune_calls,
+                branch_delete_calls: self.branch_delete_calls,
+                worktree_remove_errors: self.worktree_remove_errors,
+                worktree_remove_force_errors: self.worktree_remove_force_errors,
+            }
+        }
+    }
+
+    pub struct MockGit {
+        symbolic_ref: HashMap<PathBuf, Option<String>>,
+        rev_parse_verify: HashMap<(PathBuf, String), bool>,
+        is_ancestor: HashMap<(PathBuf, String, String), bool>,
+        rev_list_counts: HashMap<(PathBuf, String, String), (usize, usize)>,
+        log_exclusive: HashMap<(PathBuf, String, String), Vec<(String, String)>>,
+        log_grep: HashMap<(PathBuf, String, String), Vec<(String, String)>>,
+        diff_commit: HashMap<(PathBuf, String), String>,
+        diff_commit_files: HashMap<(PathBuf, String), Vec<String>>,
+        log_touching_files: HashMap<(PathBuf, String), Vec<(String, String)>>,
+        diff_commit_on_ref: HashMap<(PathBuf, String), String>,
+        status_porcelain: HashMap<PathBuf, Vec<String>>,
+        worktree_branch: HashMap<PathBuf, Option<String>>,
+        rev_parse: HashMap<(PathBuf, String), String>,
+        is_branch_checked_out: HashMap<(PathBuf, String), bool>,
+        log_file_history: HashMap<(PathBuf, String, String), Vec<(String, String)>>,
+        fetch_prune_calls: std::cell::RefCell<Vec<PathBuf>>,
+        remove_calls: std::cell::RefCell<Vec<(PathBuf, PathBuf)>>,
+        remove_force_calls: std::cell::RefCell<Vec<(PathBuf, PathBuf)>>,
+        prune_calls: std::cell::RefCell<Vec<PathBuf>>,
+        branch_delete_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+        worktree_remove_errors: HashMap<PathBuf, String>,
+        worktree_remove_force_errors: HashMap<PathBuf, String>,
+    }
+
+    #[allow(dead_code)]
+    impl MockGit {
+        pub fn fetch_prune_calls(&self) -> Vec<PathBuf> {
+            self.fetch_prune_calls.borrow().clone()
+        }
+
+        pub fn remove_calls(&self) -> Vec<(PathBuf, PathBuf)> {
+            self.remove_calls.borrow().clone()
+        }
+
+        pub fn remove_force_calls(&self) -> Vec<(PathBuf, PathBuf)> {
+            self.remove_force_calls.borrow().clone()
+        }
+
+        pub fn branch_delete_calls(&self) -> Vec<(PathBuf, String)> {
+            self.branch_delete_calls.borrow().clone()
+        }
+    }
+
+    impl GitOps for MockGit {
+        fn fetch_prune(&self, repo: &Path) -> GitResult<()> {
+            self.fetch_prune_calls.borrow_mut().push(repo.to_path_buf());
+            Ok(())
+        }
+
+        fn symbolic_ref_origin_head(&self, repo: &Path) -> GitResult<Option<String>> {
+            Ok(self
+                .symbolic_ref
+                .get(&repo.to_path_buf())
+                .cloned()
+                .unwrap_or(None))
+        }
+
+        fn rev_parse_verify(&self, repo: &Path, refspec: &str) -> GitResult<bool> {
+            Ok(*self
+                .rev_parse_verify
+                .get(&(repo.to_path_buf(), refspec.to_string()))
+                .unwrap_or(&false))
+        }
+
+        fn is_ancestor(&self, repo: &Path, branch: &str, target: &str) -> GitResult<bool> {
+            Ok(*self
+                .is_ancestor
+                .get(&(repo.to_path_buf(), branch.to_string(), target.to_string()))
+                .unwrap_or(&false))
+        }
+
+        fn rev_list_left_right_count(
+            &self,
+            repo: &Path,
+            left: &str,
+            right: &str,
+        ) -> GitResult<(usize, usize)> {
+            Ok(*self
+                .rev_list_counts
+                .get(&(repo.to_path_buf(), left.to_string(), right.to_string()))
+                .unwrap_or(&(0, 0)))
+        }
+
+        fn log_exclusive(
+            &self,
+            repo: &Path,
+            base: &str,
+            branch: &str,
+        ) -> GitResult<Vec<(String, String)>> {
+            Ok(self
+                .log_exclusive
+                .get(&(repo.to_path_buf(), base.to_string(), branch.to_string()))
+                .cloned()
+                .unwrap_or_default())
+        }
+
+        fn log_grep(
+            &self,
+            repo: &Path,
+            branch_or_ref: &str,
+            needle: &str,
+        ) -> GitResult<Vec<(String, String)>> {
+            Ok(self
+                .log_grep
+                .get(&(
+                    repo.to_path_buf(),
+                    branch_or_ref.to_string(),
+                    needle.to_string(),
+                ))
+                .cloned()
+                .unwrap_or_default())
+        }
+
+        fn diff_commit(&self, repo: &Path, commit: &str) -> GitResult<String> {
+            Ok(self
+                .diff_commit
+                .get(&(repo.to_path_buf(), commit.to_string()))
+                .cloned()
+                .unwrap_or_default())
+        }
+
+        fn diff_commit_files(&self, repo: &Path, commit: &str) -> GitResult<Vec<String>> {
+            Ok(self
+                .diff_commit_files
+                .get(&(repo.to_path_buf(), commit.to_string()))
+                .cloned()
+                .unwrap_or_default())
+        }
+
+        fn log_touching_files(
+            &self,
+            repo: &Path,
+            ref_spec: &str,
+            _files: &[String],
+        ) -> GitResult<Vec<(String, String)>> {
+            Ok(self
+                .log_touching_files
+                .get(&(repo.to_path_buf(), ref_spec.to_string()))
+                .cloned()
+                .unwrap_or_default())
+        }
+
+        fn diff_commit_on_ref(&self, repo: &Path, commit_hash: &str) -> GitResult<String> {
+            Ok(self
+                .diff_commit_on_ref
+                .get(&(repo.to_path_buf(), commit_hash.to_string()))
+                .cloned()
+                .unwrap_or_default())
+        }
+
+        fn status_porcelain(&self, worktree_path: &Path) -> GitResult<Vec<String>> {
+            Ok(self
+                .status_porcelain
+                .get(&worktree_path.to_path_buf())
+                .cloned()
+                .unwrap_or_default())
+        }
+
+        fn worktree_branch(&self, worktree_path: &Path) -> GitResult<Option<String>> {
+            Ok(self
+                .worktree_branch
+                .get(&worktree_path.to_path_buf())
+                .cloned()
+                .unwrap_or(None))
+        }
+
+        fn rev_parse(&self, repo: &Path, refspec: &str) -> GitResult<String> {
+            self.rev_parse
+                .get(&(repo.to_path_buf(), refspec.to_string()))
+                .cloned()
+                .ok_or_else(|| Error::GitCommand {
+                    command: format!("rev-parse {refspec}"),
+                    message: "not found in mock".to_string(),
+                })
+        }
+
+        fn worktree_remove(&self, repo: &Path, worktree_path: &Path) -> GitResult<()> {
+            if let Some(err) = self.worktree_remove_errors.get(&worktree_path.to_path_buf()) {
+                return Err(Error::RemovalFailed {
+                    path: worktree_path.to_path_buf(),
+                    reason: err.clone(),
+                });
+            }
+            self.remove_calls
+                .borrow_mut()
+                .push((repo.to_path_buf(), worktree_path.to_path_buf()));
+            Ok(())
+        }
+
+        fn worktree_remove_force(&self, repo: &Path, worktree_path: &Path) -> GitResult<()> {
+            if let Some(err) = self
+                .worktree_remove_force_errors
+                .get(&worktree_path.to_path_buf())
+            {
+                return Err(Error::RemovalFailed {
+                    path: worktree_path.to_path_buf(),
+                    reason: err.clone(),
+                });
+            }
+            self.remove_force_calls
+                .borrow_mut()
+                .push((repo.to_path_buf(), worktree_path.to_path_buf()));
+            Ok(())
+        }
+
+        fn worktree_prune(&self, repo: &Path) -> GitResult<()> {
+            self.prune_calls.borrow_mut().push(repo.to_path_buf());
+            Ok(())
+        }
+
+        fn branch_delete(&self, repo: &Path, branch: &str) -> GitResult<()> {
+            self.branch_delete_calls
+                .borrow_mut()
+                .push((repo.to_path_buf(), branch.to_string()));
+            Ok(())
+        }
+
+        fn is_branch_checked_out(&self, repo: &Path, branch: &str) -> GitResult<bool> {
+            Ok(*self
+                .is_branch_checked_out
+                .get(&(repo.to_path_buf(), branch.to_string()))
+                .unwrap_or(&false))
+        }
+
+        fn log_file_history(
+            &self,
+            repo: &Path,
+            ref_spec: &str,
+            file: &str,
+        ) -> GitResult<Vec<(String, String)>> {
+            Ok(self
+                .log_file_history
+                .get(&(repo.to_path_buf(), ref_spec.to_string(), file.to_string()))
+                .cloned()
+                .unwrap_or_default())
+        }
+    }
 
     #[test]
     fn parse_log_oneline_basic() {


### PR DESCRIPTION
## Summary
- Dirty detection with noise filtering (.DS_Store, *.pyc, lockfiles, etc.)
- Merged detection via `merge-base --is-ancestor`
- Active vs local classification based on remote tracking ref presence
- Annotations: remote_deleted, diverged, dirty with file counts
- Ahead/behind counts, detached HEAD handling, default branch detection
- `MockGitBuilder` moved into `git.rs` `#[cfg(test)]` module for cross-module test reuse

Part of #1. Landed detection deferred to PR 3.

## Test plan
- [x] Unit tests for noise filtering (DS_Store, pyc, lockfiles, regular files)
- [x] Unit tests for dirty detection (all noise, mixed, staged, empty)
- [x] Unit tests for default branch detection (symbolic-ref, probe main, probe master, none)
- [x] Unit tests for classification (merged, active, local, dirty, diverged, remote deleted, detached HEAD)
- [x] All 42 tests pass