### PR TITLE
Add git-tag-tidy: scan, classify, and remove stale git tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,13 +10,14 @@ cargo test --workspace -- --test-threads=1  # if tests interfere with each other
 
 ## Architecture
 
-This is a Cargo workspace with a shared core library and four binary crates.
+This is a Cargo workspace with a shared core library and five binary crates.
 
 - **`git-tidy-core`**: Shared library containing git abstraction, classification logic, output helpers, and test utilities.
 - **`git-worktree-tidy`**: Binary crate for scanning and cleaning stale git worktrees.
 - **`git-branch-tidy`**: Binary crate for scanning and cleaning stale local git branches.
 - **`git-stash-tidy`**: Binary crate for scanning and cleaning stale git stashes.
 - **`git-remote-tidy`**: Binary crate for scanning and removing stale git remotes and orphaned tracking refs.
+- **`git-tag-tidy`**: Binary crate for scanning, classifying, and removing stale git tags.
 
 ### Core patterns
 
@@ -39,7 +40,8 @@ All tools follow a similar CLI shape:
 - Worktree/branch-tidy global args: `--behind-threshold` (default 100), `--verbose` / `-v`
 - Stash-tidy global arg: `--age-threshold` (default 90) instead of `--behind-threshold`/`--verbose`
 - Remote-tidy global arg: `--offline` instead of `--behind-threshold`/`--verbose`
-- Tool-specific flags: worktree-tidy has `--delete-branches`, branch-tidy has `--include-remote`/`--force`, remote-tidy has `--force` (allow removing origin)/`--all` (include orphaned)
+- Tag-tidy global arg: `--offline` instead of `--behind-threshold`/`--verbose`
+- Tool-specific flags: worktree-tidy has `--delete-branches`, branch-tidy has `--include-remote`/`--force`, remote-tidy has `--force` (allow removing origin)/`--all` (include orphaned), tag-tidy has `--stale-only`/`--local-only`/`--include-remote`/`--force` (bypass release protection)/`--all`
 
 ## Conventions
 
@@ -122,4 +124,17 @@ crates/
       common/mod.rs                           # Re-exports from git_tidy_core::testutil
       integration_scan.rs                     # Real git repos with remote scanning
       integration_clean.rs                    # Real git repos with remote cleanup
+  git-tag-tidy/                              # Tag scanner/cleaner binary
+    src/
+      main.rs                                 # CLI dispatch
+      lib.rs                                  # Public module exports for integration tests
+      cli.rs                                  # clap derive definitions
+      scan.rs                                 # Tag classification and scanning
+      output.rs                               # Human-readable, JSON, porcelain formatters
+      clean.rs                                # Tag deletion with safety guards
+      types.rs                                # TagInfo, TagRepoGroup, TagScanResult
+    tests/
+      common/mod.rs                           # Re-exports from git_tidy_core::testutil
+      integration_scan.rs                     # Real git repos with tag scanning
+      integration_clean.rs                    # Real git repos with tag cleanup
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-tag-tidy"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "console",
+ "dialoguer",
+ "git-tidy-core",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "git-tidy-core"
 version = "0.1.0"
 dependencies = [

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Scans a directory of Git repos, classifies stash entries by staleness (committed
 
 Scans a directory of Git repos, classifies remotes by reachability (unreachable, orphaned, active), and interactively removes stale remotes and orphaned tracking refs.
 
+### git-tag-tidy
+
+Scans a directory of Git repos, classifies tags by staleness and sync status (stale, local_only, remote_only, synced), and interactively removes stale or local-only tags.
+
 ## Installation
 
 Requires Rust 1.93.0 or later (edition 2024).
@@ -29,6 +33,7 @@ cargo install --path crates/git-worktree-tidy
 cargo install --path crates/git-branch-tidy
 cargo install --path crates/git-stash-tidy
 cargo install --path crates/git-remote-tidy
+cargo install --path crates/git-tag-tidy
 ```
 
 ## Usage
@@ -102,6 +107,27 @@ git-remote-tidy clean ~/Developer --force            # allow removing origin
 git-remote-tidy clean ~/Developer --dry-run          # preview removals
 ```
 
+### git-tag-tidy
+
+```bash
+# Scan tags (default command)
+git-tag-tidy scan ~/Developer
+git-tag-tidy ~/Developer                # scan is the default
+git-tag-tidy scan ~/Developer --json     # JSON output
+git-tag-tidy scan ~/Developer --porcelain  # machine-readable
+
+# Offline mode (skip remote tag queries)
+git-tag-tidy --offline scan ~/Developer
+
+# Clean stale tags
+git-tag-tidy clean ~/Developer                    # remove stale + local-only
+git-tag-tidy clean ~/Developer --stale-only        # only stale tags
+git-tag-tidy clean ~/Developer --local-only        # only local-only tags
+git-tag-tidy clean ~/Developer --all               # stale + local-only + remote-only
+git-tag-tidy clean ~/Developer --include-remote    # also delete from remote
+git-tag-tidy clean ~/Developer --dry-run           # preview removals
+```
+
 ## Classifications
 
 ### Worktree and branch classifications
@@ -122,6 +148,15 @@ git-remote-tidy clean ~/Developer --dry-run          # preview removals
 | **orphaned** | Branch from stash message no longer exists locally | Safe |
 | **aged** | Older than `--age-threshold` days (default 90) | Review recommended |
 | **active** | None of the above; still relevant | Keep |
+
+### Tag classifications
+
+| Classification | Meaning | Removal safety |
+|----------------|---------|----------------|
+| **stale** | Tag points at a commit not reachable from any branch | Safe |
+| **local_only** | Tag exists locally but not on any configured remote | Safe |
+| **remote_only** | Tag exists on remote but not locally | Info only |
+| **synced** | Tag exists both locally and on remote, commit is reachable | Keep |
 
 ### Remote classifications
 
@@ -187,4 +222,5 @@ crates/
   git-branch-tidy/        Branch scanner/cleaner binary
   git-stash-tidy/         Stash scanner/cleaner binary
   git-remote-tidy/        Remote scanner/cleaner binary
+  git-tag-tidy/           Tag scanner/cleaner binary
 ```

--- a/crates/git-tag-tidy/Cargo.toml
+++ b/crates/git-tag-tidy/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "git-tag-tidy"
+version = "0.1.0"
+edition = "2024"
+description = "Scan, classify, and remove stale Git tags"
+
+[dependencies]
+git-tidy-core = { path = "../git-tidy-core" }
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+dialoguer = "0.11"
+console = "0.15"
+
+[dev-dependencies]
+git-tidy-core = { path = "../git-tidy-core", features = ["testutil"] }
+tempfile = "3"

--- a/crates/git-tag-tidy/README.md
+++ b/crates/git-tag-tidy/README.md
@@ -1,0 +1,74 @@
+# git-tag-tidy
+
+Scan, classify, and remove stale Git tags across multiple repositories.
+
+## Installation
+
+```bash
+cargo install --path .
+```
+
+## Usage
+
+```bash
+# Scan tags (default command)
+git-tag-tidy scan ~/Developer
+git-tag-tidy ~/Developer                # scan is the default
+git-tag-tidy scan ~/Developer --json     # JSON output
+git-tag-tidy scan ~/Developer --porcelain  # machine-readable
+
+# Offline mode (skip remote tag queries)
+git-tag-tidy --offline scan ~/Developer
+
+# Clean stale tags
+git-tag-tidy clean ~/Developer                    # remove stale + local-only
+git-tag-tidy clean ~/Developer --stale-only        # only stale tags
+git-tag-tidy clean ~/Developer --local-only        # only local-only tags
+git-tag-tidy clean ~/Developer --all               # stale + local-only + remote-only
+git-tag-tidy clean ~/Developer --force             # allow synced tags, bypass release protection
+git-tag-tidy clean ~/Developer --include-remote    # also delete from remote
+git-tag-tidy clean ~/Developer --dry-run           # preview removals
+```
+
+## Classifications
+
+| Classification | Priority | Trigger | Clean default |
+|----------------|----------|---------|---------------|
+| **stale** | 0 | Tag points at a commit not reachable from any branch | Yes |
+| **local_only** | 1 | Tag exists locally but not on any configured remote | Yes |
+| **remote_only** | 2 | Tag exists on remote but not locally | No (info only) |
+| **synced** | 3 | Tag exists both locally and on remote, commit is reachable | No |
+
+## Clean defaults
+
+- **Default**: removes stale + local_only tags
+- `--stale-only`: only stale
+- `--local-only`: only local_only
+- `--all`: stale + local_only + remote_only (not synced)
+- `--force`: allow synced tags and bypass release tag warnings
+- `--include-remote`: also delete remote copies when cleaning
+- `--dry-run`: preview without removing
+
+## Release tag protection
+
+Tags matching release version patterns (e.g., `v1.0.0`, `1.2.3`, `v1.0.0-rc1`) are skipped during cleanup with a warning. Use `--force` to override.
+
+## Offline mode
+
+With `--offline`, remote tag queries via `git ls-remote` are skipped. Local tags that are reachable default to Synced since local-only cannot be distinguished from synced without remote data.
+
+## Human output example
+
+```
+my-repo (4 tags)
+  stale         old-experiment       abc1234   lightweight
+  local_only    feature-v2-wip       def5678   lightweight
+  synced        v1.0.0               789abcd   annotated    2024-06-15T10:00:00+00:00
+  synced        v2.0.0               bcd1234   annotated    2024-12-01T10:00:00+00:00
+
+4 tags scanned: 1 stale, 1 local_only, 0 remote_only, 2 synced
+```
+
+## Porcelain output
+
+Tab-delimited columns: `repo_path`, `name`, `classification`, `commit`, `is_annotated`, `tagger_date`, `is_release_tag`, `remote_names`

--- a/crates/git-tag-tidy/src/clean.rs
+++ b/crates/git-tag-tidy/src/clean.rs
@@ -1,0 +1,499 @@
+use std::io::Write;
+use std::path::PathBuf;
+
+use git_tidy_core::error::Error;
+use git_tidy_core::git::GitOps;
+
+use crate::types::{TagClassification, TagScanResult};
+
+/// Options controlling tag cleanup behavior.
+pub struct CleanOptions {
+    /// Preview only: print what would be removed.
+    pub dry_run: bool,
+    /// Skip confirmation prompts.
+    pub yes: bool,
+    /// Allow deleting synced tags and bypass release tag warnings.
+    pub force: bool,
+    /// Only delete stale tags.
+    pub stale_only: bool,
+    /// Only delete local-only tags.
+    pub local_only: bool,
+    /// Also delete remote copies when cleaning stale tags.
+    pub include_remote: bool,
+    /// Delete stale + local_only + remote_only (not synced).
+    pub all: bool,
+}
+
+/// Result of a clean operation.
+#[derive(Debug)]
+pub struct CleanResult {
+    /// Tags that were removed (or would be in dry-run).
+    pub removed: Vec<RemovedTag>,
+    /// Tags that failed to remove.
+    pub failed: Vec<FailedTag>,
+    /// Tags that were skipped (filtered out or protected).
+    pub skipped: usize,
+}
+
+/// A tag that was successfully removed.
+#[derive(Debug)]
+pub struct RemovedTag {
+    pub repo: PathBuf,
+    pub name: String,
+    /// Whether remote copies were also deleted.
+    pub remote_deleted: bool,
+}
+
+/// A tag that failed to be removed.
+#[derive(Debug)]
+pub struct FailedTag {
+    pub repo: PathBuf,
+    pub name: String,
+    pub reason: String,
+}
+
+/// Run the clean operation on a scan result.
+pub fn run_clean(
+    git: &dyn GitOps,
+    scan_result: &TagScanResult,
+    options: &CleanOptions,
+    out: &mut dyn Write,
+) -> Result<CleanResult, Error> {
+    let mut removed = Vec::new();
+    let mut failed = Vec::new();
+    let mut skipped = 0;
+
+    for group in &scan_result.repos {
+        for tag in &group.tags {
+            if !should_clean(&tag.classification, options) {
+                skipped += 1;
+                continue;
+            }
+
+            // Release tag protection
+            if tag.is_release_tag && !options.force {
+                writeln!(
+                    out,
+                    "warning: skipping release tag {} in {} (use --force to remove)",
+                    tag.name, group.name,
+                )?;
+                skipped += 1;
+                continue;
+            }
+
+            if options.dry_run {
+                let mut action = format!("would delete tag {} in {}", tag.name, group.name);
+                if options.include_remote && !tag.remote_names.is_empty() {
+                    action.push_str(&format!(
+                        " (and from remotes: {})",
+                        tag.remote_names.join(", ")
+                    ));
+                }
+                writeln!(out, "{action}")?;
+                removed.push(RemovedTag {
+                    repo: group.repo_path.clone(),
+                    name: tag.name.clone(),
+                    remote_deleted: false,
+                });
+                continue;
+            }
+
+            // Delete local tag (for local and synced tags)
+            if tag.classification != TagClassification::RemoteOnly {
+                match git.tag_delete(&group.repo_path, &tag.name) {
+                    Ok(()) => {
+                        writeln!(out, "deleted tag {} in {}", tag.name, group.name)?;
+                    }
+                    Err(e) => {
+                        writeln!(out, "error: could not delete tag {}: {e}", tag.name,)?;
+                        failed.push(FailedTag {
+                            repo: group.repo_path.clone(),
+                            name: tag.name.clone(),
+                            reason: e.to_string(),
+                        });
+                        continue;
+                    }
+                }
+            }
+
+            // Delete remote copies if --include-remote
+            let mut remote_deleted = false;
+            if options.include_remote && !tag.remote_names.is_empty() {
+                for remote_name in &tag.remote_names {
+                    match git.tag_delete_remote(&group.repo_path, remote_name, &tag.name) {
+                        Ok(()) => {
+                            writeln!(
+                                out,
+                                "deleted tag {} from remote {remote_name} in {}",
+                                tag.name, group.name,
+                            )?;
+                            remote_deleted = true;
+                        }
+                        Err(e) => {
+                            writeln!(
+                                out,
+                                "warning: could not delete tag {} from remote {remote_name}: {e}",
+                                tag.name,
+                            )?;
+                        }
+                    }
+                }
+            }
+
+            // For remote-only tags with --all, delete from remotes
+            if tag.classification == TagClassification::RemoteOnly {
+                for remote_name in &tag.remote_names {
+                    match git.tag_delete_remote(&group.repo_path, remote_name, &tag.name) {
+                        Ok(()) => {
+                            writeln!(
+                                out,
+                                "deleted tag {} from remote {remote_name} in {}",
+                                tag.name, group.name,
+                            )?;
+                            remote_deleted = true;
+                        }
+                        Err(e) => {
+                            writeln!(
+                                out,
+                                "error: could not delete tag {} from remote {remote_name}: {e}",
+                                tag.name,
+                            )?;
+                            failed.push(FailedTag {
+                                repo: group.repo_path.clone(),
+                                name: tag.name.clone(),
+                                reason: e.to_string(),
+                            });
+                        }
+                    }
+                }
+            }
+
+            removed.push(RemovedTag {
+                repo: group.repo_path.clone(),
+                name: tag.name.clone(),
+                remote_deleted,
+            });
+        }
+    }
+
+    Ok(CleanResult {
+        removed,
+        failed,
+        skipped,
+    })
+}
+
+/// Determine if a tag should be cleaned based on its classification and options.
+fn should_clean(classification: &TagClassification, options: &CleanOptions) -> bool {
+    if options.stale_only {
+        return *classification == TagClassification::Stale;
+    }
+
+    if options.local_only {
+        return *classification == TagClassification::LocalOnly;
+    }
+
+    if options.all {
+        // Stale + LocalOnly + RemoteOnly (not Synced, unless --force)
+        return if options.force {
+            true
+        } else {
+            *classification != TagClassification::Synced
+        };
+    }
+
+    // Default: Stale + LocalOnly
+    matches!(
+        classification,
+        TagClassification::Stale | TagClassification::LocalOnly
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use git_tidy_core::testutil::MockGitBuilder;
+
+    use super::*;
+    use crate::types::*;
+
+    fn repo() -> PathBuf {
+        PathBuf::from("/repo")
+    }
+
+    fn make_scan_result(tags: Vec<TagInfo>) -> TagScanResult {
+        let mut counts = TagCounts::default();
+        for t in &tags {
+            counts.increment(t.classification);
+        }
+        TagScanResult {
+            repos: vec![TagRepoGroup {
+                repo_path: repo(),
+                name: "my-repo".to_string(),
+                tags,
+            }],
+            total_scanned: 0,
+            counts,
+            warnings: vec![],
+        }
+    }
+
+    fn tag(name: &str, classification: TagClassification) -> TagInfo {
+        TagInfo {
+            repo_path: repo(),
+            name: name.to_string(),
+            classification,
+            commit: "abc1234".to_string(),
+            is_annotated: false,
+            tagger_date: None,
+            is_release_tag: false,
+            remote_names: vec![],
+        }
+    }
+
+    fn default_options() -> CleanOptions {
+        CleanOptions {
+            dry_run: false,
+            yes: false,
+            force: false,
+            stale_only: false,
+            local_only: false,
+            include_remote: false,
+            all: false,
+        }
+    }
+
+    #[test]
+    fn clean_deletes_stale() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![tag("old-tag", TagClassification::Stale)]);
+        let mut buf = Vec::new();
+
+        let result = run_clean(&git, &scan, &default_options(), &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].name, "old-tag");
+        assert_eq!(git.tag_delete_calls().len(), 1);
+    }
+
+    #[test]
+    fn clean_deletes_local_only() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![tag("local-tag", TagClassification::LocalOnly)]);
+        let mut buf = Vec::new();
+
+        let result = run_clean(&git, &scan, &default_options(), &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].name, "local-tag");
+    }
+
+    #[test]
+    fn clean_skips_synced_by_default() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![tag("v1.0", TagClassification::Synced)]);
+        let mut buf = Vec::new();
+
+        let result = run_clean(&git, &scan, &default_options(), &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 0);
+        assert_eq!(result.skipped, 1);
+        assert_eq!(git.tag_delete_calls().len(), 0);
+    }
+
+    #[test]
+    fn clean_skips_remote_only_by_default() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![tag("remote-tag", TagClassification::RemoteOnly)]);
+        let mut buf = Vec::new();
+
+        let result = run_clean(&git, &scan, &default_options(), &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 0);
+        assert_eq!(result.skipped, 1);
+    }
+
+    #[test]
+    fn clean_stale_only_flag() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![
+            tag("stale-tag", TagClassification::Stale),
+            tag("local-tag", TagClassification::LocalOnly),
+        ]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            stale_only: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].name, "stale-tag");
+        assert_eq!(result.skipped, 1);
+    }
+
+    #[test]
+    fn clean_local_only_flag() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![
+            tag("stale-tag", TagClassification::Stale),
+            tag("local-tag", TagClassification::LocalOnly),
+        ]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            local_only: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].name, "local-tag");
+        assert_eq!(result.skipped, 1);
+    }
+
+    #[test]
+    fn clean_all_includes_remote_only() {
+        let git = MockGitBuilder::new().build();
+        let mut remote_tag = tag("remote-tag", TagClassification::RemoteOnly);
+        remote_tag.remote_names = vec!["origin".to_string()];
+
+        let scan = make_scan_result(vec![
+            tag("stale-tag", TagClassification::Stale),
+            tag("local-tag", TagClassification::LocalOnly),
+            remote_tag,
+            tag("synced-tag", TagClassification::Synced),
+        ]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            all: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+
+        // Stale + local_only + remote_only removed, synced skipped
+        assert_eq!(result.removed.len(), 3);
+        assert_eq!(result.skipped, 1);
+    }
+
+    #[test]
+    fn clean_force_deletes_synced() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![tag("v1.0", TagClassification::Synced)]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            all: true,
+            force: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(git.tag_delete_calls().len(), 1);
+    }
+
+    #[test]
+    fn clean_include_remote() {
+        let git = MockGitBuilder::new().build();
+        let mut stale = tag("old-tag", TagClassification::Stale);
+        stale.remote_names = vec!["origin".to_string()];
+
+        let scan = make_scan_result(vec![stale]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            include_remote: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 1);
+        assert!(result.removed[0].remote_deleted);
+        assert_eq!(git.tag_delete_calls().len(), 1);
+        assert_eq!(git.tag_delete_remote_calls().len(), 1);
+    }
+
+    #[test]
+    fn clean_release_tag_protection() {
+        let git = MockGitBuilder::new().build();
+        let mut release = tag("v1.0.0", TagClassification::Stale);
+        release.is_release_tag = true;
+
+        let scan = make_scan_result(vec![release]);
+        let mut buf = Vec::new();
+
+        let result = run_clean(&git, &scan, &default_options(), &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 0);
+        assert_eq!(result.skipped, 1);
+        assert_eq!(git.tag_delete_calls().len(), 0);
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("skipping release tag"));
+        assert!(output.contains("--force"));
+    }
+
+    #[test]
+    fn clean_release_tag_with_force() {
+        let git = MockGitBuilder::new().build();
+        let mut release = tag("v1.0.0", TagClassification::Stale);
+        release.is_release_tag = true;
+
+        let scan = make_scan_result(vec![release]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            force: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(git.tag_delete_calls().len(), 1);
+    }
+
+    #[test]
+    fn clean_dry_run_makes_zero_calls() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![
+            tag("stale-tag", TagClassification::Stale),
+            tag("local-tag", TagClassification::LocalOnly),
+        ]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            dry_run: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 2);
+        assert_eq!(git.tag_delete_calls().len(), 0);
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("would delete tag stale-tag"));
+        assert!(output.contains("would delete tag local-tag"));
+    }
+
+    #[test]
+    fn clean_handles_deletion_failure() {
+        let git = MockGitBuilder::new()
+            .with_tag_delete_error(&repo(), "bad-tag", "permission denied")
+            .build();
+        let scan = make_scan_result(vec![tag("bad-tag", TagClassification::Stale)]);
+        let mut buf = Vec::new();
+
+        let result = run_clean(&git, &scan, &default_options(), &mut buf).unwrap();
+
+        assert_eq!(result.removed.len(), 0);
+        assert_eq!(result.failed.len(), 1);
+        assert_eq!(result.failed[0].name, "bad-tag");
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("error: could not delete tag bad-tag"));
+    }
+}

--- a/crates/git-tag-tidy/src/cli.rs
+++ b/crates/git-tag-tidy/src/cli.rs
@@ -1,0 +1,192 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "git-tag-tidy",
+    about = "Scan, classify, and remove stale Git tags"
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Command>,
+
+    /// Directory to scan (default: current directory)
+    #[arg(global = true)]
+    pub directory: Option<PathBuf>,
+
+    /// Skip remote tag queries (no network access)
+    #[arg(long, global = true)]
+    pub offline: bool,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Read-only analysis of local and remote tags
+    Scan {
+        /// Output results as JSON
+        #[arg(long)]
+        json: bool,
+
+        /// Machine-readable tab-delimited output
+        #[arg(long)]
+        porcelain: bool,
+    },
+
+    /// Scan and interactively remove stale tags
+    Clean {
+        /// Show what would be removed without removing
+        #[arg(short = 'n', long)]
+        dry_run: bool,
+
+        /// Skip confirmation prompts
+        #[arg(short = 'y', long)]
+        yes: bool,
+
+        /// Allow deleting synced tags and bypass release tag warnings
+        #[arg(short = 'f', long)]
+        force: bool,
+
+        /// Only delete stale tags
+        #[arg(long)]
+        stale_only: bool,
+
+        /// Only delete local-only tags
+        #[arg(long)]
+        local_only: bool,
+
+        /// Also delete remote copies when cleaning
+        #[arg(long)]
+        include_remote: bool,
+
+        /// Delete stale + local_only + remote_only (not synced)
+        #[arg(long)]
+        all: bool,
+
+        /// Output results as JSON
+        #[arg(long)]
+        json: bool,
+
+        /// Machine-readable tab-delimited output
+        #[arg(long)]
+        porcelain: bool,
+    },
+}
+
+impl Cli {
+    /// Resolve the target directory, defaulting to the current directory.
+    pub fn target_directory(&self) -> PathBuf {
+        git_tidy_core::cli::resolve_directory(self.directory.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[test]
+    fn default_command_is_scan() {
+        let cli = Cli::parse_from(["git-tag-tidy"]);
+        assert!(cli.command.is_none());
+        assert!(!cli.offline);
+    }
+
+    #[test]
+    fn scan_with_directory() {
+        let cli = Cli::parse_from(["git-tag-tidy", "scan", "/tmp/dev"]);
+        assert!(matches!(cli.command, Some(Command::Scan { .. })));
+        assert_eq!(cli.directory, Some(PathBuf::from("/tmp/dev")));
+    }
+
+    #[test]
+    fn scan_json_flag() {
+        let cli = Cli::parse_from(["git-tag-tidy", "scan", "--json"]);
+        match cli.command {
+            Some(Command::Scan { json, porcelain }) => {
+                assert!(json);
+                assert!(!porcelain);
+            }
+            _ => panic!("expected Scan command"),
+        }
+    }
+
+    #[test]
+    fn clean_with_flags() {
+        let cli = Cli::parse_from(["git-tag-tidy", "clean", "--dry-run", "--yes", "--force"]);
+        match cli.command {
+            Some(Command::Clean {
+                dry_run,
+                yes,
+                force,
+                ..
+            }) => {
+                assert!(dry_run);
+                assert!(yes);
+                assert!(force);
+            }
+            _ => panic!("expected Clean command"),
+        }
+    }
+
+    #[test]
+    fn clean_stale_only_flag() {
+        let cli = Cli::parse_from(["git-tag-tidy", "clean", "--stale-only"]);
+        match cli.command {
+            Some(Command::Clean { stale_only, .. }) => {
+                assert!(stale_only);
+            }
+            _ => panic!("expected Clean command"),
+        }
+    }
+
+    #[test]
+    fn clean_local_only_flag() {
+        let cli = Cli::parse_from(["git-tag-tidy", "clean", "--local-only"]);
+        match cli.command {
+            Some(Command::Clean { local_only, .. }) => {
+                assert!(local_only);
+            }
+            _ => panic!("expected Clean command"),
+        }
+    }
+
+    #[test]
+    fn clean_include_remote_flag() {
+        let cli = Cli::parse_from(["git-tag-tidy", "clean", "--include-remote"]);
+        match cli.command {
+            Some(Command::Clean { include_remote, .. }) => {
+                assert!(include_remote);
+            }
+            _ => panic!("expected Clean command"),
+        }
+    }
+
+    #[test]
+    fn clean_all_flag() {
+        let cli = Cli::parse_from(["git-tag-tidy", "clean", "--all"]);
+        match cli.command {
+            Some(Command::Clean { all, .. }) => {
+                assert!(all);
+            }
+            _ => panic!("expected Clean command"),
+        }
+    }
+
+    #[test]
+    fn offline_flag() {
+        let cli = Cli::parse_from(["git-tag-tidy", "--offline", "scan"]);
+        assert!(cli.offline);
+    }
+
+    #[test]
+    fn offline_flag_with_clean() {
+        let cli = Cli::parse_from(["git-tag-tidy", "--offline", "clean", "--dry-run"]);
+        assert!(cli.offline);
+        match cli.command {
+            Some(Command::Clean { dry_run, .. }) => assert!(dry_run),
+            _ => panic!("expected Clean command"),
+        }
+    }
+}

--- a/crates/git-tag-tidy/src/lib.rs
+++ b/crates/git-tag-tidy/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod clean;
+pub mod cli;
+pub mod output;
+pub mod scan;
+pub mod types;
+
+pub use git_tidy_core;

--- a/crates/git-tag-tidy/src/main.rs
+++ b/crates/git-tag-tidy/src/main.rs
@@ -1,0 +1,83 @@
+use std::io;
+use std::process;
+
+use clap::Parser;
+use git_tidy_core::error;
+use git_tidy_core::git;
+
+mod clean;
+mod cli;
+mod output;
+mod scan;
+mod types;
+
+fn main() {
+    let cli = cli::Cli::parse();
+    let directory = cli.target_directory();
+
+    if !directory.is_dir() {
+        eprintln!("error: directory not found: {}", directory.display());
+        process::exit(1);
+    }
+
+    let git = git::RealGit;
+    let mut stdout = io::stdout().lock();
+
+    match &cli.command {
+        None | Some(cli::Command::Scan { .. }) => {
+            let (json, porcelain) = match &cli.command {
+                Some(cli::Command::Scan { json, porcelain }) => (*json, *porcelain),
+                _ => (false, false),
+            };
+
+            match scan::run_scan(&git, &directory, cli.offline) {
+                Ok(result) => {
+                    let write_result = if json {
+                        output::write_json(&mut stdout, &result)
+                    } else if porcelain {
+                        output::write_porcelain(&mut stdout, &result)
+                    } else {
+                        output::write_human(&mut stdout, &result)
+                    };
+                    if let Err(e) = write_result {
+                        eprintln!("error writing output: {e}");
+                        process::exit(1);
+                    }
+                }
+                Err(e) => error::exit_with_error(&e),
+            }
+        }
+        Some(cli::Command::Clean {
+            dry_run,
+            yes,
+            force,
+            stale_only,
+            local_only,
+            include_remote,
+            all,
+            ..
+        }) => match scan::run_scan(&git, &directory, cli.offline) {
+            Ok(scan_result) => {
+                let options = clean::CleanOptions {
+                    dry_run: *dry_run,
+                    yes: *yes,
+                    force: *force,
+                    stale_only: *stale_only,
+                    local_only: *local_only,
+                    include_remote: *include_remote,
+                    all: *all,
+                };
+
+                match clean::run_clean(&git, &scan_result, &options, &mut stdout) {
+                    Ok(result) => {
+                        if !result.failed.is_empty() {
+                            process::exit(1);
+                        }
+                    }
+                    Err(e) => error::exit_with_error(&e),
+                }
+            }
+            Err(e) => error::exit_with_error(&e),
+        },
+    }
+}

--- a/crates/git-tag-tidy/src/output.rs
+++ b/crates/git-tag-tidy/src/output.rs
@@ -1,0 +1,247 @@
+use std::io::Write;
+
+use git_tidy_core::output as shared;
+
+use crate::types::{JsonTag, TagScanResult};
+
+/// Write human-readable scan output.
+pub fn write_human(out: &mut dyn Write, result: &TagScanResult) -> std::io::Result<()> {
+    shared::write_warnings(out, &result.warnings)?;
+
+    for group in &result.repos {
+        let noun = if group.tags.len() == 1 { "tag" } else { "tags" };
+        writeln!(out, "\n{} ({} {noun})", group.name, group.tags.len())?;
+
+        for tag in &group.tags {
+            let label = format!("{:<13}", tag.classification.label());
+            let commit_short = if tag.commit.len() >= 7 {
+                &tag.commit[..7]
+            } else {
+                &tag.commit
+            };
+            let kind = if tag.is_annotated {
+                "annotated"
+            } else {
+                "lightweight"
+            };
+            let date = tag.tagger_date.as_deref().unwrap_or("");
+
+            writeln!(
+                out,
+                "  {label} {:<20} {:<9} {:<12} {date}",
+                tag.name, commit_short, kind,
+            )?;
+        }
+    }
+
+    write_tag_summary(out, result)?;
+
+    Ok(())
+}
+
+/// Write the tag-specific summary line.
+fn write_tag_summary(out: &mut dyn Write, result: &TagScanResult) -> std::io::Result<()> {
+    let c = &result.counts;
+    writeln!(
+        out,
+        "\n{} tags scanned: {} stale, {} local_only, {} remote_only, {} synced",
+        result.total_scanned, c.stale, c.local_only, c.remote_only, c.synced,
+    )
+}
+
+/// Write JSON scan output using the flat spec format.
+pub fn write_json(out: &mut dyn Write, result: &TagScanResult) -> std::io::Result<()> {
+    let all_tags: Vec<JsonTag> = result
+        .repos
+        .iter()
+        .flat_map(|g| g.tags.iter())
+        .map(JsonTag::from)
+        .collect();
+
+    shared::write_json_pretty(out, &all_tags)
+}
+
+/// Write porcelain (machine-readable, tab-delimited) scan output.
+pub fn write_porcelain(out: &mut dyn Write, result: &TagScanResult) -> std::io::Result<()> {
+    for group in &result.repos {
+        for tag in &group.tags {
+            let repo = tag.repo_path.display();
+            let remotes = tag.remote_names.join(",");
+
+            writeln!(
+                out,
+                "{repo}\t{}\t{}\t{}\t{}\t{}\t{}\t{remotes}",
+                tag.name,
+                tag.classification.label(),
+                tag.commit,
+                tag.is_annotated,
+                tag.tagger_date.as_deref().unwrap_or(""),
+                tag.is_release_tag,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::types::*;
+
+    fn make_scan_result() -> TagScanResult {
+        TagScanResult {
+            repos: vec![TagRepoGroup {
+                repo_path: PathBuf::from("/repos/backend"),
+                name: "backend".to_string(),
+                tags: vec![
+                    TagInfo {
+                        repo_path: PathBuf::from("/repos/backend"),
+                        name: "old-experiment".to_string(),
+                        classification: TagClassification::Stale,
+                        commit: "abc1234def5678".to_string(),
+                        is_annotated: false,
+                        tagger_date: None,
+                        is_release_tag: false,
+                        remote_names: vec![],
+                    },
+                    TagInfo {
+                        repo_path: PathBuf::from("/repos/backend"),
+                        name: "feature-v2-wip".to_string(),
+                        classification: TagClassification::LocalOnly,
+                        commit: "def5678abc1234".to_string(),
+                        is_annotated: false,
+                        tagger_date: None,
+                        is_release_tag: false,
+                        remote_names: vec![],
+                    },
+                    TagInfo {
+                        repo_path: PathBuf::from("/repos/backend"),
+                        name: "v1.0.0".to_string(),
+                        classification: TagClassification::Synced,
+                        commit: "789abcdef1234".to_string(),
+                        is_annotated: true,
+                        tagger_date: Some("2024-06-15T10:00:00+00:00".to_string()),
+                        is_release_tag: true,
+                        remote_names: vec!["origin".to_string()],
+                    },
+                ],
+            }],
+            total_scanned: 3,
+            counts: TagCounts {
+                stale: 1,
+                local_only: 1,
+                remote_only: 0,
+                synced: 1,
+            },
+            warnings: vec![],
+        }
+    }
+
+    #[test]
+    fn human_output_basic() {
+        let result = make_scan_result();
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("backend (3 tags)"));
+        assert!(output.contains("stale"));
+        assert!(output.contains("local_only"));
+        assert!(output.contains("synced"));
+        assert!(output.contains("old-experiment"));
+        assert!(output.contains("v1.0.0"));
+        assert!(output.contains("annotated"));
+        assert!(output.contains("lightweight"));
+        assert!(output.contains("3 tags scanned: 1 stale, 1 local_only, 0 remote_only, 1 synced"));
+    }
+
+    #[test]
+    fn human_output_with_warnings() {
+        let result = TagScanResult {
+            repos: vec![],
+            total_scanned: 0,
+            counts: TagCounts::default(),
+            warnings: vec!["could not list tags for /repo/Foo".to_string()],
+        };
+
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("warning: could not list tags for /repo/Foo"));
+    }
+
+    #[test]
+    fn json_output_valid() {
+        let result = make_scan_result();
+        let mut buf = Vec::new();
+        write_json(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0]["classification"], "stale");
+        assert_eq!(arr[0]["name"], "old-experiment");
+        assert!(!arr[0]["is_annotated"].as_bool().unwrap());
+        assert_eq!(arr[2]["classification"], "synced");
+        assert_eq!(arr[2]["name"], "v1.0.0");
+        assert!(arr[2]["is_annotated"].as_bool().unwrap());
+        assert!(arr[2]["is_release_tag"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn porcelain_output_tab_delimited() {
+        let result = make_scan_result();
+        let mut buf = Vec::new();
+        write_porcelain(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines.len(), 3);
+
+        let fields: Vec<&str> = lines[0].split('\t').collect();
+        assert_eq!(fields.len(), 8);
+        assert_eq!(fields[0], "/repos/backend");
+        assert_eq!(fields[1], "old-experiment");
+        assert_eq!(fields[2], "stale");
+        assert_eq!(fields[3], "abc1234def5678");
+        assert_eq!(fields[4], "false");
+        assert_eq!(fields[5], ""); // no date
+        assert_eq!(fields[6], "false");
+        assert_eq!(fields[7], ""); // no remotes
+    }
+
+    #[test]
+    fn human_output_single_tag_noun() {
+        let result = TagScanResult {
+            repos: vec![TagRepoGroup {
+                repo_path: PathBuf::from("/repos/test"),
+                name: "test".to_string(),
+                tags: vec![TagInfo {
+                    repo_path: PathBuf::from("/repos/test"),
+                    name: "v1.0".to_string(),
+                    classification: TagClassification::Synced,
+                    commit: "abc1234".to_string(),
+                    is_annotated: false,
+                    tagger_date: None,
+                    is_release_tag: true,
+                    remote_names: vec![],
+                }],
+            }],
+            total_scanned: 1,
+            counts: TagCounts {
+                synced: 1,
+                ..Default::default()
+            },
+            warnings: vec![],
+        };
+
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("test (1 tag)"));
+    }
+}

--- a/crates/git-tag-tidy/src/scan.rs
+++ b/crates/git-tag-tidy/src/scan.rs
@@ -1,0 +1,311 @@
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use git_tidy_core::discovery::discover_repos;
+use git_tidy_core::error::Error;
+use git_tidy_core::git::GitOps;
+use git_tidy_core::output::repo_display_name;
+
+use crate::types::{
+    TagClassification, TagCounts, TagInfo, TagRepoGroup, TagScanResult, is_release_tag_name,
+};
+
+/// Classify a single tag.
+///
+/// - If `local_commit` is `Some`, the tag exists locally.
+/// - If `remote_commit` is `Some`, the tag exists on at least one remote.
+/// - `is_reachable` indicates whether the tag's commit is reachable from any branch.
+/// - `offline` indicates whether we skipped remote queries.
+pub fn classify_tag(
+    local_commit: Option<&str>,
+    remote_commit: Option<&str>,
+    is_reachable: bool,
+    offline: bool,
+) -> TagClassification {
+    match (local_commit, remote_commit) {
+        (Some(_), _) if !is_reachable => TagClassification::Stale,
+        (Some(_), Some(_)) => TagClassification::Synced,
+        (Some(_), None) if offline => TagClassification::Synced,
+        (Some(_), None) => TagClassification::LocalOnly,
+        (None, Some(_)) => TagClassification::RemoteOnly,
+        (None, None) => TagClassification::Stale, // shouldn't happen in practice
+    }
+}
+
+/// Scan all repos in `directory` for tags.
+pub fn run_scan(git: &dyn GitOps, directory: &Path, offline: bool) -> Result<TagScanResult, Error> {
+    let repo_paths = discover_repos(directory)?;
+
+    let mut repos = Vec::new();
+    let mut counts = TagCounts::default();
+    let mut warnings = Vec::new();
+    let mut total_scanned = 0;
+
+    for repo_path in &repo_paths {
+        // Get local tags
+        let local_tags: HashSet<String> = match git.list_local_tags(repo_path) {
+            Ok(tags) => tags.into_iter().collect(),
+            Err(e) => {
+                warnings.push(format!(
+                    "could not list tags for {}: {e}",
+                    repo_path.display()
+                ));
+                continue;
+            }
+        };
+
+        // Get remotes and remote tags
+        let remotes = git.list_remotes(repo_path).unwrap_or_default();
+        let mut remote_tag_map: HashMap<String, (String, Vec<String>)> = HashMap::new(); // tag -> (commit, [remotes])
+
+        if !offline {
+            for remote in &remotes {
+                match git.list_remote_tags(repo_path, remote) {
+                    Ok(tags) => {
+                        for (tag_name, commit) in tags {
+                            remote_tag_map
+                                .entry(tag_name)
+                                .and_modify(|(_c, names)| names.push(remote.clone()))
+                                .or_insert_with(|| (commit, vec![remote.clone()]));
+                        }
+                    }
+                    Err(e) => {
+                        warnings.push(format!(
+                            "could not list remote tags for {remote} in {}: {e}",
+                            repo_path.display()
+                        ));
+                    }
+                }
+            }
+        }
+
+        // Union all tag names
+        let mut all_tag_names: HashSet<String> = local_tags.clone();
+        for tag_name in remote_tag_map.keys() {
+            all_tag_names.insert(tag_name.clone());
+        }
+
+        if all_tag_names.is_empty() {
+            continue;
+        }
+
+        let repo_name = repo_display_name(repo_path);
+        let mut classified = Vec::new();
+
+        for tag_name in &all_tag_names {
+            let is_local = local_tags.contains(tag_name);
+            let remote_entry = remote_tag_map.get(tag_name);
+
+            let (local_commit, is_reachable, is_annotated, tagger_date) = if is_local {
+                let commit = match git.tag_commit(repo_path, tag_name) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        warnings.push(format!(
+                            "could not resolve tag {tag_name} in {}: {e}",
+                            repo_path.display()
+                        ));
+                        continue;
+                    }
+                };
+                let reachable = git.is_commit_reachable(repo_path, &commit).unwrap_or(false);
+                let annotated = git.is_tag_annotated(repo_path, tag_name).unwrap_or(false);
+                let date = git.tag_date(repo_path, tag_name).unwrap_or(None);
+                (Some(commit), reachable, annotated, date)
+            } else {
+                (None, false, false, None)
+            };
+
+            let remote_commit = remote_entry.map(|(c, _)| c.as_str());
+            let remote_names = remote_entry
+                .map(|(_, names)| names.clone())
+                .unwrap_or_default();
+
+            let classification = classify_tag(
+                local_commit.as_deref(),
+                remote_commit,
+                is_reachable,
+                offline,
+            );
+
+            let commit = local_commit.unwrap_or_else(|| remote_commit.unwrap_or("").to_string());
+
+            counts.increment(classification);
+            total_scanned += 1;
+
+            classified.push(TagInfo {
+                repo_path: repo_path.clone(),
+                name: tag_name.clone(),
+                classification,
+                commit,
+                is_annotated,
+                tagger_date,
+                is_release_tag: is_release_tag_name(tag_name),
+                remote_names,
+            });
+        }
+
+        // Sort by classification priority, then by name
+        classified.sort_by(|a, b| {
+            a.classification
+                .priority()
+                .cmp(&b.classification.priority())
+                .then_with(|| a.name.cmp(&b.name))
+        });
+
+        repos.push(TagRepoGroup {
+            repo_path: repo_path.clone(),
+            name: repo_name,
+            tags: classified,
+        });
+    }
+
+    Ok(TagScanResult {
+        repos,
+        total_scanned,
+        counts,
+        warnings,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use git_tidy_core::testutil::MockGitBuilder;
+
+    use super::*;
+
+    fn repo() -> PathBuf {
+        PathBuf::from("/repo")
+    }
+
+    #[test]
+    fn classify_stale_unreachable_commit() {
+        let result = classify_tag(Some("abc123"), Some("abc123"), false, false);
+        assert_eq!(result, TagClassification::Stale);
+    }
+
+    #[test]
+    fn classify_stale_unreachable_local_only() {
+        let result = classify_tag(Some("abc123"), None, false, false);
+        assert_eq!(result, TagClassification::Stale);
+    }
+
+    #[test]
+    fn classify_local_only() {
+        let result = classify_tag(Some("abc123"), None, true, false);
+        assert_eq!(result, TagClassification::LocalOnly);
+    }
+
+    #[test]
+    fn classify_remote_only() {
+        let result = classify_tag(None, Some("abc123"), false, false);
+        assert_eq!(result, TagClassification::RemoteOnly);
+    }
+
+    #[test]
+    fn classify_synced() {
+        let result = classify_tag(Some("abc123"), Some("abc123"), true, false);
+        assert_eq!(result, TagClassification::Synced);
+    }
+
+    #[test]
+    fn classify_offline_local_treated_as_synced() {
+        // When offline, we can't check remote, so local+reachable = synced
+        let result = classify_tag(Some("abc123"), None, true, true);
+        assert_eq!(result, TagClassification::Synced);
+    }
+
+    #[test]
+    fn classify_offline_unreachable_still_stale() {
+        let result = classify_tag(Some("abc123"), None, false, true);
+        assert_eq!(result, TagClassification::Stale);
+    }
+
+    #[test]
+    fn scan_sort_order() {
+        let mut tags = [
+            TagInfo {
+                repo_path: repo(),
+                name: "v1.0.0".to_string(),
+                classification: TagClassification::Synced,
+                commit: "aaa".to_string(),
+                is_annotated: true,
+                tagger_date: None,
+                is_release_tag: true,
+                remote_names: vec!["origin".to_string()],
+            },
+            TagInfo {
+                repo_path: repo(),
+                name: "old-experiment".to_string(),
+                classification: TagClassification::Stale,
+                commit: "bbb".to_string(),
+                is_annotated: false,
+                tagger_date: None,
+                is_release_tag: false,
+                remote_names: vec![],
+            },
+            TagInfo {
+                repo_path: repo(),
+                name: "feature-wip".to_string(),
+                classification: TagClassification::LocalOnly,
+                commit: "ccc".to_string(),
+                is_annotated: false,
+                tagger_date: None,
+                is_release_tag: false,
+                remote_names: vec![],
+            },
+        ];
+
+        tags.sort_by(|a, b| {
+            a.classification
+                .priority()
+                .cmp(&b.classification.priority())
+                .then_with(|| a.name.cmp(&b.name))
+        });
+
+        assert_eq!(tags[0].classification, TagClassification::Stale);
+        assert_eq!(tags[1].classification, TagClassification::LocalOnly);
+        assert_eq!(tags[2].classification, TagClassification::Synced);
+    }
+
+    #[test]
+    fn scan_with_mixed_tags() {
+        let git = MockGitBuilder::new()
+            .with_local_tags(&repo(), vec!["v1.0".to_string(), "stale-tag".to_string()])
+            .with_list_remotes(&repo(), vec!["origin".to_string()])
+            .with_remote_tags(
+                &repo(),
+                "origin",
+                vec![("v1.0".to_string(), "abc123".to_string())],
+            )
+            .with_tag_commit(&repo(), "v1.0", "abc123")
+            .with_tag_commit(&repo(), "stale-tag", "def456")
+            .with_is_commit_reachable(&repo(), "abc123", true)
+            .with_is_commit_reachable(&repo(), "def456", false)
+            .with_is_tag_annotated(&repo(), "v1.0", true)
+            .with_is_tag_annotated(&repo(), "stale-tag", false)
+            .with_tag_date(&repo(), "v1.0", Some("2024-06-15T10:00:00+00:00"))
+            .build();
+
+        let result = classify_tag(Some("abc123"), Some("abc123"), true, false);
+        assert_eq!(result, TagClassification::Synced);
+
+        let result2 = classify_tag(Some("def456"), None, false, false);
+        assert_eq!(result2, TagClassification::Stale);
+
+        // Also verify mock accessors work
+        assert_eq!(
+            git.list_local_tags(&repo()).unwrap(),
+            vec!["v1.0", "stale-tag"]
+        );
+    }
+
+    #[test]
+    fn scan_no_remotes_treats_reachable_as_synced() {
+        // When there are no remotes, we can't distinguish local-only from synced,
+        // so reachable local tags become synced (same as offline behavior).
+        let result = classify_tag(Some("abc123"), None, true, true);
+        assert_eq!(result, TagClassification::Synced);
+    }
+}

--- a/crates/git-tag-tidy/src/types.rs
+++ b/crates/git-tag-tidy/src/types.rs
@@ -1,0 +1,245 @@
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+/// Classification of a tag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TagClassification {
+    /// Tag points at a commit not reachable from any branch.
+    Stale,
+    /// Tag exists locally but not on any configured remote.
+    LocalOnly,
+    /// Tag exists on remote but not locally.
+    RemoteOnly,
+    /// Tag exists both locally and on remote, commit is reachable.
+    Synced,
+}
+
+impl TagClassification {
+    /// Priority for sorting (lower = more stale).
+    pub fn priority(self) -> u8 {
+        match self {
+            Self::Stale => 0,
+            Self::LocalOnly => 1,
+            Self::RemoteOnly => 2,
+            Self::Synced => 3,
+        }
+    }
+
+    /// Human-readable label.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Stale => "stale",
+            Self::LocalOnly => "local_only",
+            Self::RemoteOnly => "remote_only",
+            Self::Synced => "synced",
+        }
+    }
+}
+
+/// Information about a single tag.
+#[derive(Debug, Clone, Serialize)]
+pub struct TagInfo {
+    /// Path to the repo containing this tag.
+    pub repo_path: PathBuf,
+    /// Tag name.
+    pub name: String,
+    /// Classification of this tag.
+    pub classification: TagClassification,
+    /// Commit SHA the tag points at (empty for remote-only if unknown).
+    pub commit: String,
+    /// Whether this is an annotated tag.
+    pub is_annotated: bool,
+    /// ISO 8601 tagger/creator date, if available.
+    pub tagger_date: Option<String>,
+    /// Whether this tag matches a release version pattern (e.g., v1.0.0).
+    pub is_release_tag: bool,
+    /// Remotes that have this tag.
+    pub remote_names: Vec<String>,
+}
+
+/// A group of tags in the same repo.
+#[derive(Debug, Clone, Serialize)]
+pub struct TagRepoGroup {
+    /// Path to the repo.
+    pub repo_path: PathBuf,
+    /// Display name (directory basename).
+    pub name: String,
+    /// Tags belonging to this repo, sorted by classification priority.
+    pub tags: Vec<TagInfo>,
+}
+
+/// Summary counts for a tag scan.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct TagCounts {
+    pub stale: usize,
+    pub local_only: usize,
+    pub remote_only: usize,
+    pub synced: usize,
+}
+
+impl TagCounts {
+    pub fn increment(&mut self, classification: TagClassification) {
+        match classification {
+            TagClassification::Stale => self.stale += 1,
+            TagClassification::LocalOnly => self.local_only += 1,
+            TagClassification::RemoteOnly => self.remote_only += 1,
+            TagClassification::Synced => self.synced += 1,
+        }
+    }
+
+    pub fn total(&self) -> usize {
+        self.stale + self.local_only + self.remote_only + self.synced
+    }
+}
+
+/// Result of a full tag scan.
+#[derive(Debug, Clone, Serialize)]
+pub struct TagScanResult {
+    /// Tags grouped by repo.
+    pub repos: Vec<TagRepoGroup>,
+    /// Total tags scanned.
+    pub total_scanned: usize,
+    /// Summary counts by classification.
+    pub counts: TagCounts,
+    /// Warnings encountered during scanning.
+    pub warnings: Vec<String>,
+}
+
+/// Flat JSON representation of a tag.
+#[derive(Debug, Serialize)]
+pub struct JsonTag {
+    pub repo_path: PathBuf,
+    pub name: String,
+    pub classification: String,
+    pub commit: String,
+    pub is_annotated: bool,
+    pub tagger_date: Option<String>,
+    pub is_release_tag: bool,
+    pub remote_names: Vec<String>,
+}
+
+impl From<&TagInfo> for JsonTag {
+    fn from(t: &TagInfo) -> Self {
+        JsonTag {
+            repo_path: t.repo_path.clone(),
+            name: t.name.clone(),
+            classification: t.classification.label().to_string(),
+            commit: t.commit.clone(),
+            is_annotated: t.is_annotated,
+            tagger_date: t.tagger_date.clone(),
+            is_release_tag: t.is_release_tag,
+            remote_names: t.remote_names.clone(),
+        }
+    }
+}
+
+/// Check if a tag name looks like a release version.
+///
+/// Matches: `v1.0`, `v1.0.0`, `V1.0`, `1.2.3`, `v1.0.0-rc1`.
+/// Does not match: `version-bump`, `v-next`.
+pub fn is_release_tag_name(name: &str) -> bool {
+    let rest = name
+        .strip_prefix('v')
+        .or_else(|| name.strip_prefix('V'))
+        .unwrap_or(name);
+    rest.starts_with(|c: char| c.is_ascii_digit()) && rest.contains('.')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classification_priority_order() {
+        assert!(TagClassification::Stale.priority() < TagClassification::LocalOnly.priority());
+        assert!(TagClassification::LocalOnly.priority() < TagClassification::RemoteOnly.priority());
+        assert!(TagClassification::RemoteOnly.priority() < TagClassification::Synced.priority());
+    }
+
+    #[test]
+    fn classification_labels() {
+        assert_eq!(TagClassification::Stale.label(), "stale");
+        assert_eq!(TagClassification::LocalOnly.label(), "local_only");
+        assert_eq!(TagClassification::RemoteOnly.label(), "remote_only");
+        assert_eq!(TagClassification::Synced.label(), "synced");
+    }
+
+    #[test]
+    fn counts_increment_and_total() {
+        let mut counts = TagCounts::default();
+        counts.increment(TagClassification::Stale);
+        counts.increment(TagClassification::LocalOnly);
+        counts.increment(TagClassification::RemoteOnly);
+        counts.increment(TagClassification::Synced);
+        counts.increment(TagClassification::Synced);
+        assert_eq!(counts.stale, 1);
+        assert_eq!(counts.local_only, 1);
+        assert_eq!(counts.remote_only, 1);
+        assert_eq!(counts.synced, 2);
+        assert_eq!(counts.total(), 5);
+    }
+
+    #[test]
+    fn json_tag_from_info() {
+        let info = TagInfo {
+            repo_path: PathBuf::from("/repos/my-repo"),
+            name: "v1.0.0".to_string(),
+            classification: TagClassification::Synced,
+            commit: "abc1234".to_string(),
+            is_annotated: true,
+            tagger_date: Some("2024-06-15T10:00:00+00:00".to_string()),
+            is_release_tag: true,
+            remote_names: vec!["origin".to_string()],
+        };
+        let json = JsonTag::from(&info);
+        assert_eq!(json.name, "v1.0.0");
+        assert_eq!(json.classification, "synced");
+        assert_eq!(json.commit, "abc1234");
+        assert!(json.is_annotated);
+        assert!(json.is_release_tag);
+        assert_eq!(json.remote_names, vec!["origin"]);
+    }
+
+    #[test]
+    fn json_tag_remote_only_empty_commit() {
+        let info = TagInfo {
+            repo_path: PathBuf::from("/repos/my-repo"),
+            name: "v2.0.0".to_string(),
+            classification: TagClassification::RemoteOnly,
+            commit: "def5678".to_string(),
+            is_annotated: false,
+            tagger_date: None,
+            is_release_tag: true,
+            remote_names: vec!["origin".to_string()],
+        };
+        let json = JsonTag::from(&info);
+        assert_eq!(json.classification, "remote_only");
+        assert!(!json.is_annotated);
+        assert!(json.tagger_date.is_none());
+    }
+
+    #[test]
+    fn is_release_tag_name_v_prefix() {
+        assert!(is_release_tag_name("v1.0"));
+        assert!(is_release_tag_name("v1.0.0"));
+        assert!(is_release_tag_name("v1.0.0-rc1"));
+        assert!(is_release_tag_name("V1.0"));
+    }
+
+    #[test]
+    fn is_release_tag_name_no_prefix() {
+        assert!(is_release_tag_name("1.2.3"));
+        assert!(is_release_tag_name("0.1.0"));
+    }
+
+    #[test]
+    fn is_release_tag_name_rejects_non_release() {
+        assert!(!is_release_tag_name("version-bump"));
+        assert!(!is_release_tag_name("v-next"));
+        assert!(!is_release_tag_name("feature-v2"));
+        assert!(!is_release_tag_name("old-experiment"));
+        assert!(!is_release_tag_name(""));
+    }
+}

--- a/crates/git-tag-tidy/tests/common/mod.rs
+++ b/crates/git-tag-tidy/tests/common/mod.rs
@@ -1,0 +1,1 @@
+pub use git_tidy_core::testutil::*;

--- a/crates/git-tag-tidy/tests/integration_clean.rs
+++ b/crates/git-tag-tidy/tests/integration_clean.rs
@@ -1,0 +1,206 @@
+mod common;
+
+use common::git;
+use git_tidy_core::git::{GitOps, RealGit};
+
+/// Set up a repo inside a scan directory so `discover_repos` finds it.
+fn set_up_repo() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().canonicalize().unwrap();
+
+    let scan_dir = base.join("projects");
+    std::fs::create_dir_all(&scan_dir).unwrap();
+
+    let repo = scan_dir.join("my-repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    git(&repo, &["init", "-b", "main"]);
+    git(&repo, &["config", "user.email", "test@test.com"]);
+    git(&repo, &["config", "user.name", "Test"]);
+
+    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
+    git(&repo, &["add", "README.md"]);
+    git(&repo, &["commit", "-m", "Initial commit"]);
+
+    (dir, repo)
+}
+
+#[test]
+fn clean_removes_local_only_tag() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Set up a bare remote
+    let bare = dir.path().canonicalize().unwrap().join("remote.git");
+    std::fs::create_dir_all(&bare).unwrap();
+    git(&bare, &["init", "--bare"]);
+    git(&repo, &["remote", "add", "origin", &bare.to_string_lossy()]);
+    git(&repo, &["push", "-u", "origin", "main"]);
+
+    // Create a local-only tag
+    git(&repo, &["tag", "local-wip"]);
+
+    // Verify tag exists
+    let tags = git_ops.list_local_tags(&repo).unwrap();
+    assert!(tags.contains(&"local-wip".to_string()));
+
+    // Scan then clean
+    let scan_result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+
+    let options = git_tag_tidy::clean::CleanOptions {
+        dry_run: false,
+        yes: true,
+        force: false,
+        stale_only: false,
+        local_only: false,
+        include_remote: false,
+        all: false,
+    };
+
+    let mut buf = Vec::new();
+    let result =
+        git_tag_tidy::clean::run_clean(&git_ops, &scan_result, &options, &mut buf).unwrap();
+
+    assert_eq!(result.removed.len(), 1);
+
+    // Verify tag is gone
+    let tags = git_ops.list_local_tags(&repo).unwrap();
+    assert!(!tags.contains(&"local-wip".to_string()));
+}
+
+#[test]
+fn clean_dry_run_preserves_tags() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Set up a bare remote
+    let bare = dir.path().canonicalize().unwrap().join("remote.git");
+    std::fs::create_dir_all(&bare).unwrap();
+    git(&bare, &["init", "--bare"]);
+    git(&repo, &["remote", "add", "origin", &bare.to_string_lossy()]);
+    git(&repo, &["push", "-u", "origin", "main"]);
+
+    git(&repo, &["tag", "local-wip"]);
+
+    let scan_result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+
+    let options = git_tag_tidy::clean::CleanOptions {
+        dry_run: true,
+        yes: true,
+        force: false,
+        stale_only: false,
+        local_only: false,
+        include_remote: false,
+        all: false,
+    };
+
+    let mut buf = Vec::new();
+    let result =
+        git_tag_tidy::clean::run_clean(&git_ops, &scan_result, &options, &mut buf).unwrap();
+
+    // Reports would-delete
+    assert_eq!(result.removed.len(), 1);
+
+    // But tag still exists
+    let tags = git_ops.list_local_tags(&repo).unwrap();
+    assert!(tags.contains(&"local-wip".to_string()));
+
+    let output = String::from_utf8(buf).unwrap();
+    assert!(output.contains("would delete"));
+}
+
+#[test]
+fn clean_removes_stale_tag() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Create an orphan branch, tag it, delete the branch
+    git(&repo, &["checkout", "--orphan", "orphan-branch"]);
+    std::fs::write(repo.join("orphan.txt"), "orphan content\n").unwrap();
+    git(&repo, &["add", "orphan.txt"]);
+    git(&repo, &["commit", "-m", "Orphan commit"]);
+    git(&repo, &["tag", "stale-tag"]);
+    git(&repo, &["checkout", "main"]);
+    git(&repo, &["branch", "-D", "orphan-branch"]);
+
+    // Verify tag exists
+    let tags = git_ops.list_local_tags(&repo).unwrap();
+    assert!(tags.contains(&"stale-tag".to_string()));
+
+    // Scan (offline since no remote) then clean
+    let scan_result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, true).unwrap();
+
+    let options = git_tag_tidy::clean::CleanOptions {
+        dry_run: false,
+        yes: true,
+        force: false,
+        stale_only: false,
+        local_only: false,
+        include_remote: false,
+        all: false,
+    };
+
+    let mut buf = Vec::new();
+    let result =
+        git_tag_tidy::clean::run_clean(&git_ops, &scan_result, &options, &mut buf).unwrap();
+
+    assert!(result.removed.iter().any(|r| r.name == "stale-tag"));
+
+    // Verify tag is gone
+    let tags = git_ops.list_local_tags(&repo).unwrap();
+    assert!(!tags.contains(&"stale-tag".to_string()));
+}
+
+#[test]
+fn clean_include_remote_deletes_from_remote() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Set up a bare remote
+    let bare = dir.path().canonicalize().unwrap().join("remote.git");
+    std::fs::create_dir_all(&bare).unwrap();
+    git(&bare, &["init", "--bare"]);
+    git(&repo, &["remote", "add", "origin", &bare.to_string_lossy()]);
+    git(&repo, &["push", "-u", "origin", "main"]);
+
+    // Create an orphan branch, tag it, push tag, delete branch
+    git(&repo, &["checkout", "--orphan", "orphan-branch"]);
+    std::fs::write(repo.join("orphan.txt"), "orphan content\n").unwrap();
+    git(&repo, &["add", "orphan.txt"]);
+    git(&repo, &["commit", "-m", "Orphan commit"]);
+    git(&repo, &["tag", "stale-pushed"]);
+    git(&repo, &["push", "origin", "stale-pushed"]);
+    git(&repo, &["checkout", "main"]);
+    git(&repo, &["branch", "-D", "orphan-branch"]);
+
+    // Scan then clean with --include-remote
+    let scan_result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+
+    let options = git_tag_tidy::clean::CleanOptions {
+        dry_run: false,
+        yes: true,
+        force: false,
+        stale_only: false,
+        local_only: false,
+        include_remote: true,
+        all: false,
+    };
+
+    let mut buf = Vec::new();
+    let result =
+        git_tag_tidy::clean::run_clean(&git_ops, &scan_result, &options, &mut buf).unwrap();
+
+    assert!(result.removed.iter().any(|r| r.name == "stale-pushed"));
+
+    // Verify local tag is gone
+    let tags = git_ops.list_local_tags(&repo).unwrap();
+    assert!(!tags.contains(&"stale-pushed".to_string()));
+
+    // Verify remote tag is also gone
+    let remote_tags = git_ops.list_remote_tags(&repo, "origin").unwrap();
+    let remote_tag_names: Vec<_> = remote_tags.iter().map(|(name, _)| name.as_str()).collect();
+    assert!(!remote_tag_names.contains(&"stale-pushed"));
+}

--- a/crates/git-tag-tidy/tests/integration_scan.rs
+++ b/crates/git-tag-tidy/tests/integration_scan.rs
@@ -1,0 +1,155 @@
+mod common;
+
+use common::git;
+use git_tidy_core::git::RealGit;
+
+use git_tag_tidy::types::TagClassification;
+
+/// Set up a repo inside a scan directory so `discover_repos` finds it.
+fn set_up_repo() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().canonicalize().unwrap();
+
+    let scan_dir = base.join("projects");
+    std::fs::create_dir_all(&scan_dir).unwrap();
+
+    let repo = scan_dir.join("my-repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    git(&repo, &["init", "-b", "main"]);
+    git(&repo, &["config", "user.email", "test@test.com"]);
+    git(&repo, &["config", "user.name", "Test"]);
+
+    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
+    git(&repo, &["add", "README.md"]);
+    git(&repo, &["commit", "-m", "Initial commit"]);
+
+    (dir, repo)
+}
+
+#[test]
+fn scan_synced_tag() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Set up a bare remote and push
+    let bare = dir.path().canonicalize().unwrap().join("remote.git");
+    std::fs::create_dir_all(&bare).unwrap();
+    git(&bare, &["init", "--bare"]);
+    git(&repo, &["remote", "add", "origin", &bare.to_string_lossy()]);
+    git(&repo, &["push", "-u", "origin", "main"]);
+
+    // Create a tag and push it
+    git(&repo, &["tag", "v1.0.0"]);
+    git(&repo, &["push", "origin", "v1.0.0"]);
+
+    let result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+    assert!(result.total_scanned >= 1);
+
+    let synced: Vec<_> = result.repos[0]
+        .tags
+        .iter()
+        .filter(|t| t.name == "v1.0.0")
+        .collect();
+    assert_eq!(synced.len(), 1);
+    assert_eq!(synced[0].classification, TagClassification::Synced);
+    assert!(synced[0].is_release_tag);
+    assert!(!synced[0].commit.is_empty());
+}
+
+#[test]
+fn scan_local_only_tag() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Set up a bare remote
+    let bare = dir.path().canonicalize().unwrap().join("remote.git");
+    std::fs::create_dir_all(&bare).unwrap();
+    git(&bare, &["init", "--bare"]);
+    git(&repo, &["remote", "add", "origin", &bare.to_string_lossy()]);
+    git(&repo, &["push", "-u", "origin", "main"]);
+
+    // Create a tag but don't push it
+    git(&repo, &["tag", "local-only-tag"]);
+
+    let result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+
+    let local: Vec<_> = result.repos[0]
+        .tags
+        .iter()
+        .filter(|t| t.name == "local-only-tag")
+        .collect();
+    assert_eq!(local.len(), 1);
+    assert_eq!(local[0].classification, TagClassification::LocalOnly);
+    assert!(!local[0].is_release_tag);
+}
+
+#[test]
+fn scan_stale_tag() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Create an orphan branch, tag it, delete the branch
+    git(&repo, &["checkout", "--orphan", "orphan-branch"]);
+    std::fs::write(repo.join("orphan.txt"), "orphan content\n").unwrap();
+    git(&repo, &["add", "orphan.txt"]);
+    git(&repo, &["commit", "-m", "Orphan commit"]);
+    git(&repo, &["tag", "stale-tag"]);
+    git(&repo, &["checkout", "main"]);
+    git(&repo, &["branch", "-D", "orphan-branch"]);
+
+    let result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, true).unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+
+    let stale: Vec<_> = result.repos[0]
+        .tags
+        .iter()
+        .filter(|t| t.name == "stale-tag")
+        .collect();
+    assert_eq!(stale.len(), 1);
+    assert_eq!(stale[0].classification, TagClassification::Stale);
+}
+
+#[test]
+fn scan_annotated_tag() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Create an annotated tag
+    git(&repo, &["tag", "-a", "v2.0.0", "-m", "Release 2.0.0"]);
+
+    let result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, true).unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+
+    let annotated: Vec<_> = result.repos[0]
+        .tags
+        .iter()
+        .filter(|t| t.name == "v2.0.0")
+        .collect();
+    assert_eq!(annotated.len(), 1);
+    assert!(annotated[0].is_annotated);
+    assert!(annotated[0].tagger_date.is_some());
+    assert!(annotated[0].is_release_tag);
+}
+
+#[test]
+fn scan_empty_repo_no_tags() {
+    let (dir, _repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    let result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, true).unwrap();
+
+    // Repo has no tags, so no groups
+    assert!(result.repos.is_empty());
+    assert_eq!(result.total_scanned, 0);
+}

--- a/crates/git-tidy-core/src/error.rs
+++ b/crates/git-tidy-core/src/error.rs
@@ -40,6 +40,13 @@ pub enum Error {
         reason: String,
     },
 
+    #[error("tag deletion failed: {tag} in {repo}: {reason}")]
+    TagDeletionFailed {
+        repo: PathBuf,
+        tag: String,
+        reason: String,
+    },
+
     #[error("dirty worktrees blocked removal (rerun with --force)")]
     DirtyBlocked,
 

--- a/crates/git-tidy-core/src/git.rs
+++ b/crates/git-tidy-core/src/git.rs
@@ -148,6 +148,34 @@ pub trait GitOps {
 
     /// Drop a stash entry.
     fn stash_drop(&self, repo: &Path, stash_ref: &str) -> GitResult<()>;
+
+    // --- Tag operations ---
+
+    /// List all local tags in a repo.
+    fn list_local_tags(&self, repo: &Path) -> GitResult<Vec<String>>;
+
+    /// List tags on a remote.
+    /// Returns `Vec<(tag_name, commit_sha)>`.
+    /// For annotated tags, prefers the dereferenced (`^{}`) commit SHA.
+    fn list_remote_tags(&self, repo: &Path, remote: &str) -> GitResult<Vec<(String, String)>>;
+
+    /// Get the commit SHA a tag points at (dereferencing annotated tags).
+    fn tag_commit(&self, repo: &Path, tag: &str) -> GitResult<String>;
+
+    /// Check if a commit is reachable from any branch.
+    fn is_commit_reachable(&self, repo: &Path, commit: &str) -> GitResult<bool>;
+
+    /// Delete a local tag.
+    fn tag_delete(&self, repo: &Path, tag: &str) -> GitResult<()>;
+
+    /// Delete a tag on a remote.
+    fn tag_delete_remote(&self, repo: &Path, remote: &str, tag: &str) -> GitResult<()>;
+
+    /// Check if a tag is annotated (vs lightweight).
+    fn is_tag_annotated(&self, repo: &Path, tag: &str) -> GitResult<bool>;
+
+    /// Get the tagger/creator date for a tag (ISO 8601).
+    fn tag_date(&self, repo: &Path, tag: &str) -> GitResult<Option<String>>;
 }
 
 /// Real git implementation that shells out to the `git` binary.
@@ -582,6 +610,99 @@ impl GitOps for RealGit {
             }
         })?;
         Ok(())
+    }
+
+    // --- Tag operations ---
+
+    fn list_local_tags(&self, repo: &Path) -> GitResult<Vec<String>> {
+        let text = Self::run_success(repo, &["tag", "-l"])?;
+        Ok(text
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| l.to_string())
+            .collect())
+    }
+
+    fn list_remote_tags(&self, repo: &Path, remote: &str) -> GitResult<Vec<(String, String)>> {
+        let output = Self::run(repo, &["ls-remote", "--tags", remote])?;
+        let text = String::from_utf8_lossy(&output.stdout);
+        let mut map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        for line in text.lines() {
+            if line.is_empty() {
+                continue;
+            }
+            let Some((sha, refname)) = line.split_once('\t') else {
+                continue;
+            };
+            let refname = refname.trim();
+            let Some(tag_ref) = refname.strip_prefix("refs/tags/") else {
+                continue;
+            };
+            if let Some(tag_name) = tag_ref.strip_suffix("^{}") {
+                // Dereferenced annotated tag -- overwrite entry
+                map.insert(tag_name.to_string(), sha.to_string());
+            } else {
+                // Only insert if we haven't seen a ^{} entry yet
+                map.entry(tag_ref.to_string())
+                    .or_insert_with(|| sha.to_string());
+            }
+        }
+        Ok(map.into_iter().collect())
+    }
+
+    fn tag_commit(&self, repo: &Path, tag: &str) -> GitResult<String> {
+        let refspec = format!("{tag}^{{commit}}");
+        Self::run_success(repo, &["rev-parse", &refspec])
+    }
+
+    fn is_commit_reachable(&self, repo: &Path, commit: &str) -> GitResult<bool> {
+        let output = Self::run(repo, &["branch", "--contains", commit])?;
+        let text = String::from_utf8_lossy(&output.stdout);
+        Ok(!text.trim().is_empty())
+    }
+
+    fn tag_delete(&self, repo: &Path, tag: &str) -> GitResult<()> {
+        Self::run_success(repo, &["tag", "-d", tag]).map_err(|_| Error::TagDeletionFailed {
+            repo: repo.to_path_buf(),
+            tag: tag.to_string(),
+            reason: "git tag -d failed".to_string(),
+        })?;
+        Ok(())
+    }
+
+    fn tag_delete_remote(&self, repo: &Path, remote: &str, tag: &str) -> GitResult<()> {
+        let refspec = format!("refs/tags/{tag}");
+        Self::run_success(repo, &["push", remote, "--delete", &refspec]).map_err(|_| {
+            Error::TagDeletionFailed {
+                repo: repo.to_path_buf(),
+                tag: tag.to_string(),
+                reason: format!("git push {remote} --delete refs/tags/{tag} failed"),
+            }
+        })?;
+        Ok(())
+    }
+
+    fn is_tag_annotated(&self, repo: &Path, tag: &str) -> GitResult<bool> {
+        let text = Self::run_success(repo, &["cat-file", "-t", tag])?;
+        Ok(text.trim() == "tag")
+    }
+
+    fn tag_date(&self, repo: &Path, tag: &str) -> GitResult<Option<String>> {
+        let refspec = format!("refs/tags/{tag}");
+        let text = Self::run_success(
+            repo,
+            &[
+                "for-each-ref",
+                "--format=%(creatordate:iso-strict)",
+                &refspec,
+            ],
+        )?;
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(trimmed.to_string()))
+        }
     }
 }
 

--- a/crates/git-tidy-core/src/testutil.rs
+++ b/crates/git-tidy-core/src/testutil.rs
@@ -51,6 +51,17 @@ pub struct MockGitBuilder {
     remote_tracking_refs: HashMap<PathBuf, Vec<(String, String)>>,
     prune_remote_refs_result: HashMap<(PathBuf, String), usize>,
     prune_remote_refs_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    // Tag operations
+    local_tags: HashMap<PathBuf, Vec<String>>,
+    remote_tags: HashMap<(PathBuf, String), Vec<(String, String)>>,
+    tag_commit: HashMap<(PathBuf, String), String>,
+    is_commit_reachable: HashMap<(PathBuf, String), bool>,
+    tag_delete_errors: HashMap<(PathBuf, String), String>,
+    tag_delete_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    tag_delete_remote_errors: HashMap<(PathBuf, String, String), String>,
+    tag_delete_remote_calls: std::cell::RefCell<Vec<(PathBuf, String, String)>>,
+    is_tag_annotated: HashMap<(PathBuf, String), bool>,
+    tag_date: HashMap<(PathBuf, String), Option<String>>,
 }
 
 impl MockGitBuilder {
@@ -317,6 +328,70 @@ impl MockGitBuilder {
         self
     }
 
+    // --- Tag builder methods ---
+
+    pub fn with_local_tags(mut self, repo: &Path, tags: Vec<String>) -> Self {
+        self.local_tags.insert(repo.to_path_buf(), tags);
+        self
+    }
+
+    pub fn with_remote_tags(
+        mut self,
+        repo: &Path,
+        remote: &str,
+        tags: Vec<(String, String)>,
+    ) -> Self {
+        self.remote_tags
+            .insert((repo.to_path_buf(), remote.to_string()), tags);
+        self
+    }
+
+    pub fn with_tag_commit(mut self, repo: &Path, tag: &str, commit: &str) -> Self {
+        self.tag_commit
+            .insert((repo.to_path_buf(), tag.to_string()), commit.to_string());
+        self
+    }
+
+    pub fn with_is_commit_reachable(mut self, repo: &Path, commit: &str, reachable: bool) -> Self {
+        self.is_commit_reachable
+            .insert((repo.to_path_buf(), commit.to_string()), reachable);
+        self
+    }
+
+    pub fn with_tag_delete_error(mut self, repo: &Path, tag: &str, error: &str) -> Self {
+        self.tag_delete_errors
+            .insert((repo.to_path_buf(), tag.to_string()), error.to_string());
+        self
+    }
+
+    pub fn with_tag_delete_remote_error(
+        mut self,
+        repo: &Path,
+        remote: &str,
+        tag: &str,
+        error: &str,
+    ) -> Self {
+        self.tag_delete_remote_errors.insert(
+            (repo.to_path_buf(), remote.to_string(), tag.to_string()),
+            error.to_string(),
+        );
+        self
+    }
+
+    pub fn with_is_tag_annotated(mut self, repo: &Path, tag: &str, annotated: bool) -> Self {
+        self.is_tag_annotated
+            .insert((repo.to_path_buf(), tag.to_string()), annotated);
+        self
+    }
+
+    pub fn with_tag_date(mut self, repo: &Path, tag: &str, date: Option<&str>) -> Self {
+        self.tag_date.insert(
+            (repo.to_path_buf(), tag.to_string()),
+            date.map(|s| s.to_string()),
+        );
+        self
+    }
+
     pub fn build(self) -> MockGit {
         MockGit {
             symbolic_ref: self.symbolic_ref,
@@ -360,6 +435,16 @@ impl MockGitBuilder {
             remote_tracking_refs: self.remote_tracking_refs,
             prune_remote_refs_result: self.prune_remote_refs_result,
             prune_remote_refs_calls: self.prune_remote_refs_calls,
+            local_tags: self.local_tags,
+            remote_tags: self.remote_tags,
+            tag_commit: self.tag_commit,
+            is_commit_reachable: self.is_commit_reachable,
+            tag_delete_errors: self.tag_delete_errors,
+            tag_delete_calls: self.tag_delete_calls,
+            tag_delete_remote_errors: self.tag_delete_remote_errors,
+            tag_delete_remote_calls: self.tag_delete_remote_calls,
+            is_tag_annotated: self.is_tag_annotated,
+            tag_date: self.tag_date,
         }
     }
 }
@@ -408,6 +493,17 @@ pub struct MockGit {
     remote_tracking_refs: HashMap<PathBuf, Vec<(String, String)>>,
     prune_remote_refs_result: HashMap<(PathBuf, String), usize>,
     prune_remote_refs_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    // Tag operations
+    local_tags: HashMap<PathBuf, Vec<String>>,
+    remote_tags: HashMap<(PathBuf, String), Vec<(String, String)>>,
+    tag_commit: HashMap<(PathBuf, String), String>,
+    is_commit_reachable: HashMap<(PathBuf, String), bool>,
+    tag_delete_errors: HashMap<(PathBuf, String), String>,
+    tag_delete_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    tag_delete_remote_errors: HashMap<(PathBuf, String, String), String>,
+    tag_delete_remote_calls: std::cell::RefCell<Vec<(PathBuf, String, String)>>,
+    is_tag_annotated: HashMap<(PathBuf, String), bool>,
+    tag_date: HashMap<(PathBuf, String), Option<String>>,
 }
 
 impl MockGit {
@@ -445,6 +541,14 @@ impl MockGit {
 
     pub fn prune_remote_refs_calls(&self) -> Vec<(PathBuf, String)> {
         self.prune_remote_refs_calls.borrow().clone()
+    }
+
+    pub fn tag_delete_calls(&self) -> Vec<(PathBuf, String)> {
+        self.tag_delete_calls.borrow().clone()
+    }
+
+    pub fn tag_delete_remote_calls(&self) -> Vec<(PathBuf, String, String)> {
+        self.tag_delete_remote_calls.borrow().clone()
     }
 }
 
@@ -800,6 +904,93 @@ impl GitOps for MockGit {
             .push((repo.to_path_buf(), stash_ref.to_string()));
         Ok(())
     }
+
+    // --- Tag operations ---
+
+    fn list_local_tags(&self, repo: &Path) -> GitResult<Vec<String>> {
+        Ok(self
+            .local_tags
+            .get(&repo.to_path_buf())
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    fn list_remote_tags(&self, repo: &Path, remote: &str) -> GitResult<Vec<(String, String)>> {
+        Ok(self
+            .remote_tags
+            .get(&(repo.to_path_buf(), remote.to_string()))
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    fn tag_commit(&self, repo: &Path, tag: &str) -> GitResult<String> {
+        self.tag_commit
+            .get(&(repo.to_path_buf(), tag.to_string()))
+            .cloned()
+            .ok_or_else(|| Error::GitCommand {
+                command: format!("rev-parse {tag}^{{commit}}"),
+                message: "not found in mock".to_string(),
+            })
+    }
+
+    fn is_commit_reachable(&self, repo: &Path, commit: &str) -> GitResult<bool> {
+        Ok(*self
+            .is_commit_reachable
+            .get(&(repo.to_path_buf(), commit.to_string()))
+            .unwrap_or(&false))
+    }
+
+    fn tag_delete(&self, repo: &Path, tag: &str) -> GitResult<()> {
+        if let Some(err) = self
+            .tag_delete_errors
+            .get(&(repo.to_path_buf(), tag.to_string()))
+        {
+            return Err(Error::TagDeletionFailed {
+                repo: repo.to_path_buf(),
+                tag: tag.to_string(),
+                reason: err.clone(),
+            });
+        }
+        self.tag_delete_calls
+            .borrow_mut()
+            .push((repo.to_path_buf(), tag.to_string()));
+        Ok(())
+    }
+
+    fn tag_delete_remote(&self, repo: &Path, remote: &str, tag: &str) -> GitResult<()> {
+        if let Some(err) = self.tag_delete_remote_errors.get(&(
+            repo.to_path_buf(),
+            remote.to_string(),
+            tag.to_string(),
+        )) {
+            return Err(Error::TagDeletionFailed {
+                repo: repo.to_path_buf(),
+                tag: tag.to_string(),
+                reason: err.clone(),
+            });
+        }
+        self.tag_delete_remote_calls.borrow_mut().push((
+            repo.to_path_buf(),
+            remote.to_string(),
+            tag.to_string(),
+        ));
+        Ok(())
+    }
+
+    fn is_tag_annotated(&self, repo: &Path, tag: &str) -> GitResult<bool> {
+        Ok(*self
+            .is_tag_annotated
+            .get(&(repo.to_path_buf(), tag.to_string()))
+            .unwrap_or(&false))
+    }
+
+    fn tag_date(&self, repo: &Path, tag: &str) -> GitResult<Option<String>> {
+        Ok(self
+            .tag_date
+            .get(&(repo.to_path_buf(), tag.to_string()))
+            .cloned()
+            .unwrap_or(None))
+    }
 }
 
 /// Helper to set up a real git repo with worktrees in a tempdir for integration tests.
@@ -912,6 +1103,23 @@ impl TestRepo {
         git(&self.main_repo, &["add", filename]);
         git(&self.main_repo, &["stash"]);
         git(&self.main_repo, &["checkout", "main"]);
+    }
+}
+
+impl TestRepo {
+    /// Create a lightweight tag on the current HEAD.
+    pub fn create_tag(&self, name: &str) {
+        git(&self.main_repo, &["tag", name]);
+    }
+
+    /// Create an annotated tag on the current HEAD.
+    pub fn create_annotated_tag(&self, name: &str, message: &str) {
+        git(&self.main_repo, &["tag", "-a", name, "-m", message]);
+    }
+
+    /// Push a tag to the given remote.
+    pub fn push_tag(&self, remote: &str, tag: &str) {
+        git(&self.main_repo, &["push", remote, tag]);
     }
 }
 


### PR DESCRIPTION
## Summary

- New binary crate `git-tag-tidy` that scans repos for tags and classifies them as stale (unreachable commit), local_only (not on remote), remote_only (only on remote), or synced
- Adds 8 tag methods to `GitOps` trait with `RealGit` implementations and mock support
- Supports offline mode, release tag protection, `--include-remote` for remote deletion, and three output formats (human, JSON, porcelain)
- 55 tests (46 unit + 9 integration)

## Test plan

- [x] `cargo test --workspace` passes (55 tag-tidy tests + all existing tests)
- [x] `cargo clippy --workspace --all-targets -- -D clippy::all` passes
- [x] `cargo fmt --check --all` passes
- [ ] CI passes

Closes #38