### PR TITLE
Add git-remote-tidy: scan, classify, and remove stale remotes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,13 @@ cargo test --workspace -- --test-threads=1  # if tests interfere with each other
 
 ## Architecture
 
-This is a Cargo workspace with a shared core library and three binary crates.
+This is a Cargo workspace with a shared core library and four binary crates.
 
 - **`git-tidy-core`**: Shared library containing git abstraction, classification logic, output helpers, and test utilities.
 - **`git-worktree-tidy`**: Binary crate for scanning and cleaning stale git worktrees.
 - **`git-branch-tidy`**: Binary crate for scanning and cleaning stale local git branches.
 - **`git-stash-tidy`**: Binary crate for scanning and cleaning stale git stashes.
+- **`git-remote-tidy`**: Binary crate for scanning and removing stale git remotes and orphaned tracking refs.
 
 ### Core patterns
 
@@ -34,7 +35,8 @@ All tools follow a similar CLI shape:
 - **Clean subcommand**: `--dry-run` / `-n`, `--yes` / `-y`, classification filters, `--all`, `--json`, `--porcelain`
 - Worktree/branch-tidy global args: `--behind-threshold` (default 100), `--verbose` / `-v`
 - Stash-tidy global arg: `--age-threshold` (default 90) instead of `--behind-threshold`/`--verbose`
-- Tool-specific flags: worktree-tidy has `--delete-branches`, branch-tidy has `--include-remote`/`--force`
+- Remote-tidy global arg: `--offline` instead of `--behind-threshold`/`--verbose`
+- Tool-specific flags: worktree-tidy has `--delete-branches`, branch-tidy has `--include-remote`/`--force`, remote-tidy has `--force` (allow removing origin)/`--all` (include orphaned)
 
 ## Conventions
 
@@ -103,4 +105,17 @@ crates/
       common/mod.rs                           # Re-exports from git_tidy_core::testutil
       integration_scan.rs                     # Real git repos with stash scanning
       integration_clean.rs                    # Real git repos with stash cleanup
+  git-remote-tidy/                           # Remote scanner/cleaner binary
+    src/
+      main.rs                                 # CLI dispatch
+      lib.rs                                  # Public module exports for integration tests
+      cli.rs                                  # clap derive definitions
+      scan.rs                                 # Remote classification and scanning
+      output.rs                               # Human-readable, JSON, porcelain formatters
+      clean.rs                                # Remote removal and ref pruning logic
+      types.rs                                # RemoteInfo, RemoteRepoGroup, RemoteScanResult
+    tests/
+      common/mod.rs                           # Re-exports from git_tidy_core::testutil
+      integration_scan.rs                     # Real git repos with remote scanning
+      integration_clean.rs                    # Real git repos with remote cleanup
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-remote-tidy"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "console",
+ "dialoguer",
+ "git-tidy-core",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "git-stash-tidy"
 version = "0.1.0"
 dependencies = [

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Scans a directory of Git repos, classifies local branches by staleness, and inte
 
 Scans a directory of Git repos, classifies stash entries by staleness (committed, orphaned, aged, active), and interactively drops stale stashes.
 
+### git-remote-tidy
+
+Scans a directory of Git repos, classifies remotes by reachability (unreachable, orphaned, active), and interactively removes stale remotes and orphaned tracking refs.
+
 ## Installation
 
 Requires Rust 1.93.0 or later (edition 2024).
@@ -24,6 +28,7 @@ Requires Rust 1.93.0 or later (edition 2024).
 cargo install --path crates/git-worktree-tidy
 cargo install --path crates/git-branch-tidy
 cargo install --path crates/git-stash-tidy
+cargo install --path crates/git-remote-tidy
 ```
 
 ## Usage
@@ -78,6 +83,25 @@ git-stash-tidy clean ~/Developer --dry-run                # preview drops
 git-stash-tidy clean ~/Developer --age-threshold 30       # custom age threshold (default 90)
 ```
 
+### git-remote-tidy
+
+```bash
+# Scan remotes (default command)
+git-remote-tidy scan ~/Developer
+git-remote-tidy ~/Developer                # scan is the default
+git-remote-tidy scan ~/Developer --json     # JSON output
+git-remote-tidy scan ~/Developer --porcelain  # machine-readable
+
+# Offline mode (skip reachability checks)
+git-remote-tidy --offline scan ~/Developer
+
+# Clean stale remotes
+git-remote-tidy clean ~/Developer                  # remove unreachable remotes
+git-remote-tidy clean ~/Developer --all             # also prune orphaned tracking refs
+git-remote-tidy clean ~/Developer --force            # allow removing origin
+git-remote-tidy clean ~/Developer --dry-run          # preview removals
+```
+
 ## Classifications
 
 ### Worktree and branch classifications
@@ -98,6 +122,14 @@ git-stash-tidy clean ~/Developer --age-threshold 30       # custom age threshold
 | **orphaned** | Branch from stash message no longer exists locally | Safe |
 | **aged** | Older than `--age-threshold` days (default 90) | Review recommended |
 | **active** | None of the above; still relevant | Keep |
+
+### Remote classifications
+
+| Classification | Meaning | Removal safety |
+|----------------|---------|----------------|
+| **unreachable** | `git ls-remote` fails or times out (10s) | Safe |
+| **orphaned** | Tracking refs exist but remote is not configured | Safe (refs pruned) |
+| **active** | Remote is reachable | Keep |
 
 ## Annotations
 
@@ -154,4 +186,5 @@ crates/
   git-worktree-tidy/      Worktree scanner/cleaner binary
   git-branch-tidy/        Branch scanner/cleaner binary
   git-stash-tidy/         Stash scanner/cleaner binary
+  git-remote-tidy/        Remote scanner/cleaner binary
 ```

--- a/crates/git-remote-tidy/Cargo.toml
+++ b/crates/git-remote-tidy/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "git-remote-tidy"
+version = "0.1.0"
+edition = "2024"
+description = "Scan, classify, and remove stale Git remotes and orphaned tracking refs"
+
+[dependencies]
+git-tidy-core = { path = "../git-tidy-core" }
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+dialoguer = "0.11"
+console = "0.15"
+
+[dev-dependencies]
+git-tidy-core = { path = "../git-tidy-core", features = ["testutil"] }
+tempfile = "3"

--- a/crates/git-remote-tidy/README.md
+++ b/crates/git-remote-tidy/README.md
@@ -1,0 +1,69 @@
+# git-remote-tidy
+
+Scan, classify, and remove stale Git remotes and orphaned tracking refs across multiple repositories.
+
+## Installation
+
+```bash
+cargo install --path .
+```
+
+## Usage
+
+```bash
+# Scan remotes (default command)
+git-remote-tidy scan ~/Developer
+git-remote-tidy ~/Developer                # scan is the default
+git-remote-tidy scan ~/Developer --json     # JSON output
+git-remote-tidy scan ~/Developer --porcelain  # machine-readable
+
+# Offline mode (skip reachability checks)
+git-remote-tidy --offline scan ~/Developer
+
+# Clean stale remotes
+git-remote-tidy clean ~/Developer                  # remove unreachable remotes
+git-remote-tidy clean ~/Developer --all             # also prune orphaned tracking refs
+git-remote-tidy clean ~/Developer --force            # allow removing origin
+git-remote-tidy clean ~/Developer --dry-run          # preview removals
+```
+
+## Classifications
+
+| Classification | Priority | Trigger | Removal safety |
+|----------------|----------|---------|----------------|
+| **unreachable** | 0 | `git ls-remote` fails or times out (10s) | Safe |
+| **orphaned** | 1 | Tracking refs exist under `refs/remotes/<name>/` but remote is not configured | Safe (refs pruned) |
+| **active** | 2 | Remote is reachable | Keep |
+
+## Clean defaults
+
+- **Default**: removes unreachable remotes only
+- `--all`: unreachable + orphaned
+- `--force`: allow removing the `origin` remote (skipped by default)
+- `--dry-run`: preview without removing
+
+## Origin safety
+
+The `origin` remote is never removed without `--force`. When skipped, a warning is emitted.
+
+## Orphaned remote cleanup
+
+Orphaned remotes (tracking refs with no config entry) are cleaned by deleting individual refs via `git update-ref -d`, since there is no config entry for `git remote remove` to act on.
+
+## Offline mode
+
+With `--offline`, reachability checks via `git ls-remote` are skipped. Configured remotes default to Active. Only orphaned refs (detectable without network) are classified.
+
+## Human output example
+
+```
+backend (2 remotes)
+  unreachable   origin       https://github.com/old-org/backend.git          (12 tracking branches)
+  active        upstream     https://github.com/new-org/backend.git          (5 tracking branches)
+
+2 remotes scanned: 1 unreachable, 0 orphaned, 1 active
+```
+
+## Porcelain output
+
+Tab-delimited columns: `repo_path`, `name`, `classification`, `url`, `tracking_count`, `is_origin`

--- a/crates/git-remote-tidy/src/clean.rs
+++ b/crates/git-remote-tidy/src/clean.rs
@@ -1,0 +1,397 @@
+use std::io::Write;
+use std::path::PathBuf;
+
+use git_tidy_core::error::Error;
+use git_tidy_core::git::GitOps;
+
+use crate::types::{RemoteClassification, RemoteScanResult};
+
+/// Options controlling remote cleanup behavior.
+pub struct CleanOptions {
+    /// Preview only: print what would be removed.
+    pub dry_run: bool,
+    /// Skip confirmation prompts.
+    pub yes: bool,
+    /// Allow removing the origin remote.
+    pub force: bool,
+    /// Include orphaned remotes (default: unreachable only).
+    pub all: bool,
+}
+
+/// Result of a clean operation.
+#[derive(Debug)]
+pub struct CleanResult {
+    /// Remotes that were removed (or would be in dry-run).
+    pub removed: Vec<RemovedRemote>,
+    /// Remotes that failed to remove.
+    pub failed: Vec<FailedRemote>,
+    /// Remotes that were skipped (filtered out or origin-protected).
+    pub skipped: usize,
+}
+
+/// A remote that was successfully removed.
+#[derive(Debug)]
+pub struct RemovedRemote {
+    pub repo: PathBuf,
+    pub name: String,
+    /// Number of orphaned refs pruned (0 for configured remotes).
+    pub refs_pruned: usize,
+}
+
+/// A remote that failed to be removed.
+#[derive(Debug)]
+pub struct FailedRemote {
+    pub repo: PathBuf,
+    pub name: String,
+    pub reason: String,
+}
+
+/// Run the clean operation on a scan result.
+pub fn run_clean(
+    git: &dyn GitOps,
+    scan_result: &RemoteScanResult,
+    options: &CleanOptions,
+    out: &mut dyn Write,
+) -> Result<CleanResult, Error> {
+    let mut removed = Vec::new();
+    let mut failed = Vec::new();
+    let mut skipped = 0;
+
+    for group in &scan_result.repos {
+        for remote in &group.remotes {
+            if !should_clean(&remote.classification, options) {
+                skipped += 1;
+                continue;
+            }
+
+            // Origin safety check
+            if remote.is_origin && !options.force {
+                writeln!(
+                    out,
+                    "warning: skipping origin remote in {} (use --force to remove)",
+                    group.name,
+                )?;
+                skipped += 1;
+                continue;
+            }
+
+            if options.dry_run {
+                let action = if remote.classification == RemoteClassification::Orphaned {
+                    "would prune refs for"
+                } else {
+                    "would remove"
+                };
+                writeln!(out, "{action} {} in {}", remote.name, group.name)?;
+                removed.push(RemovedRemote {
+                    repo: group.repo_path.clone(),
+                    name: remote.name.clone(),
+                    refs_pruned: 0,
+                });
+                continue;
+            }
+
+            // Orphaned remotes: prune refs (no config to remove)
+            if remote.classification == RemoteClassification::Orphaned {
+                match git.prune_remote_refs(&group.repo_path, &remote.name) {
+                    Ok(count) => {
+                        writeln!(
+                            out,
+                            "pruned {count} refs for {} in {}",
+                            remote.name, group.name,
+                        )?;
+                        removed.push(RemovedRemote {
+                            repo: group.repo_path.clone(),
+                            name: remote.name.clone(),
+                            refs_pruned: count,
+                        });
+                    }
+                    Err(e) => {
+                        writeln!(out, "error: could not prune refs for {}: {e}", remote.name,)?;
+                        failed.push(FailedRemote {
+                            repo: group.repo_path.clone(),
+                            name: remote.name.clone(),
+                            reason: e.to_string(),
+                        });
+                    }
+                }
+            } else {
+                // Configured remotes: git remote remove
+                match git.remote_remove(&group.repo_path, &remote.name) {
+                    Ok(()) => {
+                        writeln!(out, "removed {} in {}", remote.name, group.name)?;
+                        removed.push(RemovedRemote {
+                            repo: group.repo_path.clone(),
+                            name: remote.name.clone(),
+                            refs_pruned: 0,
+                        });
+                    }
+                    Err(e) => {
+                        writeln!(out, "error: could not remove {}: {e}", remote.name)?;
+                        failed.push(FailedRemote {
+                            repo: group.repo_path.clone(),
+                            name: remote.name.clone(),
+                            reason: e.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(CleanResult {
+        removed,
+        failed,
+        skipped,
+    })
+}
+
+/// Determine if a remote should be cleaned based on its classification and options.
+fn should_clean(classification: &RemoteClassification, options: &CleanOptions) -> bool {
+    if options.all {
+        // Unreachable + orphaned
+        return *classification != RemoteClassification::Active;
+    }
+
+    // Default: unreachable only
+    *classification == RemoteClassification::Unreachable
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use git_tidy_core::testutil::MockGitBuilder;
+
+    use super::*;
+    use crate::types::*;
+
+    fn repo() -> PathBuf {
+        PathBuf::from("/repo")
+    }
+
+    fn make_scan_result(remotes: Vec<RemoteInfo>) -> RemoteScanResult {
+        let mut counts = RemoteCounts::default();
+        for r in &remotes {
+            counts.increment(r.classification);
+        }
+        RemoteScanResult {
+            repos: vec![RemoteRepoGroup {
+                repo_path: repo(),
+                name: "my-repo".to_string(),
+                remotes,
+            }],
+            total_scanned: 0,
+            counts,
+            warnings: vec![],
+        }
+    }
+
+    fn remote(name: &str, classification: RemoteClassification, is_origin: bool) -> RemoteInfo {
+        RemoteInfo {
+            repo_path: repo(),
+            name: name.to_string(),
+            classification,
+            url: Some(format!("https://example.com/{name}.git")),
+            tracking_count: 3,
+            is_origin,
+        }
+    }
+
+    fn default_options() -> CleanOptions {
+        CleanOptions {
+            dry_run: false,
+            yes: false,
+            force: false,
+            all: false,
+        }
+    }
+
+    #[test]
+    fn clean_removes_unreachable() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![remote(
+            "stale",
+            RemoteClassification::Unreachable,
+            false,
+        )]);
+        let mut buf = Vec::new();
+
+        let result = run_clean(&git, &scan, &default_options(), &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].name, "stale");
+        assert_eq!(git.remote_remove_calls().len(), 1);
+    }
+
+    #[test]
+    fn clean_skips_active_by_default() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![remote("origin", RemoteClassification::Active, true)]);
+        let mut buf = Vec::new();
+
+        let result = run_clean(&git, &scan, &default_options(), &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 0);
+        assert_eq!(result.skipped, 1);
+        assert_eq!(git.remote_remove_calls().len(), 0);
+    }
+
+    #[test]
+    fn clean_skips_orphaned_by_default() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![remote(
+            "orphan",
+            RemoteClassification::Orphaned,
+            false,
+        )]);
+        let mut buf = Vec::new();
+
+        let result = run_clean(&git, &scan, &default_options(), &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 0);
+        assert_eq!(result.skipped, 1);
+    }
+
+    #[test]
+    fn clean_all_includes_orphaned() {
+        let git = MockGitBuilder::new()
+            .with_prune_remote_refs_result(&repo(), "orphan", 3)
+            .build();
+        let scan = make_scan_result(vec![
+            remote("stale", RemoteClassification::Unreachable, false),
+            remote("orphan", RemoteClassification::Orphaned, false),
+            remote("good", RemoteClassification::Active, false),
+        ]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            all: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+
+        // Unreachable + orphaned removed, active skipped
+        assert_eq!(result.removed.len(), 2);
+        assert_eq!(result.skipped, 1);
+    }
+
+    #[test]
+    fn clean_origin_requires_force() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![remote(
+            "origin",
+            RemoteClassification::Unreachable,
+            true,
+        )]);
+        let mut buf = Vec::new();
+
+        let result = run_clean(&git, &scan, &default_options(), &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 0);
+        assert_eq!(result.skipped, 1);
+        assert_eq!(git.remote_remove_calls().len(), 0);
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("skipping origin"));
+        assert!(output.contains("--force"));
+    }
+
+    #[test]
+    fn clean_origin_with_force() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![remote(
+            "origin",
+            RemoteClassification::Unreachable,
+            true,
+        )]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            force: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(git.remote_remove_calls().len(), 1);
+    }
+
+    #[test]
+    fn clean_orphaned_prunes_refs() {
+        let git = MockGitBuilder::new()
+            .with_prune_remote_refs_result(&repo(), "stale", 5)
+            .build();
+        let scan = make_scan_result(vec![{
+            let mut r = remote("stale", RemoteClassification::Orphaned, false);
+            r.url = None;
+            r
+        }]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            all: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].refs_pruned, 5);
+        // Should call prune_remote_refs, NOT remote_remove
+        assert_eq!(git.prune_remote_refs_calls().len(), 1);
+        assert_eq!(git.remote_remove_calls().len(), 0);
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("pruned 5 refs"));
+    }
+
+    #[test]
+    fn clean_dry_run_makes_zero_calls() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![
+            remote("stale", RemoteClassification::Unreachable, false),
+            {
+                let mut r = remote("orphan", RemoteClassification::Orphaned, false);
+                r.url = None;
+                r
+            },
+        ]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            dry_run: true,
+            all: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 2);
+        assert_eq!(git.remote_remove_calls().len(), 0);
+        assert_eq!(git.prune_remote_refs_calls().len(), 0);
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("would remove stale"));
+        assert!(output.contains("would prune refs for orphan"));
+    }
+
+    #[test]
+    fn clean_handles_removal_failure() {
+        let git = MockGitBuilder::new()
+            .with_remote_remove_error(&repo(), "stale", "permission denied")
+            .build();
+        let scan = make_scan_result(vec![remote(
+            "stale",
+            RemoteClassification::Unreachable,
+            false,
+        )]);
+        let mut buf = Vec::new();
+
+        let result = run_clean(&git, &scan, &default_options(), &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 0);
+        assert_eq!(result.failed.len(), 1);
+        assert_eq!(result.failed[0].name, "stale");
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("error: could not remove stale"));
+    }
+}

--- a/crates/git-remote-tidy/src/cli.rs
+++ b/crates/git-remote-tidy/src/cli.rs
@@ -1,0 +1,149 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "git-remote-tidy",
+    about = "Scan, classify, and remove stale Git remotes and orphaned tracking refs"
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Command>,
+
+    /// Directory to scan (default: current directory)
+    #[arg(global = true)]
+    pub directory: Option<PathBuf>,
+
+    /// Skip reachability checks (no network access)
+    #[arg(long, global = true)]
+    pub offline: bool,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Read-only analysis of configured and orphaned remotes
+    Scan {
+        /// Output results as JSON
+        #[arg(long)]
+        json: bool,
+
+        /// Machine-readable tab-delimited output
+        #[arg(long)]
+        porcelain: bool,
+    },
+
+    /// Scan and interactively remove stale remotes
+    Clean {
+        /// Show what would be removed without removing
+        #[arg(short = 'n', long)]
+        dry_run: bool,
+
+        /// Skip confirmation prompts
+        #[arg(short = 'y', long)]
+        yes: bool,
+
+        /// Allow removing the origin remote
+        #[arg(short = 'f', long)]
+        force: bool,
+
+        /// Include orphaned remotes (default: unreachable only)
+        #[arg(long)]
+        all: bool,
+
+        /// Output results as JSON
+        #[arg(long)]
+        json: bool,
+
+        /// Machine-readable tab-delimited output
+        #[arg(long)]
+        porcelain: bool,
+    },
+}
+
+impl Cli {
+    /// Resolve the target directory, defaulting to the current directory.
+    pub fn target_directory(&self) -> PathBuf {
+        self.directory.clone().unwrap_or_else(|| {
+            std::env::current_dir().expect("could not determine current directory")
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[test]
+    fn default_command_is_scan() {
+        let cli = Cli::parse_from(["git-remote-tidy"]);
+        assert!(cli.command.is_none());
+        assert!(!cli.offline);
+    }
+
+    #[test]
+    fn scan_with_directory() {
+        let cli = Cli::parse_from(["git-remote-tidy", "scan", "/tmp/dev"]);
+        assert!(matches!(cli.command, Some(Command::Scan { .. })));
+        assert_eq!(cli.directory, Some(PathBuf::from("/tmp/dev")));
+    }
+
+    #[test]
+    fn scan_json_flag() {
+        let cli = Cli::parse_from(["git-remote-tidy", "scan", "--json"]);
+        match cli.command {
+            Some(Command::Scan { json, porcelain }) => {
+                assert!(json);
+                assert!(!porcelain);
+            }
+            _ => panic!("expected Scan command"),
+        }
+    }
+
+    #[test]
+    fn clean_with_flags() {
+        let cli = Cli::parse_from(["git-remote-tidy", "clean", "--dry-run", "--yes", "--force"]);
+        match cli.command {
+            Some(Command::Clean {
+                dry_run,
+                yes,
+                force,
+                ..
+            }) => {
+                assert!(dry_run);
+                assert!(yes);
+                assert!(force);
+            }
+            _ => panic!("expected Clean command"),
+        }
+    }
+
+    #[test]
+    fn clean_all_flag() {
+        let cli = Cli::parse_from(["git-remote-tidy", "clean", "--all"]);
+        match cli.command {
+            Some(Command::Clean { all, .. }) => {
+                assert!(all);
+            }
+            _ => panic!("expected Clean command"),
+        }
+    }
+
+    #[test]
+    fn offline_flag() {
+        let cli = Cli::parse_from(["git-remote-tidy", "--offline", "scan"]);
+        assert!(cli.offline);
+    }
+
+    #[test]
+    fn offline_flag_with_clean() {
+        let cli = Cli::parse_from(["git-remote-tidy", "--offline", "clean", "--dry-run"]);
+        assert!(cli.offline);
+        match cli.command {
+            Some(Command::Clean { dry_run, .. }) => assert!(dry_run),
+            _ => panic!("expected Clean command"),
+        }
+    }
+}

--- a/crates/git-remote-tidy/src/lib.rs
+++ b/crates/git-remote-tidy/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod clean;
+pub mod cli;
+pub mod output;
+pub mod scan;
+pub mod types;
+
+pub use git_tidy_core;

--- a/crates/git-remote-tidy/src/main.rs
+++ b/crates/git-remote-tidy/src/main.rs
@@ -1,0 +1,85 @@
+use std::io;
+use std::process;
+
+use clap::Parser;
+use git_tidy_core::git;
+
+mod clean;
+mod cli;
+mod output;
+mod scan;
+mod types;
+
+fn main() {
+    let cli = cli::Cli::parse();
+    let directory = cli.target_directory();
+
+    if !directory.is_dir() {
+        eprintln!("error: directory not found: {}", directory.display());
+        process::exit(1);
+    }
+
+    let git = git::RealGit;
+    let mut stdout = io::stdout().lock();
+
+    match &cli.command {
+        None | Some(cli::Command::Scan { .. }) => {
+            let (json, porcelain) = match &cli.command {
+                Some(cli::Command::Scan { json, porcelain }) => (*json, *porcelain),
+                _ => (false, false),
+            };
+
+            match scan::run_scan(&git, &directory, cli.offline) {
+                Ok(result) => {
+                    let write_result = if json {
+                        output::write_json(&mut stdout, &result)
+                    } else if porcelain {
+                        output::write_porcelain(&mut stdout, &result)
+                    } else {
+                        output::write_human(&mut stdout, &result)
+                    };
+                    if let Err(e) = write_result {
+                        eprintln!("error writing output: {e}");
+                        process::exit(1);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    process::exit(e.exit_code());
+                }
+            }
+        }
+        Some(cli::Command::Clean {
+            dry_run,
+            yes,
+            force,
+            all,
+            ..
+        }) => match scan::run_scan(&git, &directory, cli.offline) {
+            Ok(scan_result) => {
+                let options = clean::CleanOptions {
+                    dry_run: *dry_run,
+                    yes: *yes,
+                    force: *force,
+                    all: *all,
+                };
+
+                match clean::run_clean(&git, &scan_result, &options, &mut stdout) {
+                    Ok(result) => {
+                        if !result.failed.is_empty() {
+                            process::exit(1);
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(e.exit_code());
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                process::exit(e.exit_code());
+            }
+        },
+    }
+}

--- a/crates/git-remote-tidy/src/output.rs
+++ b/crates/git-remote-tidy/src/output.rs
@@ -1,0 +1,230 @@
+use std::io::Write;
+
+use git_tidy_core::output as shared;
+
+use crate::types::{JsonRemote, RemoteScanResult};
+
+/// Write human-readable scan output.
+pub fn write_human(out: &mut dyn Write, result: &RemoteScanResult) -> std::io::Result<()> {
+    shared::write_warnings(out, &result.warnings)?;
+
+    for group in &result.repos {
+        let noun = if group.remotes.len() == 1 {
+            "remote"
+        } else {
+            "remotes"
+        };
+        writeln!(out, "\n{} ({} {noun})", group.name, group.remotes.len())?;
+
+        for remote in &group.remotes {
+            let label = format!("{:<13}", remote.classification.label());
+            let url = remote.url.as_deref().unwrap_or("");
+            let tracking = if remote.tracking_count > 0 {
+                let branch_noun = if remote.tracking_count == 1 {
+                    "tracking branch"
+                } else {
+                    "tracking branches"
+                };
+                format!("({} {branch_noun})", remote.tracking_count)
+            } else {
+                String::new()
+            };
+
+            writeln!(out, "  {label} {:<12} {:<50} {tracking}", remote.name, url,)?;
+        }
+    }
+
+    write_remote_summary(out, result)?;
+
+    Ok(())
+}
+
+/// Write the remote-specific summary line.
+fn write_remote_summary(out: &mut dyn Write, result: &RemoteScanResult) -> std::io::Result<()> {
+    let c = &result.counts;
+    writeln!(
+        out,
+        "\n{} remotes scanned: {} unreachable, {} orphaned, {} active",
+        result.total_scanned, c.unreachable, c.orphaned, c.active,
+    )
+}
+
+/// Write JSON scan output using the flat spec format.
+pub fn write_json(out: &mut dyn Write, result: &RemoteScanResult) -> std::io::Result<()> {
+    let all_remotes: Vec<JsonRemote> = result
+        .repos
+        .iter()
+        .flat_map(|g| g.remotes.iter())
+        .map(JsonRemote::from)
+        .collect();
+
+    let json = serde_json::to_string_pretty(&all_remotes).map_err(std::io::Error::other)?;
+    writeln!(out, "{json}")?;
+    Ok(())
+}
+
+/// Write porcelain (machine-readable, tab-delimited) scan output.
+pub fn write_porcelain(out: &mut dyn Write, result: &RemoteScanResult) -> std::io::Result<()> {
+    for group in &result.repos {
+        for remote in &group.remotes {
+            let repo = remote.repo_path.display();
+            let url = remote.url.as_deref().unwrap_or("");
+
+            writeln!(
+                out,
+                "{repo}\t{}\t{}\t{url}\t{}\t{}",
+                remote.name,
+                remote.classification.label(),
+                remote.tracking_count,
+                remote.is_origin,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::types::*;
+
+    fn make_scan_result() -> RemoteScanResult {
+        RemoteScanResult {
+            repos: vec![RemoteRepoGroup {
+                repo_path: PathBuf::from("/repos/backend"),
+                name: "backend".to_string(),
+                remotes: vec![
+                    RemoteInfo {
+                        repo_path: PathBuf::from("/repos/backend"),
+                        name: "origin".to_string(),
+                        classification: RemoteClassification::Unreachable,
+                        url: Some("https://github.com/old-org/backend.git".to_string()),
+                        tracking_count: 12,
+                        is_origin: true,
+                    },
+                    RemoteInfo {
+                        repo_path: PathBuf::from("/repos/backend"),
+                        name: "upstream".to_string(),
+                        classification: RemoteClassification::Active,
+                        url: Some("https://github.com/new-org/backend.git".to_string()),
+                        tracking_count: 5,
+                        is_origin: false,
+                    },
+                ],
+            }],
+            total_scanned: 2,
+            counts: RemoteCounts {
+                unreachable: 1,
+                orphaned: 0,
+                active: 1,
+            },
+            warnings: vec![],
+        }
+    }
+
+    #[test]
+    fn human_output_basic() {
+        let result = make_scan_result();
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("backend (2 remotes)"));
+        assert!(output.contains("unreachable"));
+        assert!(output.contains("active"));
+        assert!(output.contains("origin"));
+        assert!(output.contains("upstream"));
+        assert!(output.contains("12 tracking branches"));
+        assert!(output.contains("5 tracking branches"));
+        assert!(output.contains("2 remotes scanned: 1 unreachable, 0 orphaned, 1 active"));
+    }
+
+    #[test]
+    fn human_output_with_warnings() {
+        let result = RemoteScanResult {
+            repos: vec![],
+            total_scanned: 0,
+            counts: RemoteCounts::default(),
+            warnings: vec!["could not list remotes for /repo/Foo".to_string()],
+        };
+
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("warning: could not list remotes for /repo/Foo"));
+    }
+
+    #[test]
+    fn json_output_valid() {
+        let result = make_scan_result();
+        let mut buf = Vec::new();
+        write_json(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["classification"], "unreachable");
+        assert_eq!(arr[0]["name"], "origin");
+        assert_eq!(arr[0]["tracking_count"], 12);
+        assert!(arr[0]["is_origin"].as_bool().unwrap());
+        assert_eq!(arr[1]["classification"], "active");
+        assert_eq!(arr[1]["name"], "upstream");
+    }
+
+    #[test]
+    fn json_output_orphaned_null_url() {
+        let result = RemoteScanResult {
+            repos: vec![RemoteRepoGroup {
+                repo_path: PathBuf::from("/repos/test"),
+                name: "test".to_string(),
+                remotes: vec![RemoteInfo {
+                    repo_path: PathBuf::from("/repos/test"),
+                    name: "stale".to_string(),
+                    classification: RemoteClassification::Orphaned,
+                    url: None,
+                    tracking_count: 3,
+                    is_origin: false,
+                }],
+            }],
+            total_scanned: 1,
+            counts: RemoteCounts {
+                orphaned: 1,
+                ..Default::default()
+            },
+            warnings: vec![],
+        };
+
+        let mut buf = Vec::new();
+        write_json(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert!(arr[0]["url"].is_null());
+        assert_eq!(arr[0]["classification"], "orphaned");
+    }
+
+    #[test]
+    fn porcelain_output_tab_delimited() {
+        let result = make_scan_result();
+        let mut buf = Vec::new();
+        write_porcelain(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines.len(), 2);
+
+        let fields: Vec<&str> = lines[0].split('\t').collect();
+        assert_eq!(fields.len(), 6);
+        assert_eq!(fields[0], "/repos/backend");
+        assert_eq!(fields[1], "origin");
+        assert_eq!(fields[2], "unreachable");
+        assert_eq!(fields[3], "https://github.com/old-org/backend.git");
+        assert_eq!(fields[4], "12");
+        assert_eq!(fields[5], "true");
+    }
+}

--- a/crates/git-remote-tidy/src/scan.rs
+++ b/crates/git-remote-tidy/src/scan.rs
@@ -1,0 +1,237 @@
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use git_tidy_core::discovery::discover_repos;
+use git_tidy_core::error::Error;
+use git_tidy_core::git::GitOps;
+
+use crate::types::{
+    RemoteClassification, RemoteCounts, RemoteInfo, RemoteRepoGroup, RemoteScanResult,
+};
+
+/// Classify a single remote.
+///
+/// - If `is_configured` is false, the remote is Orphaned (tracking refs exist but no config).
+/// - If `offline` is true, skip reachability check and default to Active.
+/// - Otherwise, check `ls_remote_check`: reachable -> Active, unreachable -> Unreachable.
+pub fn classify_remote(
+    git: &dyn GitOps,
+    repo: &Path,
+    remote_name: &str,
+    is_configured: bool,
+    offline: bool,
+) -> RemoteClassification {
+    if !is_configured {
+        return RemoteClassification::Orphaned;
+    }
+
+    if offline {
+        return RemoteClassification::Active;
+    }
+
+    match git.ls_remote_check(repo, remote_name) {
+        Ok(true) => RemoteClassification::Active,
+        _ => RemoteClassification::Unreachable,
+    }
+}
+
+/// Scan all repos in `directory` for remotes.
+pub fn run_scan(
+    git: &dyn GitOps,
+    directory: &Path,
+    offline: bool,
+) -> Result<RemoteScanResult, Error> {
+    let repo_paths = discover_repos(directory)?;
+
+    let mut repos = Vec::new();
+    let mut counts = RemoteCounts::default();
+    let mut warnings = Vec::new();
+    let mut total_scanned = 0;
+
+    for repo_path in &repo_paths {
+        // Get configured remotes
+        let configured = match git.list_remotes(repo_path) {
+            Ok(r) => r,
+            Err(e) => {
+                warnings.push(format!(
+                    "could not list remotes for {}: {e}",
+                    repo_path.display()
+                ));
+                continue;
+            }
+        };
+
+        // Get all tracking refs to detect orphaned remotes and count per-remote
+        let tracking_refs = git.list_remote_tracking_refs(repo_path).unwrap_or_default();
+
+        // Count tracking refs per remote name and detect orphaned
+        let configured_set: HashSet<&str> = configured.iter().map(|s| s.as_str()).collect();
+        let mut tracking_counts: HashMap<String, usize> = HashMap::new();
+
+        for (short, _full) in &tracking_refs {
+            // short is like "origin/main" -- extract remote name
+            if let Some(remote_name) = short.split('/').next() {
+                // Skip HEAD refs (e.g., "origin/HEAD")
+                let branch_part = short.strip_prefix(&format!("{remote_name}/"));
+                if branch_part == Some("HEAD") {
+                    continue;
+                }
+                *tracking_counts.entry(remote_name.to_string()).or_insert(0) += 1;
+            }
+        }
+
+        // Collect all remote names (configured + orphaned)
+        let mut all_remote_names: Vec<String> = configured.clone();
+        for remote_name in tracking_counts.keys() {
+            if !configured_set.contains(remote_name.as_str()) {
+                all_remote_names.push(remote_name.clone());
+            }
+        }
+
+        if all_remote_names.is_empty() {
+            continue;
+        }
+
+        let repo_name = repo_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| repo_path.display().to_string());
+
+        let mut classified = Vec::new();
+
+        for remote_name in &all_remote_names {
+            let is_configured = configured_set.contains(remote_name.as_str());
+            let classification =
+                classify_remote(git, repo_path, remote_name, is_configured, offline);
+            let tracking_count = tracking_counts.get(remote_name).copied().unwrap_or(0);
+
+            let url = if is_configured {
+                git.remote_url(repo_path, remote_name).ok()
+            } else {
+                None
+            };
+
+            counts.increment(classification);
+            total_scanned += 1;
+
+            classified.push(RemoteInfo {
+                repo_path: repo_path.clone(),
+                name: remote_name.clone(),
+                classification,
+                url,
+                tracking_count,
+                is_origin: remote_name == "origin",
+            });
+        }
+
+        // Sort by classification priority
+        classified.sort_by_key(|r| r.classification.priority());
+
+        repos.push(RemoteRepoGroup {
+            repo_path: repo_path.clone(),
+            name: repo_name,
+            remotes: classified,
+        });
+    }
+
+    Ok(RemoteScanResult {
+        repos,
+        total_scanned,
+        counts,
+        warnings,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use git_tidy_core::testutil::MockGitBuilder;
+
+    use super::*;
+
+    fn repo() -> PathBuf {
+        PathBuf::from("/repo")
+    }
+
+    #[test]
+    fn classify_reachable_remote() {
+        let git = MockGitBuilder::new()
+            .with_ls_remote_check(&repo(), "origin", true)
+            .build();
+
+        let result = classify_remote(&git, &repo(), "origin", true, false);
+        assert_eq!(result, RemoteClassification::Active);
+    }
+
+    #[test]
+    fn classify_unreachable_remote() {
+        let git = MockGitBuilder::new()
+            .with_ls_remote_check(&repo(), "origin", false)
+            .build();
+
+        let result = classify_remote(&git, &repo(), "origin", true, false);
+        assert_eq!(result, RemoteClassification::Unreachable);
+    }
+
+    #[test]
+    fn classify_offline_skips_reachability() {
+        // No ls_remote_check configured -- if offline, should still return Active
+        let git = MockGitBuilder::new().build();
+
+        let result = classify_remote(&git, &repo(), "origin", true, true);
+        assert_eq!(result, RemoteClassification::Active);
+    }
+
+    #[test]
+    fn detect_orphaned_remote() {
+        let git = MockGitBuilder::new().build();
+
+        let result = classify_remote(&git, &repo(), "stale", false, false);
+        assert_eq!(result, RemoteClassification::Orphaned);
+    }
+
+    #[test]
+    fn is_origin_flag() {
+        // Test the origin detection logic inline
+        assert!("origin" == "origin");
+        assert!("upstream" != "origin");
+    }
+
+    #[test]
+    fn scan_sorts_by_priority() {
+        // Verify classification sorting order
+        let mut infos = [
+            RemoteInfo {
+                repo_path: repo(),
+                name: "origin".to_string(),
+                classification: RemoteClassification::Active,
+                url: Some("https://example.com".to_string()),
+                tracking_count: 5,
+                is_origin: true,
+            },
+            RemoteInfo {
+                repo_path: repo(),
+                name: "stale".to_string(),
+                classification: RemoteClassification::Unreachable,
+                url: Some("https://old.example.com".to_string()),
+                tracking_count: 2,
+                is_origin: false,
+            },
+            RemoteInfo {
+                repo_path: repo(),
+                name: "orphan".to_string(),
+                classification: RemoteClassification::Orphaned,
+                url: None,
+                tracking_count: 1,
+                is_origin: false,
+            },
+        ];
+
+        infos.sort_by_key(|r| r.classification.priority());
+
+        assert_eq!(infos[0].classification, RemoteClassification::Unreachable);
+        assert_eq!(infos[1].classification, RemoteClassification::Orphaned);
+        assert_eq!(infos[2].classification, RemoteClassification::Active);
+    }
+}

--- a/crates/git-remote-tidy/src/types.rs
+++ b/crates/git-remote-tidy/src/types.rs
@@ -1,0 +1,195 @@
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+/// Classification of a remote.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteClassification {
+    /// Remote is unreachable (ls-remote fails or times out).
+    Unreachable,
+    /// Tracking refs exist but remote is not configured.
+    Orphaned,
+    /// Remote is reachable and configured.
+    Active,
+}
+
+impl RemoteClassification {
+    /// Priority for sorting (lower = more stale).
+    pub fn priority(self) -> u8 {
+        match self {
+            Self::Unreachable => 0,
+            Self::Orphaned => 1,
+            Self::Active => 2,
+        }
+    }
+
+    /// Human-readable label.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Unreachable => "unreachable",
+            Self::Orphaned => "orphaned",
+            Self::Active => "active",
+        }
+    }
+}
+
+/// Information about a single remote (configured or orphaned).
+#[derive(Debug, Clone, Serialize)]
+pub struct RemoteInfo {
+    /// Path to the repo containing this remote.
+    pub repo_path: PathBuf,
+    /// Remote name.
+    pub name: String,
+    /// Classification of this remote.
+    pub classification: RemoteClassification,
+    /// URL of the remote (None for orphaned remotes).
+    pub url: Option<String>,
+    /// Number of tracking branches under this remote.
+    pub tracking_count: usize,
+    /// Whether this is the "origin" remote.
+    pub is_origin: bool,
+}
+
+/// A group of remotes in the same repo.
+#[derive(Debug, Clone, Serialize)]
+pub struct RemoteRepoGroup {
+    /// Path to the repo.
+    pub repo_path: PathBuf,
+    /// Display name (directory basename).
+    pub name: String,
+    /// Remotes belonging to this repo, sorted by classification priority.
+    pub remotes: Vec<RemoteInfo>,
+}
+
+/// Summary counts for a remote scan.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct RemoteCounts {
+    pub unreachable: usize,
+    pub orphaned: usize,
+    pub active: usize,
+}
+
+impl RemoteCounts {
+    pub fn increment(&mut self, classification: RemoteClassification) {
+        match classification {
+            RemoteClassification::Unreachable => self.unreachable += 1,
+            RemoteClassification::Orphaned => self.orphaned += 1,
+            RemoteClassification::Active => self.active += 1,
+        }
+    }
+
+    pub fn total(&self) -> usize {
+        self.unreachable + self.orphaned + self.active
+    }
+}
+
+/// Result of a full remote scan.
+#[derive(Debug, Clone, Serialize)]
+pub struct RemoteScanResult {
+    /// Remotes grouped by repo.
+    pub repos: Vec<RemoteRepoGroup>,
+    /// Total remotes scanned.
+    pub total_scanned: usize,
+    /// Summary counts by classification.
+    pub counts: RemoteCounts,
+    /// Warnings encountered during scanning.
+    pub warnings: Vec<String>,
+}
+
+/// Flat JSON representation of a remote.
+#[derive(Debug, Serialize)]
+pub struct JsonRemote {
+    pub repo_path: PathBuf,
+    pub name: String,
+    pub classification: String,
+    pub url: Option<String>,
+    pub tracking_count: usize,
+    pub is_origin: bool,
+}
+
+impl From<&RemoteInfo> for JsonRemote {
+    fn from(r: &RemoteInfo) -> Self {
+        JsonRemote {
+            repo_path: r.repo_path.clone(),
+            name: r.name.clone(),
+            classification: r.classification.label().to_string(),
+            url: r.url.clone(),
+            tracking_count: r.tracking_count,
+            is_origin: r.is_origin,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classification_priority_order() {
+        assert!(
+            RemoteClassification::Unreachable.priority()
+                < RemoteClassification::Orphaned.priority()
+        );
+        assert!(
+            RemoteClassification::Orphaned.priority() < RemoteClassification::Active.priority()
+        );
+    }
+
+    #[test]
+    fn classification_labels() {
+        assert_eq!(RemoteClassification::Unreachable.label(), "unreachable");
+        assert_eq!(RemoteClassification::Orphaned.label(), "orphaned");
+        assert_eq!(RemoteClassification::Active.label(), "active");
+    }
+
+    #[test]
+    fn counts_increment_and_total() {
+        let mut counts = RemoteCounts::default();
+        counts.increment(RemoteClassification::Unreachable);
+        counts.increment(RemoteClassification::Orphaned);
+        counts.increment(RemoteClassification::Active);
+        counts.increment(RemoteClassification::Active);
+        assert_eq!(counts.unreachable, 1);
+        assert_eq!(counts.orphaned, 1);
+        assert_eq!(counts.active, 2);
+        assert_eq!(counts.total(), 4);
+    }
+
+    #[test]
+    fn json_remote_from_info() {
+        let info = RemoteInfo {
+            repo_path: PathBuf::from("/repos/my-repo"),
+            name: "origin".to_string(),
+            classification: RemoteClassification::Active,
+            url: Some("https://github.com/user/repo.git".to_string()),
+            tracking_count: 5,
+            is_origin: true,
+        };
+        let json = JsonRemote::from(&info);
+        assert_eq!(json.name, "origin");
+        assert_eq!(json.classification, "active");
+        assert_eq!(
+            json.url,
+            Some("https://github.com/user/repo.git".to_string())
+        );
+        assert_eq!(json.tracking_count, 5);
+        assert!(json.is_origin);
+    }
+
+    #[test]
+    fn json_remote_orphaned_null_url() {
+        let info = RemoteInfo {
+            repo_path: PathBuf::from("/repos/my-repo"),
+            name: "stale".to_string(),
+            classification: RemoteClassification::Orphaned,
+            url: None,
+            tracking_count: 3,
+            is_origin: false,
+        };
+        let json = JsonRemote::from(&info);
+        assert_eq!(json.classification, "orphaned");
+        assert!(json.url.is_none());
+        assert!(!json.is_origin);
+    }
+}

--- a/crates/git-remote-tidy/tests/common/mod.rs
+++ b/crates/git-remote-tidy/tests/common/mod.rs
@@ -1,0 +1,1 @@
+pub use git_tidy_core::testutil::*;

--- a/crates/git-remote-tidy/tests/integration_clean.rs
+++ b/crates/git-remote-tidy/tests/integration_clean.rs
@@ -1,0 +1,148 @@
+mod common;
+
+use common::git;
+use git_tidy_core::git::{GitOps, RealGit};
+
+/// Set up a repo inside a scan directory so `discover_repos` finds it.
+fn set_up_repo() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().canonicalize().unwrap();
+
+    let scan_dir = base.join("projects");
+    std::fs::create_dir_all(&scan_dir).unwrap();
+
+    let repo = scan_dir.join("my-repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    git(&repo, &["init", "-b", "main"]);
+    git(&repo, &["config", "user.email", "test@test.com"]);
+    git(&repo, &["config", "user.name", "Test"]);
+
+    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
+    git(&repo, &["add", "README.md"]);
+    git(&repo, &["commit", "-m", "Initial commit"]);
+
+    (dir, repo)
+}
+
+#[test]
+fn clean_removes_remote_in_real_repo() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Add a remote pointing to a nonexistent path (will be unreachable)
+    git(
+        &repo,
+        &["remote", "add", "stale", "/nonexistent/path/repo.git"],
+    );
+
+    // Verify remote exists
+    let remotes = git_ops.list_remotes(&repo).unwrap();
+    assert!(remotes.contains(&"stale".to_string()));
+
+    // Scan then clean
+    let scan_result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+
+    let options = git_remote_tidy::clean::CleanOptions {
+        dry_run: false,
+        yes: true,
+        force: false,
+        all: false,
+    };
+
+    let mut buf = Vec::new();
+    let result =
+        git_remote_tidy::clean::run_clean(&git_ops, &scan_result, &options, &mut buf).unwrap();
+
+    assert_eq!(result.removed.len(), 1);
+
+    // Verify remote is gone
+    let remotes = git_ops.list_remotes(&repo).unwrap();
+    assert!(!remotes.contains(&"stale".to_string()));
+}
+
+#[test]
+fn clean_dry_run_does_not_remove() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    git(
+        &repo,
+        &["remote", "add", "stale", "/nonexistent/path/repo.git"],
+    );
+
+    let scan_result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+
+    let options = git_remote_tidy::clean::CleanOptions {
+        dry_run: true,
+        yes: true,
+        force: false,
+        all: false,
+    };
+
+    let mut buf = Vec::new();
+    let result =
+        git_remote_tidy::clean::run_clean(&git_ops, &scan_result, &options, &mut buf).unwrap();
+
+    // Reports it would remove
+    assert_eq!(result.removed.len(), 1);
+
+    // But remote still exists
+    let remotes = git_ops.list_remotes(&repo).unwrap();
+    assert!(remotes.contains(&"stale".to_string()));
+
+    let output = String::from_utf8(buf).unwrap();
+    assert!(output.contains("would remove"));
+}
+
+#[test]
+fn clean_prunes_orphaned_refs() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Manually create orphaned refs
+    let head_hash = git(&repo, &["rev-parse", "HEAD"]);
+    git(
+        &repo,
+        &["update-ref", "refs/remotes/stale/main", &head_hash],
+    );
+    git(
+        &repo,
+        &["update-ref", "refs/remotes/stale/feature", &head_hash],
+    );
+
+    // Verify refs exist
+    let refs = git_ops.list_remote_tracking_refs(&repo).unwrap();
+    let stale_refs: Vec<_> = refs
+        .iter()
+        .filter(|(s, _)| s.starts_with("stale/"))
+        .collect();
+    assert_eq!(stale_refs.len(), 2);
+
+    // Scan then clean with --all
+    let scan_result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+
+    let options = git_remote_tidy::clean::CleanOptions {
+        dry_run: false,
+        yes: true,
+        force: false,
+        all: true,
+    };
+
+    let mut buf = Vec::new();
+    let result =
+        git_remote_tidy::clean::run_clean(&git_ops, &scan_result, &options, &mut buf).unwrap();
+
+    assert_eq!(result.removed.len(), 1);
+    assert!(result.removed[0].refs_pruned > 0);
+
+    // Verify refs are gone
+    let refs = git_ops.list_remote_tracking_refs(&repo).unwrap();
+    let stale_refs: Vec<_> = refs
+        .iter()
+        .filter(|(s, _)| s.starts_with("stale/"))
+        .collect();
+    assert!(stale_refs.is_empty());
+}

--- a/crates/git-remote-tidy/tests/integration_scan.rs
+++ b/crates/git-remote-tidy/tests/integration_scan.rs
@@ -1,0 +1,138 @@
+mod common;
+
+use common::git;
+use git_tidy_core::git::RealGit;
+
+use git_remote_tidy::types::RemoteClassification;
+
+/// Set up a repo inside a scan directory so `discover_repos` finds it.
+fn set_up_repo() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().canonicalize().unwrap();
+
+    let scan_dir = base.join("projects");
+    std::fs::create_dir_all(&scan_dir).unwrap();
+
+    let repo = scan_dir.join("my-repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    git(&repo, &["init", "-b", "main"]);
+    git(&repo, &["config", "user.email", "test@test.com"]);
+    git(&repo, &["config", "user.name", "Test"]);
+
+    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
+    git(&repo, &["add", "README.md"]);
+    git(&repo, &["commit", "-m", "Initial commit"]);
+
+    (dir, repo)
+}
+
+#[test]
+fn scan_real_repo_with_reachable_remote() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Create a bare remote and push to it
+    let bare = dir.path().canonicalize().unwrap().join("remote.git");
+    std::fs::create_dir_all(&bare).unwrap();
+    git(&bare, &["init", "--bare"]);
+    git(&repo, &["remote", "add", "origin", &bare.to_string_lossy()]);
+    git(&repo, &["push", "-u", "origin", "main"]);
+
+    let result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+    assert_eq!(result.total_scanned, 1);
+
+    let remote = &result.repos[0].remotes[0];
+    assert_eq!(remote.name, "origin");
+    assert_eq!(remote.classification, RemoteClassification::Active);
+    assert!(remote.is_origin);
+    assert!(remote.tracking_count > 0);
+}
+
+#[test]
+fn scan_repo_with_unreachable_remote() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Add a remote pointing to a nonexistent path
+    git(
+        &repo,
+        &["remote", "add", "origin", "/nonexistent/path/repo.git"],
+    );
+
+    let result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+    assert_eq!(result.total_scanned, 1);
+
+    let remote = &result.repos[0].remotes[0];
+    assert_eq!(remote.name, "origin");
+    assert_eq!(remote.classification, RemoteClassification::Unreachable);
+}
+
+#[test]
+fn scan_repo_with_orphaned_refs() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Manually create a ref under refs/remotes/stale/ (no config for "stale")
+    let head_hash = git(&repo, &["rev-parse", "HEAD"]);
+    git(
+        &repo,
+        &["update-ref", "refs/remotes/stale/main", &head_hash],
+    );
+
+    let result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+
+    // Should detect the orphaned remote
+    let orphaned: Vec<_> = result.repos[0]
+        .remotes
+        .iter()
+        .filter(|r| r.classification == RemoteClassification::Orphaned)
+        .collect();
+    assert_eq!(orphaned.len(), 1);
+    assert_eq!(orphaned[0].name, "stale");
+    assert!(orphaned[0].url.is_none());
+    assert_eq!(orphaned[0].tracking_count, 1);
+}
+
+#[test]
+fn scan_empty_repo_no_remotes() {
+    let (dir, _repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    let result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+
+    // Repo has no remotes, so no groups
+    assert!(result.repos.is_empty());
+    assert_eq!(result.total_scanned, 0);
+}
+
+#[test]
+fn scan_offline_mode() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Add a remote pointing to a nonexistent path -- offline mode should skip reachability
+    git(
+        &repo,
+        &["remote", "add", "origin", "/nonexistent/path/repo.git"],
+    );
+
+    let result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, true).unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+
+    let remote = &result.repos[0].remotes[0];
+    assert_eq!(remote.name, "origin");
+    // In offline mode, configured remotes default to Active
+    assert_eq!(remote.classification, RemoteClassification::Active);
+}

--- a/crates/git-tidy-core/src/error.rs
+++ b/crates/git-tidy-core/src/error.rs
@@ -33,6 +33,13 @@ pub enum Error {
         reason: String,
     },
 
+    #[error("remote removal failed: {remote} in {repo}: {reason}")]
+    RemoteRemovalFailed {
+        repo: PathBuf,
+        remote: String,
+        reason: String,
+    },
+
     #[error("dirty worktrees blocked removal (rerun with --force)")]
     DirtyBlocked,
 

--- a/crates/git-tidy-core/src/git.rs
+++ b/crates/git-tidy-core/src/git.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::process::Command;
+use std::time::{Duration, Instant};
 
 use crate::error::Error;
 
@@ -113,6 +114,29 @@ pub trait GitOps {
         file: &str,
     ) -> GitResult<Vec<(String, String)>>;
 
+    // --- Remote operations ---
+
+    /// List configured remotes in a repo.
+    fn list_remotes(&self, repo: &Path) -> GitResult<Vec<String>>;
+
+    /// Get the URL for a configured remote.
+    fn remote_url(&self, repo: &Path, remote: &str) -> GitResult<String>;
+
+    /// Check if a remote is reachable via `ls-remote` with a timeout.
+    /// Returns `true` if the remote responds, `false` if unreachable or timed out.
+    fn ls_remote_check(&self, repo: &Path, remote: &str) -> GitResult<bool>;
+
+    /// Remove a configured remote: `git remote remove <remote>`.
+    fn remote_remove(&self, repo: &Path, remote: &str) -> GitResult<()>;
+
+    /// List all remote tracking refs under `refs/remotes/`.
+    /// Returns `(short_name, full_refname)` pairs.
+    fn list_remote_tracking_refs(&self, repo: &Path) -> GitResult<Vec<(String, String)>>;
+
+    /// Prune tracking refs belonging to a specific remote name.
+    /// Returns the number of refs successfully deleted.
+    fn prune_remote_refs(&self, repo: &Path, remote: &str) -> GitResult<usize>;
+
     // --- Stash operations ---
 
     /// List stashes in a repo.
@@ -153,6 +177,52 @@ impl RealGit {
             });
         }
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    /// Run a git command with a timeout. Returns `None` if timed out.
+    fn run_with_timeout(
+        repo: &Path,
+        args: &[&str],
+        timeout: Duration,
+    ) -> GitResult<Option<std::process::Output>> {
+        let mut child = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| Error::GitCommand {
+                command: format!("git -C {} {}", repo.display(), args.join(" ")),
+                message: e.to_string(),
+            })?;
+
+        let start = Instant::now();
+        loop {
+            match child.try_wait() {
+                Ok(Some(_status)) => {
+                    let output = child.wait_with_output().map_err(|e| Error::GitCommand {
+                        command: format!("git -C {} {}", repo.display(), args.join(" ")),
+                        message: e.to_string(),
+                    })?;
+                    return Ok(Some(output));
+                }
+                Ok(None) => {
+                    if start.elapsed() >= timeout {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        return Ok(None);
+                    }
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+                Err(e) => {
+                    return Err(Error::GitCommand {
+                        command: format!("git -C {} {}", repo.display(), args.join(" ")),
+                        message: e.to_string(),
+                    });
+                }
+            }
+        }
     }
 
     fn parse_log_oneline(output: &str) -> Vec<(String, String)> {
@@ -400,6 +470,80 @@ impl GitOps for RealGit {
         let output = Self::run(repo, &["log", ref_spec, "--oneline", "--all", "--", file])?;
         let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
         Ok(Self::parse_log_oneline(&text))
+    }
+
+    // --- Remote operations ---
+
+    fn list_remotes(&self, repo: &Path) -> GitResult<Vec<String>> {
+        let text = Self::run_success(repo, &["remote"])?;
+        Ok(text
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| l.to_string())
+            .collect())
+    }
+
+    fn remote_url(&self, repo: &Path, remote: &str) -> GitResult<String> {
+        Self::run_success(repo, &["remote", "get-url", remote])
+    }
+
+    fn ls_remote_check(&self, repo: &Path, remote: &str) -> GitResult<bool> {
+        let timeout = Duration::from_secs(10);
+        match Self::run_with_timeout(
+            repo,
+            &["ls-remote", "--exit-code", "--heads", remote],
+            timeout,
+        )? {
+            Some(output) => Ok(output.status.success()),
+            None => Ok(false), // timed out
+        }
+    }
+
+    fn remote_remove(&self, repo: &Path, remote: &str) -> GitResult<()> {
+        Self::run_success(repo, &["remote", "remove", remote]).map_err(|_| {
+            Error::RemoteRemovalFailed {
+                repo: repo.to_path_buf(),
+                remote: remote.to_string(),
+                reason: "git remote remove failed".to_string(),
+            }
+        })?;
+        Ok(())
+    }
+
+    fn list_remote_tracking_refs(&self, repo: &Path) -> GitResult<Vec<(String, String)>> {
+        let output = Self::run(
+            repo,
+            &[
+                "for-each-ref",
+                "--format=%(refname:short)%00%(refname)",
+                "refs/remotes/",
+            ],
+        )?;
+        let text = String::from_utf8_lossy(&output.stdout);
+        let mut result = Vec::new();
+        for line in text.lines() {
+            if line.is_empty() {
+                continue;
+            }
+            if let Some((short, full)) = line.split_once('\0') {
+                result.push((short.to_string(), full.to_string()));
+            }
+        }
+        Ok(result)
+    }
+
+    fn prune_remote_refs(&self, repo: &Path, remote: &str) -> GitResult<usize> {
+        let refs = self.list_remote_tracking_refs(repo)?;
+        let prefix = format!("{remote}/");
+        let mut deleted = 0;
+        for (short, full) in &refs {
+            if (short.starts_with(&prefix) || short == remote)
+                && Self::run_success(repo, &["update-ref", "-d", full]).is_ok()
+            {
+                deleted += 1;
+            }
+        }
+        Ok(deleted)
     }
 
     // --- Stash operations ---

--- a/crates/git-tidy-core/src/testutil.rs
+++ b/crates/git-tidy-core/src/testutil.rs
@@ -42,6 +42,15 @@ pub struct MockGitBuilder {
     stash_diff: HashMap<(PathBuf, String), String>,
     stash_drop_errors: HashMap<(PathBuf, String), String>,
     stash_drop_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    // Remote operations
+    list_remotes: HashMap<PathBuf, Vec<String>>,
+    remote_url: HashMap<(PathBuf, String), String>,
+    ls_remote_check: HashMap<(PathBuf, String), bool>,
+    remote_remove_errors: HashMap<(PathBuf, String), String>,
+    remote_remove_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    remote_tracking_refs: HashMap<PathBuf, Vec<(String, String)>>,
+    prune_remote_refs_result: HashMap<(PathBuf, String), usize>,
+    prune_remote_refs_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
 }
 
 impl MockGitBuilder {
@@ -267,6 +276,47 @@ impl MockGitBuilder {
         self
     }
 
+    // --- Remote builder methods ---
+
+    pub fn with_list_remotes(mut self, repo: &Path, remotes: Vec<String>) -> Self {
+        self.list_remotes.insert(repo.to_path_buf(), remotes);
+        self
+    }
+
+    pub fn with_remote_url(mut self, repo: &Path, remote: &str, url: &str) -> Self {
+        self.remote_url
+            .insert((repo.to_path_buf(), remote.to_string()), url.to_string());
+        self
+    }
+
+    pub fn with_ls_remote_check(mut self, repo: &Path, remote: &str, reachable: bool) -> Self {
+        self.ls_remote_check
+            .insert((repo.to_path_buf(), remote.to_string()), reachable);
+        self
+    }
+
+    pub fn with_remote_remove_error(mut self, repo: &Path, remote: &str, error: &str) -> Self {
+        self.remote_remove_errors
+            .insert((repo.to_path_buf(), remote.to_string()), error.to_string());
+        self
+    }
+
+    pub fn with_remote_tracking_refs(mut self, repo: &Path, refs: Vec<(String, String)>) -> Self {
+        self.remote_tracking_refs.insert(repo.to_path_buf(), refs);
+        self
+    }
+
+    pub fn with_prune_remote_refs_result(
+        mut self,
+        repo: &Path,
+        remote: &str,
+        count: usize,
+    ) -> Self {
+        self.prune_remote_refs_result
+            .insert((repo.to_path_buf(), remote.to_string()), count);
+        self
+    }
+
     pub fn build(self) -> MockGit {
         MockGit {
             symbolic_ref: self.symbolic_ref,
@@ -302,6 +352,14 @@ impl MockGitBuilder {
             stash_diff: self.stash_diff,
             stash_drop_errors: self.stash_drop_errors,
             stash_drop_calls: self.stash_drop_calls,
+            list_remotes: self.list_remotes,
+            remote_url: self.remote_url,
+            ls_remote_check: self.ls_remote_check,
+            remote_remove_errors: self.remote_remove_errors,
+            remote_remove_calls: self.remote_remove_calls,
+            remote_tracking_refs: self.remote_tracking_refs,
+            prune_remote_refs_result: self.prune_remote_refs_result,
+            prune_remote_refs_calls: self.prune_remote_refs_calls,
         }
     }
 }
@@ -341,6 +399,15 @@ pub struct MockGit {
     stash_diff: HashMap<(PathBuf, String), String>,
     stash_drop_errors: HashMap<(PathBuf, String), String>,
     stash_drop_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    // Remote operations
+    list_remotes: HashMap<PathBuf, Vec<String>>,
+    remote_url: HashMap<(PathBuf, String), String>,
+    ls_remote_check: HashMap<(PathBuf, String), bool>,
+    remote_remove_errors: HashMap<(PathBuf, String), String>,
+    remote_remove_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    remote_tracking_refs: HashMap<PathBuf, Vec<(String, String)>>,
+    prune_remote_refs_result: HashMap<(PathBuf, String), usize>,
+    prune_remote_refs_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
 }
 
 impl MockGit {
@@ -370,6 +437,14 @@ impl MockGit {
 
     pub fn stash_drop_calls(&self) -> Vec<(PathBuf, String)> {
         self.stash_drop_calls.borrow().clone()
+    }
+
+    pub fn remote_remove_calls(&self) -> Vec<(PathBuf, String)> {
+        self.remote_remove_calls.borrow().clone()
+    }
+
+    pub fn prune_remote_refs_calls(&self) -> Vec<(PathBuf, String)> {
+        self.prune_remote_refs_calls.borrow().clone()
     }
 }
 
@@ -629,6 +704,68 @@ impl GitOps for MockGit {
         Ok(())
     }
 
+    // --- Remote operations ---
+
+    fn list_remotes(&self, repo: &Path) -> GitResult<Vec<String>> {
+        Ok(self
+            .list_remotes
+            .get(&repo.to_path_buf())
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    fn remote_url(&self, repo: &Path, remote: &str) -> GitResult<String> {
+        self.remote_url
+            .get(&(repo.to_path_buf(), remote.to_string()))
+            .cloned()
+            .ok_or_else(|| Error::GitCommand {
+                command: format!("remote get-url {remote}"),
+                message: "not found in mock".to_string(),
+            })
+    }
+
+    fn ls_remote_check(&self, repo: &Path, remote: &str) -> GitResult<bool> {
+        Ok(*self
+            .ls_remote_check
+            .get(&(repo.to_path_buf(), remote.to_string()))
+            .unwrap_or(&false))
+    }
+
+    fn remote_remove(&self, repo: &Path, remote: &str) -> GitResult<()> {
+        if let Some(err) = self
+            .remote_remove_errors
+            .get(&(repo.to_path_buf(), remote.to_string()))
+        {
+            return Err(Error::RemoteRemovalFailed {
+                repo: repo.to_path_buf(),
+                remote: remote.to_string(),
+                reason: err.clone(),
+            });
+        }
+        self.remote_remove_calls
+            .borrow_mut()
+            .push((repo.to_path_buf(), remote.to_string()));
+        Ok(())
+    }
+
+    fn list_remote_tracking_refs(&self, repo: &Path) -> GitResult<Vec<(String, String)>> {
+        Ok(self
+            .remote_tracking_refs
+            .get(&repo.to_path_buf())
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    fn prune_remote_refs(&self, repo: &Path, remote: &str) -> GitResult<usize> {
+        self.prune_remote_refs_calls
+            .borrow_mut()
+            .push((repo.to_path_buf(), remote.to_string()));
+        Ok(*self
+            .prune_remote_refs_result
+            .get(&(repo.to_path_buf(), remote.to_string()))
+            .unwrap_or(&0))
+    }
+
     // --- Stash operations ---
 
     fn list_stashes(&self, repo: &Path) -> GitResult<Vec<(String, String, String)>> {
@@ -752,6 +889,11 @@ impl TestRepo {
         );
         git(&self.main_repo, &["push", "-u", "origin", "main"]);
         bare
+    }
+
+    /// Add a remote to the repo.
+    pub fn add_remote(&self, name: &str, url: &str) {
+        git(&self.main_repo, &["remote", "add", name, url]);
     }
 
     /// Create a stash by writing a file and running `git stash`.


### PR DESCRIPTION
## Summary

- Adds `git-remote-tidy` binary crate for scanning repos and removing stale/orphaned remotes
- Classifies remotes as unreachable (ls-remote fails/times out), orphaned (tracking refs without config), or active
- Extends `git-tidy-core` with 6 new GitOps methods + `run_with_timeout()` polling helper
- Supports `--offline` mode, `--force` for origin removal, and `--all` to include orphaned ref pruning

Closes #32

## Test plan

- [x] 32 unit tests (types, scan, output, clean, CLI) - all pass
- [x] 8 integration tests with real git repos (scan + clean scenarios) - all pass
- [x] `cargo clippy --workspace --all-targets -- -D clippy::all` clean
- [x] `cargo fmt --check --all` clean
- [x] Smoke tested against ~/Developer (98 remotes scanned)