### PR TITLE
Add branch output formatters

### DIFF
--- a/crates/git-branch-tidy/src/lib.rs
+++ b/crates/git-branch-tidy/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod discovery;
+pub mod output;
 pub mod scan;
 pub mod types;
 

--- a/crates/git-branch-tidy/src/main.rs
+++ b/crates/git-branch-tidy/src/main.rs
@@ -6,6 +6,7 @@ use git_tidy_core::git;
 
 mod cli;
 mod discovery;
+mod output;
 mod scan;
 mod types;
 
@@ -19,20 +20,27 @@ fn main() {
     }
 
     let git = git::RealGit;
-    let _stdout = io::stdout().lock();
+    let mut stdout = io::stdout().lock();
 
     match &cli.command {
         None | Some(cli::Command::Scan { .. }) => {
+            let (json, porcelain) = match &cli.command {
+                Some(cli::Command::Scan { json, porcelain }) => (*json, *porcelain),
+                _ => (false, false),
+            };
+
             match scan::run_scan(&git, &directory, cli.behind_threshold, cli.verbose) {
                 Ok(result) => {
-                    // Output formatting will be added in PR 5
-                    eprintln!(
-                        "{} branches scanned across {} repos",
-                        result.total_scanned,
-                        result.repos.len()
-                    );
-                    for warning in &result.warnings {
-                        eprintln!("warning: {warning}");
+                    let write_result = if json {
+                        output::write_json(&mut stdout, &result)
+                    } else if porcelain {
+                        output::write_porcelain(&mut stdout, &result)
+                    } else {
+                        output::write_human(&mut stdout, &result)
+                    };
+                    if let Err(e) = write_result {
+                        eprintln!("error writing output: {e}");
+                        process::exit(1);
                     }
                 }
                 Err(e) => {

--- a/crates/git-branch-tidy/src/output.rs
+++ b/crates/git-branch-tidy/src/output.rs
@@ -1,0 +1,316 @@
+use std::io::Write;
+
+use git_tidy_core::types::Classification;
+
+use crate::types::{BranchInfo, BranchScanResult, JsonBranch};
+
+/// Write human-readable scan output.
+pub fn write_human(out: &mut dyn Write, result: &BranchScanResult) -> std::io::Result<()> {
+    for warning in &result.warnings {
+        writeln!(out, "warning: {warning}")?;
+    }
+
+    for group in &result.repos {
+        writeln!(out, "\n{} ({} branches)", group.name, group.branches.len())?;
+
+        for branch in &group.branches {
+            write_branch_line(out, branch)?;
+
+            // For partial landings, list unmatched commits
+            if let Classification::LandedPartial { unmatched, .. } = &branch.classification {
+                for commit in unmatched {
+                    writeln!(
+                        out,
+                        "    unmatched: {} {}",
+                        commit.short_hash, commit.subject
+                    )?;
+                }
+            }
+        }
+    }
+
+    writeln!(
+        out,
+        "\n{} branches scanned: {} merged, {} landed, {} partial, {} active, {} local",
+        result.total_scanned,
+        result.counts.merged,
+        result.counts.landed,
+        result.counts.partial,
+        result.counts.active,
+        result.counts.local,
+    )?;
+
+    Ok(())
+}
+
+fn write_branch_line(out: &mut dyn Write, branch: &BranchInfo) -> std::io::Result<()> {
+    let label = format!("{:<8}", branch.classification.label());
+
+    let name = if branch.is_current {
+        format!("* {}", branch.name)
+    } else {
+        format!("  {}", branch.name)
+    };
+
+    // Landed ratio
+    let ratio = match &branch.classification {
+        Classification::Landed { matched, total } => format!("{matched}/{total}"),
+        Classification::LandedPartial { matched, total, .. } => format!("{matched}/{total}"),
+        _ => String::new(),
+    };
+
+    // Ahead/behind
+    let ahead_behind = if branch.ahead > 0 || branch.behind > 0 {
+        format!("+{}/-{}", branch.ahead, branch.behind)
+    } else {
+        String::new()
+    };
+
+    // Annotations
+    let mut annotations = Vec::new();
+    if branch.diverged {
+        annotations.push("diverged".to_string());
+    }
+    if branch.remote_deleted {
+        annotations.push("remote deleted".to_string());
+    }
+
+    write!(out, "  {label} {name:<34}")?;
+    if !ratio.is_empty() {
+        write!(out, " {ratio:<8}")?;
+    }
+    if !ahead_behind.is_empty() {
+        write!(out, " {ahead_behind:<10}")?;
+    }
+    for ann in &annotations {
+        write!(out, "  {ann}")?;
+    }
+    writeln!(out)?;
+
+    Ok(())
+}
+
+/// Write JSON scan output using the flat spec format.
+pub fn write_json(out: &mut dyn Write, result: &BranchScanResult) -> std::io::Result<()> {
+    let all_branches: Vec<JsonBranch> = result
+        .repos
+        .iter()
+        .flat_map(|g| g.branches.iter())
+        .map(JsonBranch::from)
+        .collect();
+
+    let json = serde_json::to_string_pretty(&all_branches).map_err(std::io::Error::other)?;
+    writeln!(out, "{json}")?;
+    Ok(())
+}
+
+/// Write porcelain (machine-readable, tab-delimited) scan output.
+pub fn write_porcelain(out: &mut dyn Write, result: &BranchScanResult) -> std::io::Result<()> {
+    for group in &result.repos {
+        for branch in &group.branches {
+            let repo = branch.repo_path.display();
+            let name = &branch.name;
+            let class = branch.classification.label();
+
+            let ratio = match &branch.classification {
+                Classification::Landed { matched, total } => format!("{matched}/{total}"),
+                Classification::LandedPartial { matched, total, .. } => {
+                    format!("{matched}/{total}")
+                }
+                _ => String::new(),
+            };
+
+            let mut anns = Vec::new();
+            if branch.remote_deleted {
+                anns.push("remote_deleted");
+            }
+            if branch.diverged {
+                anns.push("diverged");
+            }
+            let annotations = anns.join(",");
+
+            writeln!(
+                out,
+                "{repo}\t{name}\t{class}\t{ratio}\t{}\t{}\t{}\t{annotations}",
+                branch.ahead, branch.behind, branch.is_current,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::types::*;
+    use git_tidy_core::types::*;
+
+    fn make_scan_result() -> BranchScanResult {
+        BranchScanResult {
+            repos: vec![BranchRepoGroup {
+                repo_path: PathBuf::from("/repos/Backend"),
+                name: "Backend".to_string(),
+                branches: vec![
+                    BranchInfo {
+                        repo_path: PathBuf::from("/repos/Backend"),
+                        name: "fix/skip-db-init".to_string(),
+                        default_branch: "main".to_string(),
+                        classification: Classification::Merged,
+                        remote_tracking: true,
+                        remote_deleted: true,
+                        ahead: 0,
+                        behind: 0,
+                        diverged: false,
+                        is_current: false,
+                    },
+                    BranchInfo {
+                        repo_path: PathBuf::from("/repos/Backend"),
+                        name: "feature/caps".to_string(),
+                        default_branch: "main".to_string(),
+                        classification: Classification::Active,
+                        remote_tracking: true,
+                        remote_deleted: false,
+                        ahead: 3,
+                        behind: 0,
+                        diverged: false,
+                        is_current: true,
+                    },
+                ],
+            }],
+            total_scanned: 2,
+            counts: ScanCounts {
+                merged: 1,
+                landed: 0,
+                partial: 0,
+                active: 1,
+                local: 0,
+            },
+            warnings: vec![],
+        }
+    }
+
+    #[test]
+    fn human_output_basic() {
+        let result = make_scan_result();
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("Backend (2 branches)"));
+        assert!(output.contains("merged"));
+        assert!(output.contains("active"));
+        assert!(output.contains("fix/skip-db-init"));
+        assert!(output.contains("* feature/caps"));
+        assert!(output.contains("remote deleted"));
+        assert!(
+            output.contains("2 branches scanned: 1 merged, 0 landed, 0 partial, 1 active, 0 local")
+        );
+    }
+
+    #[test]
+    fn human_output_with_partial() {
+        let result = BranchScanResult {
+            repos: vec![BranchRepoGroup {
+                repo_path: PathBuf::from("/repos/App"),
+                name: "App".to_string(),
+                branches: vec![BranchInfo {
+                    repo_path: PathBuf::from("/repos/App"),
+                    name: "alternate-icons".to_string(),
+                    default_branch: "main".to_string(),
+                    classification: Classification::LandedPartial {
+                        matched: 4,
+                        total: 6,
+                        unmatched: vec![
+                            UnmatchedCommit {
+                                short_hash: "8d8a06c".to_string(),
+                                subject: "Add app icon button".to_string(),
+                            },
+                            UnmatchedCommit {
+                                short_hash: "b4cd142".to_string(),
+                                subject: "Add themed icons".to_string(),
+                            },
+                        ],
+                    },
+                    remote_tracking: true,
+                    remote_deleted: false,
+                    ahead: 6,
+                    behind: 324,
+                    diverged: true,
+                    is_current: false,
+                }],
+            }],
+            total_scanned: 1,
+            counts: ScanCounts {
+                partial: 1,
+                ..Default::default()
+            },
+            warnings: vec![],
+        };
+
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("partial"));
+        assert!(output.contains("4/6"));
+        assert!(output.contains("unmatched: 8d8a06c Add app icon button"));
+        assert!(output.contains("unmatched: b4cd142 Add themed icons"));
+        assert!(output.contains("diverged"));
+    }
+
+    #[test]
+    fn json_output_valid() {
+        let result = make_scan_result();
+        let mut buf = Vec::new();
+        write_json(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["classification"], "merged");
+        assert_eq!(arr[0]["remote_deleted"], true);
+        assert_eq!(arr[1]["classification"], "active");
+        assert_eq!(arr[1]["is_current"], true);
+    }
+
+    #[test]
+    fn porcelain_output_tab_delimited() {
+        let result = make_scan_result();
+        let mut buf = Vec::new();
+        write_porcelain(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines.len(), 2);
+
+        let fields: Vec<&str> = lines[0].split('\t').collect();
+        assert_eq!(fields.len(), 8);
+        assert_eq!(fields[0], "/repos/Backend"); // repo
+        assert_eq!(fields[1], "fix/skip-db-init"); // branch name
+        assert_eq!(fields[2], "merged"); // classification
+        assert_eq!(fields[7], "remote_deleted"); // annotations
+
+        let fields2: Vec<&str> = lines[1].split('\t').collect();
+        assert_eq!(fields2[2], "active");
+        assert_eq!(fields2[6], "true"); // is_current
+    }
+
+    #[test]
+    fn human_output_with_warnings() {
+        let result = BranchScanResult {
+            repos: vec![],
+            total_scanned: 0,
+            counts: ScanCounts::default(),
+            warnings: vec!["could not determine default branch for /repo/Foo".to_string()],
+        };
+
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("warning: could not determine default branch"));
+    }
+}


### PR DESCRIPTION
## Summary

- Human, JSON, and porcelain formatters for `BranchScanResult`
- Human format shows `*` prefix for current branch, groups by repo, shows annotations
- Wire formatters into main.rs for `--json` and `--porcelain` flags

Closes #22

## Test plan

- [x] 5 output tests (human basic, partial with unmatched, warnings, JSON, porcelain)
- [x] All 150 workspace tests pass
- [x] `cargo build --workspace` succeeds