### PR TITLE
Extract shared abstractions into git-tidy-core

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,12 +22,15 @@ This is a Cargo workspace with a shared core library and four binary crates.
 
 - **`GitOps` trait** (`git-tidy-core/src/git.rs`): All git operations go through this trait. `RealGit` shells out to `git`; `MockGit` (in `testutil.rs`) returns canned data.
 - **Output to `&mut dyn Write`**: Enables unit testing output formatters without process capture.
-- **Shared output helpers** (`git-tidy-core/src/output.rs`): `write_summary_line`, `write_warnings`, `format_ahead_behind`, `format_annotations`, `format_landed_ratio`. Both tools call these to avoid duplicating formatting logic.
+- **Shared output helpers** (`git-tidy-core/src/output.rs`): `write_summary_line`, `write_warnings`, `format_ahead_behind`, `format_annotations`, `format_landed_ratio`, `repo_display_name`, `write_json_pretty`. All tools call these to avoid duplicating formatting logic.
+- **Shared CLI utilities** (`git-tidy-core/src/cli.rs`): `resolve_directory` for resolving optional directory arguments, used by all tools.
+- **Shared error handling** (`git-tidy-core/src/error.rs`): `exit_with_error` for consistent error-exit behavior across all tools.
+- **Shared type helpers** (`git-tidy-core/src/types.rs`): `extract_landed_fields` for extracting landed ratio/total/unmatched from `Classification` for JSON serialization.
 - **`thiserror`** for errors: Known, finite variants with exit code mapping (1=error, 2=dirty-blocked).
 - **Sequential repo processing**: No parallelism needed for typical workloads (~9 repos, ~39 worktrees).
 - **Library-first design**: `scan.rs` and `clean.rs` are library functions; `main.rs` is thin dispatch. Enables future tools to call scan as a library.
 
-### CLI pattern (documented convention, not shared code)
+### CLI pattern (shared `resolve_directory`, per-crate `clap` definitions)
 
 All tools follow a similar CLI shape:
 - **Global args**: `directory` (positional, default cwd), plus tool-specific thresholds
@@ -56,15 +59,16 @@ crates/
   git-tidy-core/                              # Shared library
     src/
       lib.rs                                  # Module exports
+      cli.rs                                  # Shared CLI utilities (resolve_directory)
       git.rs                                  # GitOps trait + RealGit implementation
       types.rs                                # Classification, BranchClassification, WorktreeInfo, etc.
-      error.rs                                # thiserror Error enum
+      error.rs                                # thiserror Error enum + exit_with_error
       classification.rs                       # classify_branch + classify_worktree
       config.rs                               # Noise pattern configuration (file + CLI + defaults)
       dirty.rs                                # Status parsing with noise filtering
       discovery.rs                            # Repo discovery (shared by all tools)
       landed.rs                               # Subject matching, fuzzy, patch similarity
-      output.rs                               # Shared output helpers (summary, warnings, formatting)
+      output.rs                               # Shared output helpers (summary, warnings, formatting, JSON)
       testutil.rs                             # MockGitBuilder, MockGit, TestRepo, git() helper
   git-worktree-tidy/                          # Worktree scanner/cleaner binary
     src/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ name = "git-tidy-core"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
  "strsim",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/git-branch-tidy/src/cli.rs
+++ b/crates/git-branch-tidy/src/cli.rs
@@ -80,9 +80,7 @@ pub enum Command {
 impl Cli {
     /// Resolve the target directory, defaulting to the current directory.
     pub fn target_directory(&self) -> PathBuf {
-        self.directory.clone().unwrap_or_else(|| {
-            std::env::current_dir().expect("could not determine current directory")
-        })
+        git_tidy_core::cli::resolve_directory(self.directory.clone())
     }
 }
 

--- a/crates/git-branch-tidy/src/main.rs
+++ b/crates/git-branch-tidy/src/main.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::process;
 
 use clap::Parser;
+use git_tidy_core::error;
 use git_tidy_core::git;
 
 mod clean;
@@ -44,10 +45,7 @@ fn main() {
                         process::exit(1);
                     }
                 }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(e.exit_code());
-                }
+                Err(e) => error::exit_with_error(&e),
             }
         }
         Some(cli::Command::Clean {
@@ -79,16 +77,10 @@ fn main() {
                                 process::exit(1);
                             }
                         }
-                        Err(e) => {
-                            eprintln!("error: {e}");
-                            process::exit(e.exit_code());
-                        }
+                        Err(e) => error::exit_with_error(&e),
                     }
                 }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(e.exit_code());
-                }
+                Err(e) => error::exit_with_error(&e),
             }
         }
     }

--- a/crates/git-branch-tidy/src/output.rs
+++ b/crates/git-branch-tidy/src/output.rs
@@ -79,9 +79,7 @@ pub fn write_json(out: &mut dyn Write, result: &BranchScanResult) -> std::io::Re
         .map(JsonBranch::from)
         .collect();
 
-    let json = serde_json::to_string_pretty(&all_branches).map_err(std::io::Error::other)?;
-    writeln!(out, "{json}")?;
-    Ok(())
+    shared::write_json_pretty(out, &all_branches)
 }
 
 /// Write porcelain (machine-readable, tab-delimited) scan output.

--- a/crates/git-branch-tidy/src/scan.rs
+++ b/crates/git-branch-tidy/src/scan.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use git_tidy_core::classification;
 use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
+use git_tidy_core::output::repo_display_name;
 use git_tidy_core::types::ScanCounts;
 
 use crate::discovery;
@@ -55,10 +56,7 @@ pub fn run_scan(
         // Detect current branch
         let current = git.current_branch(repo_path).unwrap_or(None);
 
-        let repo_name = repo_path
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| repo_path.display().to_string());
+        let repo_name = repo_display_name(repo_path);
 
         let mut classified = Vec::new();
 

--- a/crates/git-branch-tidy/src/types.rs
+++ b/crates/git-branch-tidy/src/types.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use git_tidy_core::types::{Classification, ScanCounts, UnmatchedCommit};
+use git_tidy_core::types::{Classification, ScanCounts, UnmatchedCommit, extract_landed_fields};
 use serde::Serialize;
 
 /// Information about a single local branch.
@@ -72,21 +72,7 @@ pub struct JsonBranch {
 
 impl From<&BranchInfo> for JsonBranch {
     fn from(b: &BranchInfo) -> Self {
-        let (landed_ratio, landed_total, unmatched_commits) = match &b.classification {
-            Classification::Landed { matched, total } => {
-                (Some(format!("{matched}/{total}")), Some(*total), vec![])
-            }
-            Classification::LandedPartial {
-                matched,
-                total,
-                unmatched,
-            } => (
-                Some(format!("{matched}/{total}")),
-                Some(*total),
-                unmatched.clone(),
-            ),
-            _ => (None, None, vec![]),
-        };
+        let landed = extract_landed_fields(&b.classification);
 
         JsonBranch {
             repo_path: b.repo_path.clone(),
@@ -99,9 +85,9 @@ impl From<&BranchInfo> for JsonBranch {
             behind: b.behind,
             diverged: b.diverged,
             is_current: b.is_current,
-            landed_ratio,
-            landed_total,
-            unmatched_commits,
+            landed_ratio: landed.ratio,
+            landed_total: landed.total,
+            unmatched_commits: landed.unmatched,
         }
     }
 }

--- a/crates/git-remote-tidy/src/cli.rs
+++ b/crates/git-remote-tidy/src/cli.rs
@@ -64,9 +64,7 @@ pub enum Command {
 impl Cli {
     /// Resolve the target directory, defaulting to the current directory.
     pub fn target_directory(&self) -> PathBuf {
-        self.directory.clone().unwrap_or_else(|| {
-            std::env::current_dir().expect("could not determine current directory")
-        })
+        git_tidy_core::cli::resolve_directory(self.directory.clone())
     }
 }
 

--- a/crates/git-remote-tidy/src/main.rs
+++ b/crates/git-remote-tidy/src/main.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::process;
 
 use clap::Parser;
+use git_tidy_core::error;
 use git_tidy_core::git;
 
 mod clean;
@@ -43,10 +44,7 @@ fn main() {
                         process::exit(1);
                     }
                 }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(e.exit_code());
-                }
+                Err(e) => error::exit_with_error(&e),
             }
         }
         Some(cli::Command::Clean {
@@ -70,16 +68,10 @@ fn main() {
                             process::exit(1);
                         }
                     }
-                    Err(e) => {
-                        eprintln!("error: {e}");
-                        process::exit(e.exit_code());
-                    }
+                    Err(e) => error::exit_with_error(&e),
                 }
             }
-            Err(e) => {
-                eprintln!("error: {e}");
-                process::exit(e.exit_code());
-            }
+            Err(e) => error::exit_with_error(&e),
         },
     }
 }

--- a/crates/git-remote-tidy/src/output.rs
+++ b/crates/git-remote-tidy/src/output.rs
@@ -58,9 +58,7 @@ pub fn write_json(out: &mut dyn Write, result: &RemoteScanResult) -> std::io::Re
         .map(JsonRemote::from)
         .collect();
 
-    let json = serde_json::to_string_pretty(&all_remotes).map_err(std::io::Error::other)?;
-    writeln!(out, "{json}")?;
-    Ok(())
+    shared::write_json_pretty(out, &all_remotes)
 }
 
 /// Write porcelain (machine-readable, tab-delimited) scan output.

--- a/crates/git-remote-tidy/src/scan.rs
+++ b/crates/git-remote-tidy/src/scan.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
+use git_tidy_core::output::repo_display_name;
 
 use crate::types::{
     RemoteClassification, RemoteCounts, RemoteInfo, RemoteRepoGroup, RemoteScanResult,
@@ -92,10 +93,7 @@ pub fn run_scan(
             continue;
         }
 
-        let repo_name = repo_path
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| repo_path.display().to_string());
+        let repo_name = repo_display_name(repo_path);
 
         let mut classified = Vec::new();
 

--- a/crates/git-stash-tidy/src/cli.rs
+++ b/crates/git-stash-tidy/src/cli.rs
@@ -68,9 +68,7 @@ pub enum Command {
 impl Cli {
     /// Resolve the target directory, defaulting to the current directory.
     pub fn target_directory(&self) -> PathBuf {
-        self.directory.clone().unwrap_or_else(|| {
-            std::env::current_dir().expect("could not determine current directory")
-        })
+        git_tidy_core::cli::resolve_directory(self.directory.clone())
     }
 }
 

--- a/crates/git-stash-tidy/src/main.rs
+++ b/crates/git-stash-tidy/src/main.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::process;
 
 use clap::Parser;
+use git_tidy_core::error;
 use git_tidy_core::git;
 
 mod clean;
@@ -43,10 +44,7 @@ fn main() {
                         process::exit(1);
                     }
                 }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(e.exit_code());
-                }
+                Err(e) => error::exit_with_error(&e),
             }
         }
         Some(cli::Command::Clean {
@@ -72,16 +70,10 @@ fn main() {
                             process::exit(1);
                         }
                     }
-                    Err(e) => {
-                        eprintln!("error: {e}");
-                        process::exit(e.exit_code());
-                    }
+                    Err(e) => error::exit_with_error(&e),
                 }
             }
-            Err(e) => {
-                eprintln!("error: {e}");
-                process::exit(e.exit_code());
-            }
+            Err(e) => error::exit_with_error(&e),
         },
     }
 }

--- a/crates/git-stash-tidy/src/output.rs
+++ b/crates/git-stash-tidy/src/output.rs
@@ -52,9 +52,7 @@ pub fn write_json(out: &mut dyn Write, result: &StashScanResult) -> std::io::Res
         .map(JsonStash::from)
         .collect();
 
-    let json = serde_json::to_string_pretty(&all_stashes).map_err(std::io::Error::other)?;
-    writeln!(out, "{json}")?;
-    Ok(())
+    shared::write_json_pretty(out, &all_stashes)
 }
 
 /// Write porcelain (machine-readable, tab-delimited) scan output.

--- a/crates/git-stash-tidy/src/scan.rs
+++ b/crates/git-stash-tidy/src/scan.rs
@@ -5,6 +5,7 @@ use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
 use git_tidy_core::landed::diff_similarity;
+use git_tidy_core::output::repo_display_name;
 
 use crate::types::{
     StashClassification, StashCounts, StashInfo, StashRepoGroup, StashScanResult,
@@ -89,10 +90,7 @@ pub fn run_scan(
             continue;
         }
 
-        let repo_name = repo_path
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| repo_path.display().to_string());
+        let repo_name = repo_display_name(repo_path);
 
         let mut classified = Vec::new();
 

--- a/crates/git-tidy-core/Cargo.toml
+++ b/crates/git-tidy-core/Cargo.toml
@@ -9,6 +9,7 @@ testutil = ["dep:tempfile"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 strsim = "0.11"
 thiserror = "2"
 toml = "0.8"

--- a/crates/git-tidy-core/src/cli.rs
+++ b/crates/git-tidy-core/src/cli.rs
@@ -1,0 +1,27 @@
+//! Shared CLI utilities for resolving common command-line arguments.
+
+use std::path::PathBuf;
+
+/// Resolve an optional directory argument, defaulting to the current directory.
+pub fn resolve_directory(dir: Option<PathBuf>) -> PathBuf {
+    dir.unwrap_or_else(|| std::env::current_dir().expect("could not determine current directory"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_directory_with_some() {
+        let path = PathBuf::from("/tmp/test");
+        assert_eq!(resolve_directory(Some(path.clone())), path);
+    }
+
+    #[test]
+    fn resolve_directory_with_none() {
+        let result = resolve_directory(None);
+        // Should return the current directory
+        assert!(result.is_absolute());
+        assert_eq!(result, std::env::current_dir().unwrap());
+    }
+}

--- a/crates/git-tidy-core/src/error.rs
+++ b/crates/git-tidy-core/src/error.rs
@@ -56,3 +56,9 @@ impl Error {
         }
     }
 }
+
+/// Print an error message to stderr and exit with the appropriate code.
+pub fn exit_with_error(e: &Error) -> ! {
+    eprintln!("error: {e}");
+    std::process::exit(e.exit_code());
+}

--- a/crates/git-tidy-core/src/lib.rs
+++ b/crates/git-tidy-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod classification;
+pub mod cli;
 pub mod config;
 pub mod date;
 pub mod dirty;

--- a/crates/git-tidy-core/src/output.rs
+++ b/crates/git-tidy-core/src/output.rs
@@ -1,6 +1,9 @@
-//! Shared output helpers used by both git-worktree-tidy and git-branch-tidy.
+//! Shared output helpers used by all git-tidy binary crates.
 
 use std::io::Write;
+use std::path::Path;
+
+use serde::Serialize;
 
 use crate::types::{Classification, ScanCounts};
 
@@ -39,6 +42,19 @@ pub fn format_ahead_behind(ahead: usize, behind: usize) -> String {
 /// Returns empty string when the list is empty.
 pub fn format_annotations(annotations: &[&str]) -> String {
     annotations.join(", ")
+}
+
+/// Extract a display name from a repo path (last path component, or full path as fallback).
+pub fn repo_display_name(path: &Path) -> String {
+    path.file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+/// Serialize a value as pretty-printed JSON and write to output.
+pub fn write_json_pretty(out: &mut dyn Write, value: &impl Serialize) -> std::io::Result<()> {
+    let json = serde_json::to_string_pretty(value).map_err(std::io::Error::other)?;
+    writeln!(out, "{json}")
 }
 
 /// Format the landed ratio for display. Returns empty string for non-landed classifications.
@@ -149,5 +165,32 @@ mod tests {
     #[test]
     fn landed_ratio_other() {
         assert_eq!(format_landed_ratio(&Classification::Active), "");
+    }
+
+    #[test]
+    fn repo_display_name_normal() {
+        use std::path::PathBuf;
+        assert_eq!(
+            repo_display_name(&PathBuf::from("/repos/my-project")),
+            "my-project"
+        );
+    }
+
+    #[test]
+    fn write_json_pretty_basic() {
+        let data = vec!["hello", "world"];
+        let mut buf = Vec::new();
+        write_json_pretty(&mut buf, &data).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed, serde_json::json!(["hello", "world"]));
+    }
+
+    #[test]
+    fn repo_display_name_root_path() {
+        use std::path::PathBuf;
+        let path = PathBuf::from("/");
+        // Root path has no file_name, should fall back to display
+        assert_eq!(repo_display_name(&path), "/");
     }
 }

--- a/crates/git-tidy-core/src/types.rs
+++ b/crates/git-tidy-core/src/types.rs
@@ -46,6 +46,39 @@ impl Classification {
     }
 }
 
+/// Extracted landed fields for JSON serialization.
+#[derive(Debug)]
+pub struct LandedFields {
+    pub ratio: Option<String>,
+    pub total: Option<usize>,
+    pub unmatched: Vec<UnmatchedCommit>,
+}
+
+/// Extract landed ratio, total, and unmatched commits from a classification.
+pub fn extract_landed_fields(classification: &Classification) -> LandedFields {
+    match classification {
+        Classification::Landed { matched, total } => LandedFields {
+            ratio: Some(format!("{matched}/{total}")),
+            total: Some(*total),
+            unmatched: vec![],
+        },
+        Classification::LandedPartial {
+            matched,
+            total,
+            unmatched,
+        } => LandedFields {
+            ratio: Some(format!("{matched}/{total}")),
+            total: Some(*total),
+            unmatched: unmatched.clone(),
+        },
+        _ => LandedFields {
+            ratio: None,
+            total: None,
+            unmatched: vec![],
+        },
+    }
+}
+
 /// A branch commit that did not match any commit on the default branch.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct UnmatchedCommit {
@@ -170,21 +203,7 @@ pub struct JsonWorktree {
 
 impl From<&WorktreeInfo> for JsonWorktree {
     fn from(wt: &WorktreeInfo) -> Self {
-        let (landed_ratio, landed_total, unmatched_commits) = match &wt.classification {
-            Classification::Landed { matched, total } => {
-                (Some(format!("{matched}/{total}")), Some(*total), vec![])
-            }
-            Classification::LandedPartial {
-                matched,
-                total,
-                unmatched,
-            } => (
-                Some(format!("{matched}/{total}")),
-                Some(*total),
-                unmatched.clone(),
-            ),
-            _ => (None, None, vec![]),
-        };
+        let landed = extract_landed_fields(&wt.classification);
 
         JsonWorktree {
             path: wt.path.clone(),
@@ -200,9 +219,9 @@ impl From<&WorktreeInfo> for JsonWorktree {
             dirty_files: wt.dirty_files.clone(),
             meaningful_dirty_files: wt.meaningful_dirty_files.clone(),
             diverged: wt.annotations.diverged,
-            landed_ratio,
-            landed_total,
-            unmatched_commits,
+            landed_ratio: landed.ratio,
+            landed_total: landed.total,
+            unmatched_commits: landed.unmatched,
         }
     }
 }
@@ -218,4 +237,56 @@ pub struct ScanResult {
     pub counts: ScanCounts,
     /// Repos that were skipped (e.g. no default branch).
     pub warnings: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_landed_merged() {
+        let c = Classification::Merged;
+        let f = extract_landed_fields(&c);
+        assert!(f.ratio.is_none());
+        assert!(f.total.is_none());
+        assert!(f.unmatched.is_empty());
+    }
+
+    #[test]
+    fn extract_landed_landed() {
+        let c = Classification::Landed {
+            matched: 3,
+            total: 3,
+        };
+        let f = extract_landed_fields(&c);
+        assert_eq!(f.ratio.as_deref(), Some("3/3"));
+        assert_eq!(f.total, Some(3));
+        assert!(f.unmatched.is_empty());
+    }
+
+    #[test]
+    fn extract_landed_partial() {
+        let c = Classification::LandedPartial {
+            matched: 2,
+            total: 5,
+            unmatched: vec![UnmatchedCommit {
+                short_hash: "abc".to_string(),
+                subject: "test".to_string(),
+            }],
+        };
+        let f = extract_landed_fields(&c);
+        assert_eq!(f.ratio.as_deref(), Some("2/5"));
+        assert_eq!(f.total, Some(5));
+        assert_eq!(f.unmatched.len(), 1);
+        assert_eq!(f.unmatched[0].short_hash, "abc");
+    }
+
+    #[test]
+    fn extract_landed_active() {
+        let c = Classification::Active;
+        let f = extract_landed_fields(&c);
+        assert!(f.ratio.is_none());
+        assert!(f.total.is_none());
+        assert!(f.unmatched.is_empty());
+    }
 }

--- a/crates/git-worktree-tidy/src/cli.rs
+++ b/crates/git-worktree-tidy/src/cli.rs
@@ -88,9 +88,7 @@ pub enum Command {
 impl Cli {
     /// Resolve the target directory, defaulting to the current directory.
     pub fn target_directory(&self) -> PathBuf {
-        self.directory.clone().unwrap_or_else(|| {
-            std::env::current_dir().expect("could not determine current directory")
-        })
+        git_tidy_core::cli::resolve_directory(self.directory.clone())
     }
 }
 

--- a/crates/git-worktree-tidy/src/main.rs
+++ b/crates/git-worktree-tidy/src/main.rs
@@ -6,6 +6,7 @@ use git_tidy_core::classification;
 use git_tidy_core::config;
 use git_tidy_core::error;
 use git_tidy_core::git;
+use git_tidy_core::output::repo_display_name;
 use git_tidy_core::types::{RepoGroup, ScanCounts, ScanResult};
 
 mod clean;
@@ -64,10 +65,7 @@ fn main() {
                         process::exit(1);
                     }
                 }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(e.exit_code());
-                }
+                Err(e) => error::exit_with_error(&e),
             }
         }
         Some(cli::Command::Clean { .. }) => {
@@ -109,10 +107,7 @@ fn run_scan(
             }
         };
 
-        let repo_name = repo_path
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| repo_path.display().to_string());
+        let repo_name = repo_display_name(repo_path);
 
         let mut classified = Vec::new();
         for wt in worktrees {

--- a/crates/git-worktree-tidy/src/output.rs
+++ b/crates/git-worktree-tidy/src/output.rs
@@ -84,9 +84,7 @@ pub fn write_json(out: &mut dyn Write, result: &ScanResult) -> std::io::Result<(
         .map(JsonWorktree::from)
         .collect();
 
-    let json = serde_json::to_string_pretty(&all_worktrees).map_err(std::io::Error::other)?;
-    writeln!(out, "{json}")?;
-    Ok(())
+    shared::write_json_pretty(out, &all_worktrees)
 }
 
 /// Write porcelain (machine-readable, tab-delimited) scan output.


### PR DESCRIPTION
## Summary

- Extract 5 shared helpers from duplicated code across all 4 binary crates into `git-tidy-core`
- New `cli.rs` module with `resolve_directory` for optional directory arg resolution
- Add `repo_display_name`, `write_json_pretty` to `output.rs`
- Add `extract_landed_fields` + `LandedFields` to `types.rs`
- Add `exit_with_error` to `error.rs`
- Update all 4 binary crates to use the shared abstractions
- Net: +211 lines, -122 lines (89 net, but much of the addition is tests)

Closes #34

**Note**: This PR targets `main` and depends on PR #33 merging first (adds `git-remote-tidy`).

## Test plan

- [x] All existing unit tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy --workspace --all-targets -- -D clippy::all`)
- [x] Formatting clean (`cargo fmt --check --all`)
- [x] Behavior-preserving: no new integration tests needed, existing tests cover all paths