### PR TITLE
Add git-tidy audit runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ git config core.hooksPath .githooks
 
 This is a Cargo workspace with a shared core library and six binary crates.
 
+- **`git-tidy`**: Audit runner binary that discovers installed `git-*-tidy` tools and produces a consolidated summary. No dependency on `git-tidy-core`.
 - **`git-tidy-core`**: Shared library containing git abstraction, classification logic, output helpers, and test utilities.
 - **`git-worktree-tidy`**: Binary crate for scanning and cleaning stale git worktrees.
 - **`git-branch-tidy`**: Binary crate for scanning and cleaning stale local git branches.
@@ -52,6 +53,7 @@ All tools follow a similar CLI shape:
 - Tag-tidy global arg: `--offline` instead of `--behind-threshold`/`--verbose`
 - Repo-tidy global args: `--stale-months` (default 6), `--offline`
 - Tool-specific flags: worktree-tidy has `--delete-branches`, branch-tidy has `--include-remote`/`--force`, remote-tidy has `--force` (allow removing origin)/`--all` (include orphaned), tag-tidy has `--stale-only`/`--local-only`/`--include-remote`/`--force` (bypass release protection)/`--all`, repo-tidy has `--force` (allow deleting dirty repos)/`--stale-only`/`--orphaned-only`/`--all`
+- git-tidy (audit runner): `Audit` subcommand (default) with `--json`/`--porcelain`/`--verbose`/`--tools`. Uses `ToolRunner` trait instead of `GitOps`. No dependency on `git-tidy-core`.
 
 ## Conventions
 
@@ -70,6 +72,16 @@ All tools follow a similar CLI shape:
 ```
 Cargo.toml                                    # Workspace root
 crates/
+  git-tidy/                                   # Audit runner binary (no core dependency)
+    src/
+      main.rs                                 # CLI dispatch
+      lib.rs                                  # Public module exports
+      cli.rs                                  # clap definitions (Audit subcommand)
+      types.rs                                # ToolSpec, TOOL_SPECS, ToolResult, AuditResult
+      runner.rs                               # ToolRunner trait, RealToolRunner, run_audit
+      output.rs                               # Human-readable, JSON, porcelain formatters
+    tests/
+      integration.rs                          # End-to-end with FakeToolRunner
   git-tidy-core/                              # Shared library
     src/
       lib.rs                                  # Module exports

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +316,17 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "git-tidy"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "which",
 ]
 
 [[package]]
@@ -820,6 +837,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +943,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A Cargo workspace for Git housekeeping tools that share classification logic (me
 
 ## Tools
 
+### git-tidy (audit runner)
+
+Discovers installed `git-*-tidy` tools, runs each with `scan --json`, and produces a consolidated summary. Works with whatever subset of tools is installed.
+
 ### git-worktree-tidy
 
 Scans a directory for linked Git worktrees, classifies them by staleness, and interactively removes the stale ones.
@@ -33,6 +37,11 @@ Scans a directory of Git repos, classifies them by activity (stale, orphaned, ac
 Requires Rust 1.93.0 or later (edition 2024).
 
 ```bash
+# Install all tools at once
+./install.sh
+
+# Or install individually
+cargo install --path crates/git-tidy              # audit runner
 cargo install --path crates/git-worktree-tidy
 cargo install --path crates/git-branch-tidy
 cargo install --path crates/git-stash-tidy
@@ -156,6 +165,18 @@ git-repo-tidy clean ~/Developer --force            # allow deleting dirty repos
 git-repo-tidy clean ~/Developer --dry-run          # preview deletions
 ```
 
+### git-tidy (audit runner)
+
+```bash
+# Run audit across all installed tools (default command)
+git-tidy ~/Developer
+git-tidy audit ~/Developer          # explicit subcommand
+git-tidy ~/Developer --json          # JSON output
+git-tidy ~/Developer --porcelain     # machine-readable
+git-tidy ~/Developer -v              # verbose (shows tool paths)
+git-tidy ~/Developer --tools branch,tag  # run only specific tools
+```
+
 ## Classifications
 
 ### Worktree and branch classifications
@@ -263,6 +284,7 @@ git config core.hooksPath .githooks
 
 ```
 crates/
+  git-tidy/               Audit runner binary (no core dependency)
   git-tidy-core/          Shared classification, git abstraction, output helpers, test utilities
   git-worktree-tidy/      Worktree scanner/cleaner binary
   git-branch-tidy/        Branch scanner/cleaner binary

--- a/crates/git-tidy/Cargo.toml
+++ b/crates/git-tidy/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "git-tidy"
+version = "0.1.0"
+edition = "2024"
+description = "Audit runner for git-tidy tools"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+which = "8"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/git-tidy/README.md
+++ b/crates/git-tidy/README.md
@@ -1,0 +1,84 @@
+# git-tidy
+
+Audit runner that discovers installed `git-*-tidy` tools, runs each with `scan --json` (or `lint --json`), and produces a consolidated summary.
+
+## Installation
+
+```bash
+cargo install --path .
+```
+
+## Usage
+
+```bash
+# Run audit across all installed tools (default command)
+git-tidy ~/Developer
+git-tidy audit ~/Developer          # explicit subcommand
+
+# Output formats
+git-tidy ~/Developer --json          # JSON output
+git-tidy ~/Developer --porcelain     # machine-readable tab-delimited
+
+# Verbose mode (shows tool paths)
+git-tidy ~/Developer -v
+
+# Run only specific tools
+git-tidy ~/Developer --tools branch,tag
+git-tidy ~/Developer --tools git-branch-tidy,git-tag-tidy
+```
+
+## Supported tools
+
+| Binary | Item noun | Scan command | Count field |
+|--------|-----------|-------------|-------------|
+| git-worktree-tidy | worktrees | scan | classification |
+| git-branch-tidy | branches | scan | classification |
+| git-stash-tidy | stashes | scan | classification |
+| git-remote-tidy | remotes | scan | classification |
+| git-tag-tidy | tags | scan | classification |
+| git-repo-tidy | repos | scan | classification |
+| git-config-tidy | config issues | lint | kind |
+| git-lfs-tidy | LFS files | scan | classification |
+
+Only installed tools are run. Missing tools are listed in the output.
+
+## Human output example
+
+```
+git-tidy audit: ~/Developer
+
+  worktrees:       8 scanned (1 merged, 2 landed, 5 active)
+  branches:       22 scanned (3 merged, 5 landed, 2 partial, 12 active)
+  stashes:         6 scanned (2 committed, 1 orphaned, 3 active)
+  remotes:         4 scanned (1 unreachable, 3 active)
+  tags:           15 scanned (2 stale, 3 local_only, 10 synced)
+  config:          2 issues (1 orphaned_branch_config, 1 alias_shadows_builtin)
+  LFS:             3 scanned (2 untracked, 1 healthy)
+
+  not installed: git-repo-tidy
+
+Run individual tools for details.
+```
+
+## JSON output
+
+```json
+{
+  "directory": "/Users/jake/Developer",
+  "tools_found": ["git-worktree-tidy", "git-branch-tidy"],
+  "tools_missing": ["git-repo-tidy"],
+  "results": [
+    {
+      "name": "git-worktree-tidy",
+      "item_noun": "worktrees",
+      "total": 8,
+      "counts": { "active": 5, "landed": 2, "merged": 1 },
+      "error": null
+    }
+  ]
+}
+```
+
+## Porcelain output
+
+Tab-delimited columns: `tool_name`, `item_noun`, `total`, `counts_json`, `error`

--- a/crates/git-tidy/src/cli.rs
+++ b/crates/git-tidy/src/cli.rs
@@ -1,0 +1,126 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(name = "git-tidy", about = "Audit runner for git-tidy tools")]
+pub struct Cli {
+    /// Directory to scan (default: current directory)
+    #[arg(global = true)]
+    pub directory: Option<PathBuf>,
+
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Run audit across all installed git-tidy tools (default)
+    Audit {
+        /// Output results as JSON
+        #[arg(long)]
+        json: bool,
+
+        /// Machine-readable tab-delimited output
+        #[arg(long)]
+        porcelain: bool,
+
+        /// Show verbose output (tool paths, timing)
+        #[arg(long, short)]
+        verbose: bool,
+
+        /// Comma-separated list of tools to run (e.g., "branch,tag" or "git-branch-tidy")
+        #[arg(long, value_delimiter = ',')]
+        tools: Vec<String>,
+    },
+}
+
+impl Cli {
+    /// Resolve the target directory, defaulting to the current directory.
+    pub fn target_directory(&self) -> PathBuf {
+        self.directory
+            .clone()
+            .unwrap_or_else(|| std::env::current_dir().expect("cannot determine current directory"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[test]
+    fn default_command_is_none() {
+        let cli = Cli::parse_from(["git-tidy"]);
+        assert!(cli.command.is_none());
+        assert!(cli.directory.is_none());
+    }
+
+    #[test]
+    fn audit_subcommand_explicit() {
+        let cli = Cli::parse_from(["git-tidy", "audit"]);
+        assert!(matches!(cli.command, Some(Command::Audit { .. })));
+    }
+
+    #[test]
+    fn audit_with_json_flag() {
+        let cli = Cli::parse_from(["git-tidy", "audit", "--json"]);
+        match cli.command {
+            Some(Command::Audit {
+                json,
+                porcelain,
+                verbose,
+                ..
+            }) => {
+                assert!(json);
+                assert!(!porcelain);
+                assert!(!verbose);
+            }
+            _ => panic!("expected Audit command"),
+        }
+    }
+
+    #[test]
+    fn audit_with_porcelain_flag() {
+        let cli = Cli::parse_from(["git-tidy", "audit", "--porcelain"]);
+        match cli.command {
+            Some(Command::Audit { porcelain, .. }) => assert!(porcelain),
+            _ => panic!("expected Audit command"),
+        }
+    }
+
+    #[test]
+    fn audit_with_verbose_flag() {
+        let cli = Cli::parse_from(["git-tidy", "audit", "-v"]);
+        match cli.command {
+            Some(Command::Audit { verbose, .. }) => assert!(verbose),
+            _ => panic!("expected Audit command"),
+        }
+    }
+
+    #[test]
+    fn audit_with_tools_filter() {
+        let cli = Cli::parse_from(["git-tidy", "audit", "--tools", "branch,tag"]);
+        match cli.command {
+            Some(Command::Audit { tools, .. }) => {
+                assert_eq!(tools, vec!["branch", "tag"]);
+            }
+            _ => panic!("expected Audit command"),
+        }
+    }
+
+    #[test]
+    fn directory_argument() {
+        let cli = Cli::parse_from(["git-tidy", "/tmp/dev"]);
+        assert_eq!(cli.directory, Some(PathBuf::from("/tmp/dev")));
+        assert!(cli.command.is_none());
+    }
+
+    #[test]
+    fn directory_with_audit_subcommand() {
+        let cli = Cli::parse_from(["git-tidy", "audit", "--json", "/tmp/dev"]);
+        assert_eq!(cli.directory, Some(PathBuf::from("/tmp/dev")));
+        assert!(matches!(cli.command, Some(Command::Audit { .. })));
+    }
+}

--- a/crates/git-tidy/src/lib.rs
+++ b/crates/git-tidy/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod cli;
+pub mod output;
+pub mod runner;
+pub mod types;

--- a/crates/git-tidy/src/main.rs
+++ b/crates/git-tidy/src/main.rs
@@ -1,0 +1,52 @@
+use std::io;
+use std::process;
+
+use clap::Parser;
+
+mod cli;
+mod output;
+mod runner;
+mod types;
+
+fn main() {
+    let cli = cli::Cli::parse();
+    let directory = cli.target_directory();
+
+    if !directory.is_dir() {
+        eprintln!("error: directory not found: {}", directory.display());
+        process::exit(1);
+    }
+
+    let (json, porcelain, verbose, tools) = match &cli.command {
+        Some(cli::Command::Audit {
+            json,
+            porcelain,
+            verbose,
+            tools,
+        }) => (*json, *porcelain, *verbose, tools.clone()),
+        None => (false, false, false, vec![]),
+    };
+
+    let tool_filter = if tools.is_empty() {
+        None
+    } else {
+        Some(tools.as_slice())
+    };
+
+    let runner = runner::RealToolRunner;
+    let result = runner::run_audit(&runner, &directory, tool_filter);
+
+    let mut stdout = io::stdout().lock();
+    let write_result = if json {
+        output::write_json(&mut stdout, &result)
+    } else if porcelain {
+        output::write_porcelain(&mut stdout, &result)
+    } else {
+        output::write_human(&mut stdout, &result, verbose)
+    };
+
+    if let Err(e) = write_result {
+        eprintln!("error writing output: {e}");
+        process::exit(1);
+    }
+}

--- a/crates/git-tidy/src/output.rs
+++ b/crates/git-tidy/src/output.rs
@@ -1,0 +1,267 @@
+use std::io::Write;
+use std::path::Path;
+
+use crate::types::AuditResult;
+
+/// Display a path with `~` shorthand for the user's home directory.
+fn display_path(path: &Path) -> String {
+    if let Some(home) = dirs_home(path) {
+        return home;
+    }
+    path.display().to_string()
+}
+
+/// Replace the home directory prefix with `~`.
+fn dirs_home(path: &Path) -> Option<String> {
+    let home = std::env::var("HOME").ok()?;
+    let home_path = Path::new(&home);
+    path.strip_prefix(home_path)
+        .ok()
+        .map(|rest| format!("~/{}", rest.display()))
+}
+
+/// Write human-readable audit output.
+pub fn write_human(
+    out: &mut dyn Write,
+    result: &AuditResult,
+    verbose: bool,
+) -> std::io::Result<()> {
+    writeln!(out, "git-tidy audit: {}\n", display_path(&result.directory))?;
+
+    for tool_result in &result.results {
+        if let Some(ref err) = tool_result.error {
+            writeln!(
+                out,
+                "  {:<14} error: {err}",
+                format!("{}:", tool_result.item_noun),
+            )?;
+            continue;
+        }
+
+        let counts_str = if tool_result.counts.is_empty() {
+            String::new()
+        } else {
+            let parts: Vec<String> = tool_result
+                .counts
+                .iter()
+                .map(|(k, v)| format!("{v} {k}"))
+                .collect();
+            format!(" ({})", parts.join(", "))
+        };
+
+        let noun_label = format!("{}:", tool_result.item_noun);
+        writeln!(
+            out,
+            "  {noun_label:<14} {:>3} scanned{counts_str}",
+            tool_result.total,
+        )?;
+    }
+
+    if !result.tools_missing.is_empty() {
+        writeln!(out)?;
+        writeln!(out, "  not installed: {}", result.tools_missing.join(", "))?;
+    }
+
+    if verbose {
+        writeln!(out)?;
+        for name in &result.tools_found {
+            writeln!(out, "  found: {name}")?;
+        }
+    }
+
+    writeln!(out, "\nRun individual tools for details.")?;
+
+    Ok(())
+}
+
+/// Write JSON audit output.
+pub fn write_json(out: &mut dyn Write, result: &AuditResult) -> std::io::Result<()> {
+    let json = serde_json::to_string_pretty(result).map_err(std::io::Error::other)?;
+    writeln!(out, "{json}")
+}
+
+/// Write porcelain (tab-delimited) audit output.
+///
+/// Format: `tool_name\titem_noun\ttotal\tcounts_json\terror`
+pub fn write_porcelain(out: &mut dyn Write, result: &AuditResult) -> std::io::Result<()> {
+    for tool_result in &result.results {
+        let counts_json =
+            serde_json::to_string(&tool_result.counts).map_err(std::io::Error::other)?;
+        let error = tool_result.error.as_deref().unwrap_or("");
+
+        writeln!(
+            out,
+            "{}\t{}\t{}\t{counts_json}\t{error}",
+            tool_result.name, tool_result.item_noun, tool_result.total,
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::types::{AuditResult, ToolResult};
+
+    fn make_audit_result() -> AuditResult {
+        AuditResult {
+            directory: PathBuf::from("/tmp/dev"),
+            tools_found: vec![
+                "git-worktree-tidy".to_string(),
+                "git-branch-tidy".to_string(),
+            ],
+            tools_missing: vec!["git-repo-tidy".to_string()],
+            results: vec![
+                ToolResult {
+                    name: "git-worktree-tidy".to_string(),
+                    item_noun: "worktrees".to_string(),
+                    total: 8,
+                    counts: BTreeMap::from([
+                        ("active".to_string(), 5),
+                        ("landed".to_string(), 2),
+                        ("merged".to_string(), 1),
+                    ]),
+                    error: None,
+                },
+                ToolResult {
+                    name: "git-branch-tidy".to_string(),
+                    item_noun: "branches".to_string(),
+                    total: 3,
+                    counts: BTreeMap::from([("active".to_string(), 2), ("merged".to_string(), 1)]),
+                    error: None,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn human_output_basic() {
+        let result = make_audit_result();
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result, false).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("git-tidy audit: /tmp/dev"));
+        assert!(output.contains("worktrees:       8 scanned (5 active, 2 landed, 1 merged)"));
+        assert!(output.contains("branches:        3 scanned (2 active, 1 merged)"));
+        assert!(output.contains("not installed: git-repo-tidy"));
+        assert!(output.contains("Run individual tools for details."));
+    }
+
+    #[test]
+    fn human_output_verbose_shows_found() {
+        let result = make_audit_result();
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result, true).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("found: git-worktree-tidy"));
+        assert!(output.contains("found: git-branch-tidy"));
+    }
+
+    #[test]
+    fn human_output_not_verbose_hides_found() {
+        let result = make_audit_result();
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result, false).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(!output.contains("found:"));
+    }
+
+    #[test]
+    fn human_output_with_error() {
+        let result = AuditResult {
+            directory: PathBuf::from("/tmp"),
+            tools_found: vec!["git-branch-tidy".to_string()],
+            tools_missing: vec![],
+            results: vec![ToolResult {
+                name: "git-branch-tidy".to_string(),
+                item_noun: "branches".to_string(),
+                total: 0,
+                counts: BTreeMap::new(),
+                error: Some("process failed".to_string()),
+            }],
+        };
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result, false).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("branches:      error: process failed"));
+    }
+
+    #[test]
+    fn human_output_no_missing() {
+        let mut result = make_audit_result();
+        result.tools_missing.clear();
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result, false).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(!output.contains("not installed"));
+    }
+
+    #[test]
+    fn json_output_valid() {
+        let result = make_audit_result();
+        let mut buf = Vec::new();
+        write_json(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed["directory"], "/tmp/dev");
+        assert_eq!(parsed["tools_found"][0], "git-worktree-tidy");
+        assert_eq!(parsed["tools_missing"][0], "git-repo-tidy");
+        assert_eq!(parsed["results"][0]["total"], 8);
+        assert_eq!(parsed["results"][0]["counts"]["active"], 5);
+        assert!(parsed["results"][0]["error"].is_null());
+    }
+
+    #[test]
+    fn porcelain_output_format() {
+        let result = make_audit_result();
+        let mut buf = Vec::new();
+        write_porcelain(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines.len(), 2);
+
+        let fields: Vec<&str> = lines[0].split('\t').collect();
+        assert_eq!(fields.len(), 5);
+        assert_eq!(fields[0], "git-worktree-tidy");
+        assert_eq!(fields[1], "worktrees");
+        assert_eq!(fields[2], "8");
+        // Counts are sorted (BTreeMap): active, landed, merged
+        let counts: serde_json::Value = serde_json::from_str(fields[3]).unwrap();
+        assert_eq!(counts["active"], 5);
+        assert_eq!(counts["landed"], 2);
+        assert_eq!(counts["merged"], 1);
+        assert_eq!(fields[4], ""); // no error
+    }
+
+    #[test]
+    fn porcelain_output_with_error() {
+        let result = AuditResult {
+            directory: PathBuf::from("/tmp"),
+            tools_found: vec!["git-branch-tidy".to_string()],
+            tools_missing: vec![],
+            results: vec![ToolResult {
+                name: "git-branch-tidy".to_string(),
+                item_noun: "branches".to_string(),
+                total: 0,
+                counts: BTreeMap::new(),
+                error: Some("failed".to_string()),
+            }],
+        };
+        let mut buf = Vec::new();
+        write_porcelain(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        let fields: Vec<&str> = output.lines().next().unwrap().split('\t').collect();
+        assert_eq!(fields[4], "failed");
+    }
+}

--- a/crates/git-tidy/src/runner.rs
+++ b/crates/git-tidy/src/runner.rs
@@ -1,0 +1,391 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::types::{AuditResult, TOOL_SPECS, ToolResult, ToolSpec};
+
+/// Abstraction for finding and running git-tidy sub-tools.
+pub trait ToolRunner {
+    /// Check if a binary is available, returning its path.
+    fn find_tool(&self, binary: &str) -> Option<PathBuf>;
+    /// Run a tool's scan/lint command and return its stdout as a string.
+    fn run_tool(&self, path: &Path, scan_cmd: &str, directory: &Path) -> Result<String, String>;
+}
+
+/// Real implementation that uses `which` and `std::process::Command`.
+pub struct RealToolRunner;
+
+impl ToolRunner for RealToolRunner {
+    fn find_tool(&self, binary: &str) -> Option<PathBuf> {
+        which::which(binary).ok()
+    }
+
+    fn run_tool(&self, path: &Path, scan_cmd: &str, directory: &Path) -> Result<String, String> {
+        let output = Command::new(path)
+            .arg(scan_cmd)
+            .arg("--json")
+            .arg(directory)
+            .output()
+            .map_err(|e| format!("failed to execute {}: {e}", path.display()))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!(
+                "{} exited with {}: {}",
+                path.display(),
+                output.status,
+                stderr.trim()
+            ));
+        }
+
+        String::from_utf8(output.stdout)
+            .map_err(|e| format!("invalid UTF-8 from {}: {e}", path.display()))
+    }
+}
+
+/// Parse a JSON array from a tool's output and count items by a given field.
+pub fn parse_tool_output(
+    json_str: &str,
+    count_field: &str,
+) -> Result<(usize, BTreeMap<String, usize>), String> {
+    let value: serde_json::Value =
+        serde_json::from_str(json_str).map_err(|e| format!("invalid JSON: {e}"))?;
+
+    let array = value
+        .as_array()
+        .ok_or_else(|| "expected JSON array".to_string())?;
+
+    let mut counts = BTreeMap::new();
+    for item in array {
+        if let Some(field_value) = item.get(count_field).and_then(|v| v.as_str()) {
+            *counts.entry(field_value.to_string()).or_insert(0) += 1;
+        }
+    }
+
+    Ok((array.len(), counts))
+}
+
+/// Check whether a tool name matches a filter entry.
+///
+/// Accepts both full binary names ("git-branch-tidy") and short names ("branch-tidy",
+/// "branch", "worktree").
+fn matches_filter(binary: &str, filter_entry: &str) -> bool {
+    if binary == filter_entry {
+        return true;
+    }
+    // Strip "git-" prefix from binary for short-name matching
+    let short = binary.strip_prefix("git-").unwrap_or(binary);
+    if short == filter_entry {
+        return true;
+    }
+    // Also allow just the tool word (e.g., "branch" matches "git-branch-tidy")
+    let tool_word = short.strip_suffix("-tidy").unwrap_or(short);
+    tool_word == filter_entry
+}
+
+/// Run an audit across all known git-tidy tools.
+pub fn run_audit(
+    runner: &dyn ToolRunner,
+    directory: &Path,
+    tool_filter: Option<&[String]>,
+) -> AuditResult {
+    let mut tools_found = Vec::new();
+    let mut tools_missing = Vec::new();
+    let mut results = Vec::new();
+
+    for spec in TOOL_SPECS {
+        // Apply filter if set
+        if let Some(filter) = tool_filter
+            && !filter.iter().any(|f| matches_filter(spec.binary, f))
+        {
+            continue;
+        }
+
+        let Some(path) = runner.find_tool(spec.binary) else {
+            tools_missing.push(spec.binary.to_string());
+            continue;
+        };
+
+        tools_found.push(spec.binary.to_string());
+
+        let result = match runner.run_tool(&path, spec.scan_command, directory) {
+            Ok(output) => match parse_tool_output(&output, spec.count_field) {
+                Ok((total, counts)) => make_tool_result(spec, total, counts, None),
+                Err(e) => make_tool_result(spec, 0, BTreeMap::new(), Some(e)),
+            },
+            Err(e) => make_tool_result(spec, 0, BTreeMap::new(), Some(e)),
+        };
+
+        results.push(result);
+    }
+
+    AuditResult {
+        directory: directory.to_path_buf(),
+        tools_found,
+        tools_missing,
+        results,
+    }
+}
+
+fn make_tool_result(
+    spec: &ToolSpec,
+    total: usize,
+    counts: BTreeMap<String, usize>,
+    error: Option<String>,
+) -> ToolResult {
+    ToolResult {
+        name: spec.binary.to_string(),
+        item_noun: spec.item_noun.to_string(),
+        total,
+        counts,
+        error,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- parse_tool_output tests --
+
+    #[test]
+    fn parse_classification_field() {
+        let json = r#"[
+            {"name": "a", "classification": "merged"},
+            {"name": "b", "classification": "active"},
+            {"name": "c", "classification": "merged"},
+            {"name": "d", "classification": "landed"}
+        ]"#;
+
+        let (total, counts) = parse_tool_output(json, "classification").unwrap();
+        assert_eq!(total, 4);
+        assert_eq!(counts["merged"], 2);
+        assert_eq!(counts["active"], 1);
+        assert_eq!(counts["landed"], 1);
+    }
+
+    #[test]
+    fn parse_kind_field() {
+        let json = r#"[
+            {"kind": "orphaned_branch_config", "severity": "warning"},
+            {"kind": "alias_shadows_builtin", "severity": "error"},
+            {"kind": "orphaned_branch_config", "severity": "warning"}
+        ]"#;
+
+        let (total, counts) = parse_tool_output(json, "kind").unwrap();
+        assert_eq!(total, 3);
+        assert_eq!(counts["orphaned_branch_config"], 2);
+        assert_eq!(counts["alias_shadows_builtin"], 1);
+    }
+
+    #[test]
+    fn parse_empty_array() {
+        let (total, counts) = parse_tool_output("[]", "classification").unwrap();
+        assert_eq!(total, 0);
+        assert!(counts.is_empty());
+    }
+
+    #[test]
+    fn parse_invalid_json() {
+        let result = parse_tool_output("not json", "classification");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("invalid JSON"));
+    }
+
+    #[test]
+    fn parse_non_array_json() {
+        let result = parse_tool_output(r#"{"key": "value"}"#, "classification");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("expected JSON array"));
+    }
+
+    #[test]
+    fn parse_items_missing_field() {
+        let json = r#"[
+            {"name": "a", "classification": "active"},
+            {"name": "b"}
+        ]"#;
+        let (total, counts) = parse_tool_output(json, "classification").unwrap();
+        assert_eq!(total, 2);
+        assert_eq!(counts["active"], 1);
+        assert_eq!(counts.len(), 1);
+    }
+
+    // -- matches_filter tests --
+
+    #[test]
+    fn filter_full_name() {
+        assert!(matches_filter("git-branch-tidy", "git-branch-tidy"));
+    }
+
+    #[test]
+    fn filter_short_name() {
+        assert!(matches_filter("git-branch-tidy", "branch-tidy"));
+    }
+
+    #[test]
+    fn filter_tool_word() {
+        assert!(matches_filter("git-branch-tidy", "branch"));
+        assert!(matches_filter("git-worktree-tidy", "worktree"));
+        assert!(matches_filter("git-config-tidy", "config"));
+    }
+
+    #[test]
+    fn filter_no_match() {
+        assert!(!matches_filter("git-branch-tidy", "tag"));
+        assert!(!matches_filter("git-branch-tidy", "git-tag-tidy"));
+    }
+
+    // -- MockToolRunner and run_audit tests --
+
+    struct MockToolRunner {
+        tools: Vec<(String, Result<String, String>)>,
+    }
+
+    impl MockToolRunner {
+        fn new(tools: Vec<(&str, Result<&str, &str>)>) -> Self {
+            Self {
+                tools: tools
+                    .into_iter()
+                    .map(|(name, result)| {
+                        (
+                            name.to_string(),
+                            result.map(|s| s.to_string()).map_err(|s| s.to_string()),
+                        )
+                    })
+                    .collect(),
+            }
+        }
+    }
+
+    impl ToolRunner for MockToolRunner {
+        fn find_tool(&self, binary: &str) -> Option<PathBuf> {
+            self.tools
+                .iter()
+                .find(|(name, _)| name == binary)
+                .map(|_| PathBuf::from(format!("/usr/local/bin/{binary}")))
+        }
+
+        fn run_tool(
+            &self,
+            path: &Path,
+            _scan_cmd: &str,
+            _directory: &Path,
+        ) -> Result<String, String> {
+            let binary = path.file_name().unwrap().to_str().unwrap();
+            self.tools
+                .iter()
+                .find(|(name, _)| name == binary)
+                .map(|(_, result)| result.clone())
+                .unwrap_or_else(|| Err("tool not found".to_string()))
+        }
+    }
+
+    #[test]
+    fn audit_all_tools_found() {
+        let runner = MockToolRunner::new(vec![
+            (
+                "git-worktree-tidy",
+                Ok(r#"[{"classification":"active"},{"classification":"merged"}]"#),
+            ),
+            ("git-branch-tidy", Ok(r#"[{"classification":"landed"}]"#)),
+            ("git-stash-tidy", Ok("[]")),
+            ("git-remote-tidy", Ok("[]")),
+            ("git-tag-tidy", Ok("[]")),
+            ("git-repo-tidy", Ok("[]")),
+            (
+                "git-config-tidy",
+                Ok(r#"[{"kind":"alias_shadows_builtin"}]"#),
+            ),
+            ("git-lfs-tidy", Ok("[]")),
+        ]);
+
+        let result = run_audit(&runner, Path::new("/dev"), None);
+        assert_eq!(result.tools_found.len(), 8);
+        assert!(result.tools_missing.is_empty());
+        assert_eq!(result.results.len(), 8);
+
+        let wt = &result.results[0];
+        assert_eq!(wt.name, "git-worktree-tidy");
+        assert_eq!(wt.total, 2);
+        assert_eq!(wt.counts["active"], 1);
+        assert_eq!(wt.counts["merged"], 1);
+        assert!(wt.error.is_none());
+
+        let config = &result.results[6];
+        assert_eq!(config.name, "git-config-tidy");
+        assert_eq!(config.total, 1);
+        assert_eq!(config.counts["alias_shadows_builtin"], 1);
+    }
+
+    #[test]
+    fn audit_some_tools_missing() {
+        let runner = MockToolRunner::new(vec![(
+            "git-branch-tidy",
+            Ok(r#"[{"classification":"active"}]"#),
+        )]);
+
+        let result = run_audit(&runner, Path::new("/dev"), None);
+        assert_eq!(result.tools_found, vec!["git-branch-tidy"]);
+        assert!(
+            result
+                .tools_missing
+                .contains(&"git-worktree-tidy".to_string())
+        );
+        assert!(result.tools_missing.contains(&"git-repo-tidy".to_string()));
+        assert_eq!(result.results.len(), 1);
+    }
+
+    #[test]
+    fn audit_tool_returns_error() {
+        let runner = MockToolRunner::new(vec![("git-branch-tidy", Err("process failed"))]);
+
+        let result = run_audit(&runner, Path::new("/dev"), None);
+        assert_eq!(result.results.len(), 1);
+        assert_eq!(result.results[0].error.as_deref(), Some("process failed"));
+        assert_eq!(result.results[0].total, 0);
+    }
+
+    #[test]
+    fn audit_tool_returns_invalid_json() {
+        let runner = MockToolRunner::new(vec![("git-branch-tidy", Ok("not json"))]);
+
+        let result = run_audit(&runner, Path::new("/dev"), None);
+        assert_eq!(result.results.len(), 1);
+        assert!(result.results[0].error.is_some());
+        assert!(
+            result.results[0]
+                .error
+                .as_ref()
+                .unwrap()
+                .contains("invalid JSON")
+        );
+    }
+
+    #[test]
+    fn audit_with_filter() {
+        let runner = MockToolRunner::new(vec![
+            ("git-worktree-tidy", Ok("[]")),
+            ("git-branch-tidy", Ok(r#"[{"classification":"active"}]"#)),
+            ("git-tag-tidy", Ok("[]")),
+        ]);
+
+        let filter = vec!["branch".to_string(), "tag".to_string()];
+        let result = run_audit(&runner, Path::new("/dev"), Some(&filter));
+
+        // Only branch and tag should be checked
+        assert_eq!(result.tools_found, vec!["git-branch-tidy", "git-tag-tidy"]);
+        assert!(result.tools_missing.is_empty());
+        assert_eq!(result.results.len(), 2);
+    }
+
+    #[test]
+    fn audit_no_tools_found() {
+        let runner = MockToolRunner::new(vec![]);
+
+        let result = run_audit(&runner, Path::new("/dev"), None);
+        assert!(result.tools_found.is_empty());
+        assert_eq!(result.tools_missing.len(), 8);
+        assert!(result.results.is_empty());
+    }
+}

--- a/crates/git-tidy/src/types.rs
+++ b/crates/git-tidy/src/types.rs
@@ -1,0 +1,179 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+/// Metadata for a known git-tidy sub-tool.
+pub struct ToolSpec {
+    /// Binary name (e.g., "git-worktree-tidy").
+    pub binary: &'static str,
+    /// Noun describing items scanned (e.g., "worktrees").
+    pub item_noun: &'static str,
+    /// Subcommand to run for scanning (e.g., "scan" or "lint").
+    pub scan_command: &'static str,
+    /// JSON field to count by (e.g., "classification" or "kind").
+    pub count_field: &'static str,
+}
+
+/// All known git-tidy sub-tools.
+pub static TOOL_SPECS: &[ToolSpec] = &[
+    ToolSpec {
+        binary: "git-worktree-tidy",
+        item_noun: "worktrees",
+        scan_command: "scan",
+        count_field: "classification",
+    },
+    ToolSpec {
+        binary: "git-branch-tidy",
+        item_noun: "branches",
+        scan_command: "scan",
+        count_field: "classification",
+    },
+    ToolSpec {
+        binary: "git-stash-tidy",
+        item_noun: "stashes",
+        scan_command: "scan",
+        count_field: "classification",
+    },
+    ToolSpec {
+        binary: "git-remote-tidy",
+        item_noun: "remotes",
+        scan_command: "scan",
+        count_field: "classification",
+    },
+    ToolSpec {
+        binary: "git-tag-tidy",
+        item_noun: "tags",
+        scan_command: "scan",
+        count_field: "classification",
+    },
+    ToolSpec {
+        binary: "git-repo-tidy",
+        item_noun: "repos",
+        scan_command: "scan",
+        count_field: "classification",
+    },
+    ToolSpec {
+        binary: "git-config-tidy",
+        item_noun: "config issues",
+        scan_command: "lint",
+        count_field: "kind",
+    },
+    ToolSpec {
+        binary: "git-lfs-tidy",
+        item_noun: "LFS files",
+        scan_command: "scan",
+        count_field: "classification",
+    },
+];
+
+/// Result from running a single tool.
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolResult {
+    /// Binary name (e.g., "git-worktree-tidy").
+    pub name: String,
+    /// Noun describing items (e.g., "worktrees").
+    pub item_noun: String,
+    /// Total items found.
+    pub total: usize,
+    /// Counts by classification/kind (sorted by key).
+    pub counts: BTreeMap<String, usize>,
+    /// Error message if the tool failed.
+    pub error: Option<String>,
+}
+
+/// Consolidated result of an audit run.
+#[derive(Debug, Clone, Serialize)]
+pub struct AuditResult {
+    /// Directory that was scanned.
+    pub directory: PathBuf,
+    /// Names of installed tools.
+    pub tools_found: Vec<String>,
+    /// Names of tools not found on PATH.
+    pub tools_missing: Vec<String>,
+    /// Per-tool results.
+    pub results: Vec<ToolResult>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_specs_count() {
+        assert_eq!(TOOL_SPECS.len(), 8);
+    }
+
+    #[test]
+    fn tool_specs_binary_names() {
+        let names: Vec<&str> = TOOL_SPECS.iter().map(|s| s.binary).collect();
+        assert_eq!(
+            names,
+            [
+                "git-worktree-tidy",
+                "git-branch-tidy",
+                "git-stash-tidy",
+                "git-remote-tidy",
+                "git-tag-tidy",
+                "git-repo-tidy",
+                "git-config-tidy",
+                "git-lfs-tidy",
+            ]
+        );
+    }
+
+    #[test]
+    fn tool_specs_config_uses_lint_and_kind() {
+        let config = TOOL_SPECS
+            .iter()
+            .find(|s| s.binary == "git-config-tidy")
+            .unwrap();
+        assert_eq!(config.scan_command, "lint");
+        assert_eq!(config.count_field, "kind");
+    }
+
+    #[test]
+    fn tool_specs_others_use_scan_and_classification() {
+        for spec in TOOL_SPECS.iter().filter(|s| s.binary != "git-config-tidy") {
+            assert_eq!(
+                spec.scan_command, "scan",
+                "expected scan for {}",
+                spec.binary
+            );
+            assert_eq!(
+                spec.count_field, "classification",
+                "expected classification for {}",
+                spec.binary
+            );
+        }
+    }
+
+    #[test]
+    fn tool_result_serializes() {
+        let result = ToolResult {
+            name: "git-branch-tidy".to_string(),
+            item_noun: "branches".to_string(),
+            total: 5,
+            counts: BTreeMap::from([("active".to_string(), 3), ("merged".to_string(), 2)]),
+            error: None,
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["total"], 5);
+        assert_eq!(json["counts"]["active"], 3);
+        assert!(json["error"].is_null());
+    }
+
+    #[test]
+    fn audit_result_serializes() {
+        let result = AuditResult {
+            directory: PathBuf::from("/tmp/dev"),
+            tools_found: vec!["git-branch-tidy".to_string()],
+            tools_missing: vec!["git-repo-tidy".to_string()],
+            results: vec![],
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["directory"], "/tmp/dev");
+        assert_eq!(json["tools_found"][0], "git-branch-tidy");
+        assert_eq!(json["tools_missing"][0], "git-repo-tidy");
+    }
+}

--- a/crates/git-tidy/tests/integration.rs
+++ b/crates/git-tidy/tests/integration.rs
@@ -1,0 +1,180 @@
+use std::path::{Path, PathBuf};
+
+use git_tidy::runner::{ToolRunner, run_audit};
+
+/// A test runner that simulates installed tools with canned responses.
+struct FakeToolRunner {
+    available: Vec<(String, String)>, // (binary, json_output)
+}
+
+impl FakeToolRunner {
+    fn new(tools: Vec<(&str, &str)>) -> Self {
+        Self {
+            available: tools
+                .into_iter()
+                .map(|(name, output)| (name.to_string(), output.to_string()))
+                .collect(),
+        }
+    }
+}
+
+impl ToolRunner for FakeToolRunner {
+    fn find_tool(&self, binary: &str) -> Option<PathBuf> {
+        self.available
+            .iter()
+            .find(|(name, _)| name == binary)
+            .map(|_| PathBuf::from(format!("/fake/bin/{binary}")))
+    }
+
+    fn run_tool(&self, path: &Path, _scan_cmd: &str, _directory: &Path) -> Result<String, String> {
+        let binary = path.file_name().unwrap().to_str().unwrap();
+        self.available
+            .iter()
+            .find(|(name, _)| name == binary)
+            .map(|(_, output)| Ok(output.clone()))
+            .unwrap_or(Err("not found".to_string()))
+    }
+}
+
+#[test]
+fn full_audit_multiple_tools() {
+    let runner = FakeToolRunner::new(vec![
+        (
+            "git-worktree-tidy",
+            r#"[
+                {"classification":"active","name":"a"},
+                {"classification":"merged","name":"b"},
+                {"classification":"active","name":"c"}
+            ]"#,
+        ),
+        (
+            "git-branch-tidy",
+            r#"[
+                {"classification":"landed","name":"feature"},
+                {"classification":"active","name":"main"}
+            ]"#,
+        ),
+        (
+            "git-config-tidy",
+            r#"[
+                {"kind":"orphaned_branch_config","severity":"warning"},
+                {"kind":"alias_shadows_builtin","severity":"error"}
+            ]"#,
+        ),
+    ]);
+
+    let result = run_audit(&runner, Path::new("/tmp/test"), None);
+
+    // Check found/missing
+    assert!(
+        result
+            .tools_found
+            .contains(&"git-worktree-tidy".to_string())
+    );
+    assert!(result.tools_found.contains(&"git-branch-tidy".to_string()));
+    assert!(result.tools_found.contains(&"git-config-tidy".to_string()));
+    assert!(result.tools_missing.contains(&"git-stash-tidy".to_string()));
+    assert!(result.tools_missing.contains(&"git-repo-tidy".to_string()));
+
+    // Worktree results
+    let wt = result
+        .results
+        .iter()
+        .find(|r| r.name == "git-worktree-tidy")
+        .unwrap();
+    assert_eq!(wt.total, 3);
+    assert_eq!(wt.counts["active"], 2);
+    assert_eq!(wt.counts["merged"], 1);
+    assert!(wt.error.is_none());
+
+    // Config results (uses "kind" field)
+    let cfg = result
+        .results
+        .iter()
+        .find(|r| r.name == "git-config-tidy")
+        .unwrap();
+    assert_eq!(cfg.total, 2);
+    assert_eq!(cfg.counts["orphaned_branch_config"], 1);
+    assert_eq!(cfg.counts["alias_shadows_builtin"], 1);
+}
+
+#[test]
+fn full_audit_json_roundtrip() {
+    let runner = FakeToolRunner::new(vec![(
+        "git-branch-tidy",
+        r#"[{"classification":"active"}]"#,
+    )]);
+
+    let result = run_audit(&runner, Path::new("/tmp/test"), None);
+
+    // Serialize to JSON and parse back
+    let mut buf = Vec::new();
+    git_tidy::output::write_json(&mut buf, &result).unwrap();
+    let json_str = String::from_utf8(buf).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(parsed["directory"], "/tmp/test");
+    assert!(!parsed["results"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn full_audit_porcelain_roundtrip() {
+    let runner = FakeToolRunner::new(vec![(
+        "git-branch-tidy",
+        r#"[{"classification":"active"},{"classification":"merged"}]"#,
+    )]);
+
+    let result = run_audit(&runner, Path::new("/tmp"), None);
+
+    let mut buf = Vec::new();
+    git_tidy::output::write_porcelain(&mut buf, &result).unwrap();
+    let output = String::from_utf8(buf).unwrap();
+
+    // Should have exactly 1 line (one tool result)
+    let lines: Vec<&str> = output.lines().collect();
+    assert_eq!(lines.len(), 1);
+
+    let fields: Vec<&str> = lines[0].split('\t').collect();
+    assert_eq!(fields[0], "git-branch-tidy");
+    assert_eq!(fields[1], "branches");
+    assert_eq!(fields[2], "2");
+}
+
+#[test]
+fn full_audit_human_output_end_to_end() {
+    let runner = FakeToolRunner::new(vec![(
+        "git-worktree-tidy",
+        r#"[{"classification":"active"},{"classification":"active"},{"classification":"merged"}]"#,
+    )]);
+
+    let result = run_audit(&runner, Path::new("/tmp/dev"), None);
+
+    let mut buf = Vec::new();
+    git_tidy::output::write_human(&mut buf, &result, false).unwrap();
+    let output = String::from_utf8(buf).unwrap();
+
+    assert!(output.contains("git-tidy audit:"));
+    assert!(output.contains("worktrees:"));
+    assert!(output.contains("3 scanned"));
+    assert!(output.contains("2 active"));
+    assert!(output.contains("1 merged"));
+    assert!(output.contains("not installed:"));
+    assert!(output.contains("Run individual tools for details."));
+}
+
+#[test]
+fn audit_filter_limits_tools() {
+    let runner = FakeToolRunner::new(vec![
+        ("git-worktree-tidy", "[]"),
+        ("git-branch-tidy", r#"[{"classification":"active"}]"#),
+        ("git-tag-tidy", "[]"),
+    ]);
+
+    let filter = vec!["branch".to_string()];
+    let result = run_audit(&runner, Path::new("/tmp"), Some(&filter));
+
+    assert_eq!(result.tools_found, vec!["git-branch-tidy"]);
+    assert!(result.tools_missing.is_empty());
+    assert_eq!(result.results.len(), 1);
+    assert_eq!(result.results[0].name, "git-branch-tidy");
+}

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-for crate in crates/git-*-tidy; do
-  name=$(basename "$crate")
-  echo "Installing $name..."
-  cargo install --path "$crate"
+for crate in crates/git-worktree-tidy crates/git-branch-tidy crates/git-stash-tidy \
+             crates/git-remote-tidy crates/git-tag-tidy crates/git-tidy; do
+  if [ -d "$crate" ]; then
+    name=$(basename "$crate")
+    echo "Installing $name..."
+    cargo install --path "$crate"
+  fi
 done
 
 echo "All tools installed."


### PR DESCRIPTION
## Summary

- Adds `git-tidy` binary: a meta-runner that discovers installed `git-*-tidy` tools, runs each with `scan --json`, and produces a consolidated summary
- Works with whatever subset of tools is installed (missing tools listed in output)
- No dependency on `git-tidy-core` -- treats sub-tools as black-box processes
- 43 tests (38 unit + 5 integration)

Closes #44

## Test plan

- [x] `cargo test -p git-tidy` -- 43 tests pass
- [x] `cargo clippy -p git-tidy --all-targets -- -D clippy::all` -- no errors
- [x] `cargo fmt --check` -- clean
- [ ] CI passes
- [ ] Smoke test with installed tools: `cargo install --path crates/git-tidy && git-tidy ~/Developer`