### PR TITLE
Fix diff commands failing on root commits

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -215,14 +215,13 @@ impl GitOps for RealGit {
     }
 
     fn diff_commit(&self, repo: &Path, commit: &str) -> GitResult<String> {
-        let range = format!("{commit}^..{commit}");
-        Self::run_success(repo, &["diff", &range])
+        Self::run_success(repo, &["diff-tree", "-p", "--root", commit])
     }
 
     fn diff_commit_files(&self, repo: &Path, commit: &str) -> GitResult<Vec<String>> {
         let text = Self::run_success(
             repo,
-            &["diff-tree", "--no-commit-id", "-r", "--name-only", commit],
+            &["diff-tree", "--root", "--no-commit-id", "-r", "--name-only", commit],
         )?;
         Ok(text.lines().map(|l| l.to_string()).collect())
     }
@@ -242,8 +241,7 @@ impl GitOps for RealGit {
     }
 
     fn diff_commit_on_ref(&self, repo: &Path, commit_hash: &str) -> GitResult<String> {
-        let range = format!("{commit_hash}^..{commit_hash}");
-        Self::run_success(repo, &["diff", &range])
+        Self::run_success(repo, &["diff-tree", "-p", "--root", commit_hash])
     }
 
     fn status_porcelain(&self, worktree_path: &Path) -> GitResult<Vec<String>> {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -532,7 +532,7 @@ impl TestRepo {
     }
 }
 
-fn git(dir: &Path, args: &[&str]) -> String {
+pub fn git(dir: &Path, args: &[&str]) -> String {
     let output = Command::new("git")
         .arg("-C")
         .arg(dir)

--- a/tests/integration_git.rs
+++ b/tests/integration_git.rs
@@ -1,0 +1,41 @@
+mod common;
+
+use common::TestRepo;
+use git_worktree_tidy::git::{GitOps, RealGit};
+
+#[test]
+fn diff_commit_handles_root_commit() {
+    let test = TestRepo::new();
+    let git = RealGit;
+
+    // The initial commit created by TestRepo::new() is a root commit (no parent)
+    let root_hash = common::git(&test.main_repo, &["rev-parse", "HEAD"]);
+
+    let diff = git.diff_commit(&test.main_repo, &root_hash).unwrap();
+    assert!(diff.contains("README.md"), "root commit diff should show the added file");
+}
+
+#[test]
+fn diff_commit_files_handles_root_commit() {
+    let test = TestRepo::new();
+    let git = RealGit;
+
+    let root_hash = common::git(&test.main_repo, &["rev-parse", "HEAD"]);
+
+    let files = git.diff_commit_files(&test.main_repo, &root_hash).unwrap();
+    assert!(
+        files.contains(&"README.md".to_string()),
+        "root commit should list README.md as a changed file, got: {files:?}"
+    );
+}
+
+#[test]
+fn diff_commit_on_ref_handles_root_commit() {
+    let test = TestRepo::new();
+    let git = RealGit;
+
+    let root_hash = common::git(&test.main_repo, &["rev-parse", "HEAD"]);
+
+    let diff = git.diff_commit_on_ref(&test.main_repo, &root_hash).unwrap();
+    assert!(diff.contains("README.md"), "root commit diff should show the added file");
+}


### PR DESCRIPTION
## Summary
- Replace `git diff HASH^..HASH` with `git diff-tree -p --root HASH` in `diff_commit` and `diff_commit_on_ref`
- Add `--root` flag to `diff_commit_files` so it lists files for initial commits
- Add integration tests for all three methods against root commits

Closes #6

## Test plan
- [x] `diff_commit_handles_root_commit` — verifies diff output contains the added file
- [x] `diff_commit_files_handles_root_commit` — verifies file listing includes the initial file
- [x] `diff_commit_on_ref_handles_root_commit` — verifies diff output contains the added file
- [x] All 90 existing tests pass
- [x] Manual verification: `cargo run -- scan ~/Developer` no longer produces classification warnings