### PR TITLE
Extract shared output helpers, add TestRepo builders, update docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,17 +10,28 @@ cargo test --workspace -- --test-threads=1  # if tests interfere with each other
 
 ## Architecture
 
-This is a Cargo workspace with a shared core library and (currently) one binary crate.
+This is a Cargo workspace with a shared core library and two binary crates.
 
-- **`git-tidy-core`**: Shared library containing git abstraction, classification logic, and test utilities.
+- **`git-tidy-core`**: Shared library containing git abstraction, classification logic, output helpers, and test utilities.
 - **`git-worktree-tidy`**: Binary crate for scanning and cleaning stale git worktrees.
+- **`git-branch-tidy`**: Binary crate for scanning and cleaning stale local git branches.
 
 ### Core patterns
 
 - **`GitOps` trait** (`git-tidy-core/src/git.rs`): All git operations go through this trait. `RealGit` shells out to `git`; `MockGit` (in `testutil.rs`) returns canned data.
 - **Output to `&mut dyn Write`**: Enables unit testing output formatters without process capture.
+- **Shared output helpers** (`git-tidy-core/src/output.rs`): `write_summary_line`, `write_warnings`, `format_ahead_behind`, `format_annotations`, `format_landed_ratio`. Both tools call these to avoid duplicating formatting logic.
 - **`thiserror`** for errors: Known, finite variants with exit code mapping (1=error, 2=dirty-blocked).
 - **Sequential repo processing**: No parallelism needed for typical workloads (~9 repos, ~39 worktrees).
+- **Library-first design**: `scan.rs` and `clean.rs` are library functions; `main.rs` is thin dispatch. Enables future tools to call scan as a library.
+
+### CLI pattern (documented convention, not shared code)
+
+Both tools follow the same CLI shape:
+- **Global args**: `directory` (positional, default cwd), `--behind-threshold` (default 100), `--verbose` / `-v`
+- **Scan subcommand** (default): `--json`, `--porcelain`
+- **Clean subcommand**: `--dry-run` / `-n`, `--force` / `-f`, `--yes` / `-y`, `--merged-only`, `--landed`, `--all`, `--json`, `--porcelain`
+- Tool-specific flags: worktree-tidy has `--delete-branches`, branch-tidy has `--include-remote`
 
 ## Conventions
 
@@ -29,6 +40,8 @@ This is a Cargo workspace with a shared core library and (currently) one binary 
 - Path canonicalization in discovery handles macOS `/var` -> `/private/var` symlinks.
 - Classification priority order: merged (0) > landed (1) > partial (2) > active (3) > local (4).
 - Shared test utilities (MockGitBuilder, TestRepo, git helper) live in `git-tidy-core/src/testutil.rs`, gated behind the `testutil` feature. Binary crates depend on `git-tidy-core = { features = ["testutil"] }` in `[dev-dependencies]`.
+- `classify_branch` is the core classification function shared by both tools. `classify_worktree` is a thin wrapper that adds dirty detection.
+- Discovery is inverted between tools: worktree discovery finds `.git` files (linked worktrees), branch discovery finds `.git` directories (repos).
 
 ## Project Layout
 
@@ -39,12 +52,13 @@ crates/
     src/
       lib.rs                                  # Module exports
       git.rs                                  # GitOps trait + RealGit implementation
-      types.rs                                # Classification, WorktreeInfo, ScanResult, etc.
+      types.rs                                # Classification, BranchClassification, WorktreeInfo, etc.
       error.rs                                # thiserror Error enum
-      classification.rs                       # Classification pipeline
+      classification.rs                       # classify_branch + classify_worktree
       config.rs                               # Noise pattern configuration (file + CLI + defaults)
       dirty.rs                                # Status parsing with noise filtering
       landed.rs                               # Subject matching, fuzzy, patch similarity
+      output.rs                               # Shared output helpers (summary, warnings, formatting)
       testutil.rs                             # MockGitBuilder, MockGit, TestRepo, git() helper
   git-worktree-tidy/                          # Worktree scanner/cleaner binary
     src/
@@ -57,5 +71,19 @@ crates/
     tests/
       common/mod.rs                           # Re-exports from git_tidy_core::testutil
       integration_discovery.rs                # Real git repos in tempdirs
-      integration_git.rs                      # Root commit handling tests
+      integration_git.rs                      # GitOps integration tests
+  git-branch-tidy/                            # Branch scanner/cleaner binary
+    src/
+      main.rs                                 # CLI dispatch
+      lib.rs                                  # Public module exports for integration tests
+      cli.rs                                  # clap derive definitions
+      discovery.rs                            # Repo discovery (finds .git directories)
+      scan.rs                                 # Branch enumeration and classification
+      output.rs                               # Human-readable, JSON, porcelain formatters
+      clean.rs                                # Branch deletion with safety guards
+      types.rs                                # BranchInfo, BranchRepoGroup, BranchScanResult
+    tests/
+      common/mod.rs                           # Re-exports from git_tidy_core::testutil
+      integration_scan.rs                     # Real git repos with branch scanning
+      integration_clean.rs                    # Real git repos with branch cleanup
 ```

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ A Cargo workspace for Git housekeeping tools that share classification logic (me
 
 Scans a directory for linked Git worktrees, classifies them by staleness, and interactively removes the stale ones.
 
-### git-branch-tidy (planned)
+### git-branch-tidy
 
-Scans and cleans up stale local and remote branches across multiple repos.
+Scans a directory of Git repos, classifies local branches by staleness, and interactively removes stale branches.
 
 ## Installation
 
@@ -18,26 +18,42 @@ Requires Rust 1.85.0 or later (edition 2024).
 
 ```bash
 cargo install --path crates/git-worktree-tidy
+cargo install --path crates/git-branch-tidy
 ```
 
 ## Usage
 
-### Scan worktrees (default command)
+### git-worktree-tidy
 
 ```bash
+# Scan worktrees (default command)
 git-worktree-tidy scan ~/Developer
 git-worktree-tidy ~/Developer              # scan is the default
 git-worktree-tidy scan ~/Developer --json   # JSON output
 git-worktree-tidy scan ~/Developer --porcelain  # machine-readable
-```
 
-### Clean stale worktrees
-
-```bash
+# Clean stale worktrees
 git-worktree-tidy clean ~/Developer                    # interactive
 git-worktree-tidy clean ~/Developer --merged-only --yes  # non-interactive, merged only
 git-worktree-tidy clean ~/Developer --landed --yes       # merged + fully landed
 git-worktree-tidy clean ~/Developer --dry-run            # preview removals
+```
+
+### git-branch-tidy
+
+```bash
+# Scan branches (default command)
+git-branch-tidy scan ~/Developer
+git-branch-tidy ~/Developer                # scan is the default
+git-branch-tidy scan ~/Developer --json     # JSON output
+git-branch-tidy scan ~/Developer --porcelain  # machine-readable
+
+# Clean stale branches
+git-branch-tidy clean ~/Developer                         # delete merged + landed
+git-branch-tidy clean ~/Developer --merged-only --yes      # non-interactive, merged only
+git-branch-tidy clean ~/Developer --all --force            # force-delete all classifications
+git-branch-tidy clean ~/Developer --dry-run                # preview deletions
+git-branch-tidy clean ~/Developer --include-remote --yes   # also delete remote branches
 ```
 
 ## Classifications
@@ -54,7 +70,7 @@ git-worktree-tidy clean ~/Developer --dry-run            # preview removals
 
 - **remote deleted**: Remote tracking branch no longer exists after `fetch --prune`
 - **diverged**: Branch is more than `--behind-threshold` (default: 100) commits behind
-- **dirty**: Working tree has meaningful uncommitted changes
+- **dirty** (worktree-tidy only): Working tree has meaningful uncommitted changes
 
 ## Noise Configuration
 
@@ -89,26 +105,6 @@ exclude = ["package-lock.json"]
 
 Merge order: `(defaults - exclude) + config extra + CLI extra`. The `--no-default-noise` flag clears all defaults, keeping only config extras and CLI extras.
 
-## CLI Flags
-
-```
-Options:
-  -n, --dry-run              Show what would be removed without removing
-  -f, --force                Remove worktrees with meaningful uncommitted changes
-  -y, --yes                  Skip confirmation prompts (accept all defaults)
-      --merged-only          Only target merged worktrees
-      --landed               Target merged and fully landed worktrees (not partial)
-      --all                  Include active and local worktrees in interactive clean
-      --behind-threshold N   Commit count for diverged annotation (default: 100)
-      --delete-branches      Delete local branches after removing their worktrees
-      --noise-pattern PAT    Additional file pattern to treat as noise (repeatable)
-      --no-default-noise     Disable all built-in noise patterns
-      --json                 Output scan results as JSON
-      --porcelain            Machine-readable tab-delimited output
-  -v, --verbose              Show commit-matching details during landed detection
-  -h, --help                 Show help
-```
-
 ## Exit Codes
 
 | Code | Meaning |
@@ -121,6 +117,7 @@ Options:
 
 ```
 crates/
-  git-tidy-core/          Shared classification, git abstraction, test utilities
+  git-tidy-core/          Shared classification, git abstraction, output helpers, test utilities
   git-worktree-tidy/      Worktree scanner/cleaner binary
+  git-branch-tidy/        Branch scanner/cleaner binary
 ```

--- a/crates/git-branch-tidy/README.md
+++ b/crates/git-branch-tidy/README.md
@@ -1,0 +1,63 @@
+# git-branch-tidy
+
+Scan, classify, and interactively remove stale local Git branches across multiple repositories.
+
+## Installation
+
+```bash
+cargo install --path .
+```
+
+## Usage
+
+### Scan branches
+
+```bash
+git-branch-tidy scan ~/Developer          # human-readable output
+git-branch-tidy ~/Developer               # scan is the default
+git-branch-tidy scan ~/Developer --json    # JSON output
+git-branch-tidy scan ~/Developer --porcelain  # machine-readable tab-delimited
+```
+
+### Clean stale branches
+
+```bash
+git-branch-tidy clean ~/Developer                         # delete merged + landed
+git-branch-tidy clean ~/Developer --merged-only --yes      # non-interactive, merged only
+git-branch-tidy clean ~/Developer --all --force            # force-delete all classifications
+git-branch-tidy clean ~/Developer --dry-run                # preview deletions
+git-branch-tidy clean ~/Developer --include-remote --yes   # also delete remote tracking branches
+```
+
+### Safety
+
+- The default branch is never deleted (excluded during scan)
+- The currently checked-out branch is never deleted
+- Without `--force`: uses `git branch -d` which refuses to delete unmerged branches
+- With `--force`: uses `git branch -D` to force-delete
+- `--dry-run` prints what would be deleted without making any changes
+- Remote branch deletion failures are warned, not fatal
+
+### Options
+
+```
+Global:
+      <directory>              Directory to scan (default: current directory)
+      --behind-threshold N     Commit count for diverged annotation (default: 100)
+  -v, --verbose                Show commit-matching details during landed detection
+
+Scan:
+      --json                   Output results as JSON
+      --porcelain              Machine-readable tab-delimited output
+
+Clean:
+  -n, --dry-run                Show what would be deleted without deleting
+  -f, --force                  Force-delete branches (git branch -D)
+  -y, --yes                    Skip confirmation prompts
+      --merged-only            Only target merged branches
+      --landed                 Target merged and fully landed branches
+      --all                    Include all classifications
+      --include-remote         Also delete remote tracking branches
+      --json                   Output results as JSON
+      --porcelain              Machine-readable tab-delimited output
+```

--- a/crates/git-branch-tidy/src/output.rs
+++ b/crates/git-branch-tidy/src/output.rs
@@ -1,14 +1,13 @@
 use std::io::Write;
 
+use git_tidy_core::output as shared;
 use git_tidy_core::types::Classification;
 
 use crate::types::{BranchInfo, BranchScanResult, JsonBranch};
 
 /// Write human-readable scan output.
 pub fn write_human(out: &mut dyn Write, result: &BranchScanResult) -> std::io::Result<()> {
-    for warning in &result.warnings {
-        writeln!(out, "warning: {warning}")?;
-    }
+    shared::write_warnings(out, &result.warnings)?;
 
     for group in &result.repos {
         writeln!(out, "\n{} ({} branches)", group.name, group.branches.len())?;
@@ -29,16 +28,7 @@ pub fn write_human(out: &mut dyn Write, result: &BranchScanResult) -> std::io::R
         }
     }
 
-    writeln!(
-        out,
-        "\n{} branches scanned: {} merged, {} landed, {} partial, {} active, {} local",
-        result.total_scanned,
-        result.counts.merged,
-        result.counts.landed,
-        result.counts.partial,
-        result.counts.active,
-        result.counts.local,
-    )?;
+    shared::write_summary_line(out, result.total_scanned, &result.counts, "branches")?;
 
     Ok(())
 }
@@ -52,28 +42,18 @@ fn write_branch_line(out: &mut dyn Write, branch: &BranchInfo) -> std::io::Resul
         format!("  {}", branch.name)
     };
 
-    // Landed ratio
-    let ratio = match &branch.classification {
-        Classification::Landed { matched, total } => format!("{matched}/{total}"),
-        Classification::LandedPartial { matched, total, .. } => format!("{matched}/{total}"),
-        _ => String::new(),
-    };
-
-    // Ahead/behind
-    let ahead_behind = if branch.ahead > 0 || branch.behind > 0 {
-        format!("+{}/-{}", branch.ahead, branch.behind)
-    } else {
-        String::new()
-    };
+    let ratio = shared::format_landed_ratio(&branch.classification);
+    let ahead_behind = shared::format_ahead_behind(branch.ahead, branch.behind);
 
     // Annotations
-    let mut annotations = Vec::new();
+    let mut ann_strs = Vec::new();
     if branch.diverged {
-        annotations.push("diverged".to_string());
+        ann_strs.push("diverged");
     }
     if branch.remote_deleted {
-        annotations.push("remote deleted".to_string());
+        ann_strs.push("remote deleted");
     }
+    let annotations = shared::format_annotations(&ann_strs);
 
     write!(out, "  {label} {name:<34}")?;
     if !ratio.is_empty() {
@@ -82,8 +62,8 @@ fn write_branch_line(out: &mut dyn Write, branch: &BranchInfo) -> std::io::Resul
     if !ahead_behind.is_empty() {
         write!(out, " {ahead_behind:<10}")?;
     }
-    for ann in &annotations {
-        write!(out, "  {ann}")?;
+    if !annotations.is_empty() {
+        write!(out, "  {annotations}")?;
     }
     writeln!(out)?;
 
@@ -111,14 +91,7 @@ pub fn write_porcelain(out: &mut dyn Write, result: &BranchScanResult) -> std::i
             let repo = branch.repo_path.display();
             let name = &branch.name;
             let class = branch.classification.label();
-
-            let ratio = match &branch.classification {
-                Classification::Landed { matched, total } => format!("{matched}/{total}"),
-                Classification::LandedPartial { matched, total, .. } => {
-                    format!("{matched}/{total}")
-                }
-                _ => String::new(),
-            };
+            let ratio = shared::format_landed_ratio(&branch.classification);
 
             let mut anns = Vec::new();
             if branch.remote_deleted {
@@ -288,14 +261,14 @@ mod tests {
 
         let fields: Vec<&str> = lines[0].split('\t').collect();
         assert_eq!(fields.len(), 8);
-        assert_eq!(fields[0], "/repos/Backend"); // repo
-        assert_eq!(fields[1], "fix/skip-db-init"); // branch name
-        assert_eq!(fields[2], "merged"); // classification
-        assert_eq!(fields[7], "remote_deleted"); // annotations
+        assert_eq!(fields[0], "/repos/Backend");
+        assert_eq!(fields[1], "fix/skip-db-init");
+        assert_eq!(fields[2], "merged");
+        assert_eq!(fields[7], "remote_deleted");
 
         let fields2: Vec<&str> = lines[1].split('\t').collect();
         assert_eq!(fields2[2], "active");
-        assert_eq!(fields2[6], "true"); // is_current
+        assert_eq!(fields2[6], "true");
     }
 
     #[test]

--- a/crates/git-tidy-core/src/lib.rs
+++ b/crates/git-tidy-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod dirty;
 pub mod error;
 pub mod git;
 pub mod landed;
+pub mod output;
 pub mod types;
 
 #[cfg(any(test, feature = "testutil"))]

--- a/crates/git-tidy-core/src/output.rs
+++ b/crates/git-tidy-core/src/output.rs
@@ -1,0 +1,153 @@
+//! Shared output helpers used by both git-worktree-tidy and git-branch-tidy.
+
+use std::io::Write;
+
+use crate::types::{Classification, ScanCounts};
+
+/// Write the summary line: "N {item_noun} scanned: X merged, Y landed, ..."
+pub fn write_summary_line(
+    out: &mut dyn Write,
+    total: usize,
+    counts: &ScanCounts,
+    item_noun: &str,
+) -> std::io::Result<()> {
+    writeln!(
+        out,
+        "\n{total} {item_noun} scanned: {} merged, {} landed, {} partial, {} active, {} local",
+        counts.merged, counts.landed, counts.partial, counts.active, counts.local,
+    )
+}
+
+/// Write warnings with the "warning: " prefix.
+pub fn write_warnings(out: &mut dyn Write, warnings: &[String]) -> std::io::Result<()> {
+    for warning in warnings {
+        writeln!(out, "warning: {warning}")?;
+    }
+    Ok(())
+}
+
+/// Format ahead/behind as "+N/-M". Returns empty string when both are 0.
+pub fn format_ahead_behind(ahead: usize, behind: usize) -> String {
+    if ahead > 0 || behind > 0 {
+        format!("+{}/-{}", ahead, behind)
+    } else {
+        String::new()
+    }
+}
+
+/// Format a comma-separated annotation list from string slices.
+/// Returns empty string when the list is empty.
+pub fn format_annotations(annotations: &[&str]) -> String {
+    annotations.join(", ")
+}
+
+/// Format the landed ratio for display. Returns empty string for non-landed classifications.
+pub fn format_landed_ratio(classification: &Classification) -> String {
+    match classification {
+        Classification::Landed { matched, total } => format!("{matched}/{total}"),
+        Classification::LandedPartial { matched, total, .. } => format!("{matched}/{total}"),
+        _ => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summary_line_format() {
+        let counts = ScanCounts {
+            merged: 3,
+            landed: 1,
+            partial: 0,
+            active: 2,
+            local: 1,
+        };
+        let mut buf = Vec::new();
+        write_summary_line(&mut buf, 7, &counts, "branches").unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert_eq!(
+            output,
+            "\n7 branches scanned: 3 merged, 1 landed, 0 partial, 2 active, 1 local\n"
+        );
+    }
+
+    #[test]
+    fn summary_line_worktrees() {
+        let counts = ScanCounts {
+            merged: 1,
+            ..Default::default()
+        };
+        let mut buf = Vec::new();
+        write_summary_line(&mut buf, 1, &counts, "worktrees").unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("1 worktrees scanned"));
+    }
+
+    #[test]
+    fn warnings_output() {
+        let mut buf = Vec::new();
+        write_warnings(&mut buf, &["fetch failed for /repo".to_string()]).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert_eq!(output, "warning: fetch failed for /repo\n");
+    }
+
+    #[test]
+    fn warnings_empty() {
+        let mut buf = Vec::new();
+        write_warnings(&mut buf, &[]).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn ahead_behind_nonzero() {
+        assert_eq!(format_ahead_behind(3, 5), "+3/-5");
+    }
+
+    #[test]
+    fn ahead_behind_zero() {
+        assert_eq!(format_ahead_behind(0, 0), "");
+    }
+
+    #[test]
+    fn annotations_basic() {
+        assert_eq!(
+            format_annotations(&["diverged", "remote deleted"]),
+            "diverged, remote deleted"
+        );
+    }
+
+    #[test]
+    fn annotations_empty() {
+        assert_eq!(format_annotations(&[]), "");
+    }
+
+    #[test]
+    fn landed_ratio_landed() {
+        assert_eq!(
+            format_landed_ratio(&Classification::Landed {
+                matched: 3,
+                total: 3
+            }),
+            "3/3"
+        );
+    }
+
+    #[test]
+    fn landed_ratio_partial() {
+        assert_eq!(
+            format_landed_ratio(&Classification::LandedPartial {
+                matched: 2,
+                total: 5,
+                unmatched: vec![],
+            }),
+            "2/5"
+        );
+    }
+
+    #[test]
+    fn landed_ratio_other() {
+        assert_eq!(format_landed_ratio(&Classification::Active), "");
+    }
+}

--- a/crates/git-tidy-core/src/testutil.rs
+++ b/crates/git-tidy-core/src/testutil.rs
@@ -641,6 +641,44 @@ impl TestRepo {
     }
 }
 
+impl TestRepo {
+    /// Create a local branch (without checking it out).
+    pub fn create_branch(&self, name: &str) {
+        git(&self.main_repo, &["branch", name]);
+    }
+
+    /// Create a branch with a commit, then merge it into main.
+    pub fn create_merged_branch(&self, name: &str) {
+        git(&self.main_repo, &["checkout", "-b", name]);
+        let filename = format!("{name}.txt");
+        self.commit_file(
+            &self.main_repo,
+            &filename,
+            "merged content",
+            &format!("work on {name}"),
+        );
+        git(&self.main_repo, &["checkout", "main"]);
+        git(
+            &self.main_repo,
+            &["merge", "--no-ff", name, "-m", &format!("Merge {name}")],
+        );
+    }
+
+    /// Set up a bare remote and push main to it.
+    /// Returns the path to the bare repo.
+    pub fn set_up_remote(&self) -> PathBuf {
+        let bare = self.dir.path().join("remote.git");
+        std::fs::create_dir_all(&bare).unwrap();
+        git(&bare, &["init", "--bare"]);
+        git(
+            &self.main_repo,
+            &["remote", "add", "origin", &bare.to_string_lossy()],
+        );
+        git(&self.main_repo, &["push", "-u", "origin", "main"]);
+        bare
+    }
+}
+
 /// Run a git command in the given directory, panicking on failure.
 pub fn git(dir: &Path, args: &[&str]) -> String {
     let output = Command::new("git")

--- a/crates/git-worktree-tidy/src/output.rs
+++ b/crates/git-worktree-tidy/src/output.rs
@@ -1,12 +1,11 @@
 use std::io::Write;
 
+use git_tidy_core::output as shared;
 use git_tidy_core::types::{Classification, JsonWorktree, ScanResult, WorktreeInfo};
 
 /// Write human-readable scan output.
 pub fn write_human(out: &mut dyn Write, result: &ScanResult) -> std::io::Result<()> {
-    for warning in &result.warnings {
-        writeln!(out, "warning: {warning}")?;
-    }
+    shared::write_warnings(out, &result.warnings)?;
 
     for group in &result.repos {
         writeln!(
@@ -32,16 +31,7 @@ pub fn write_human(out: &mut dyn Write, result: &ScanResult) -> std::io::Result<
         }
     }
 
-    writeln!(
-        out,
-        "\n{} worktrees scanned: {} merged, {} landed, {} partial, {} active, {} local",
-        result.total_scanned,
-        result.counts.merged,
-        result.counts.landed,
-        result.counts.partial,
-        result.counts.active,
-        result.counts.local,
-    )?;
+    shared::write_summary_line(out, result.total_scanned, &result.counts, "worktrees")?;
 
     Ok(())
 }
@@ -55,19 +45,8 @@ fn write_worktree_line(out: &mut dyn Write, wt: &WorktreeInfo) -> std::io::Resul
         .unwrap_or_default();
     let branch = wt.branch.as_deref().unwrap_or("(detached)");
 
-    // Landed ratio
-    let ratio = match &wt.classification {
-        Classification::Landed { matched, total } => format!("{matched}/{total}"),
-        Classification::LandedPartial { matched, total, .. } => format!("{matched}/{total}"),
-        _ => String::new(),
-    };
-
-    // Ahead/behind
-    let ahead_behind = if wt.ahead > 0 || wt.behind > 0 {
-        format!("+{}/{}-0", wt.ahead, wt.behind)
-    } else {
-        String::new()
-    };
+    let ratio = shared::format_landed_ratio(&wt.classification);
+    let ahead_behind = shared::format_ahead_behind(wt.ahead, wt.behind);
 
     // Annotations
     let mut annotations = Vec::new();
@@ -118,15 +97,7 @@ pub fn write_porcelain(out: &mut dyn Write, result: &ScanResult) -> std::io::Res
             let parent = wt.parent_repo.display();
             let branch = wt.branch.as_deref().unwrap_or("");
             let class = wt.classification.label();
-
-            let ratio = match &wt.classification {
-                Classification::Landed { matched, total } => format!("{matched}/{total}"),
-                Classification::LandedPartial { matched, total, .. } => {
-                    format!("{matched}/{total}")
-                }
-                _ => String::new(),
-            };
-
+            let ratio = shared::format_landed_ratio(&wt.classification);
             let dirty_count = wt.annotations.dirty_file_count;
 
             let mut anns = Vec::new();


### PR DESCRIPTION
## Summary

Closes #26

- Extract shared output formatting functions into `git-tidy-core/src/output.rs`, used by both worktree and branch tools
- Add composable `TestRepo` builder methods (`create_branch`, `create_merged_branch`, `set_up_remote`)
- Update workspace documentation (CLAUDE.md, README.md, crate README)

## Test plan

- [ ] `cargo test --workspace` passes (181 tests, 11 new for shared output helpers)
- [ ] Both tools produce identical output before and after refactoring
- [ ] New TestRepo builder methods work in existing integration tests