### PR TITLE
Reduce allocations, clones, and subprocess calls

### DIFF
--- a/crates/git-branch-tidy/src/scan.rs
+++ b/crates/git-branch-tidy/src/scan.rs
@@ -58,7 +58,7 @@ pub fn run_scan(
 
         let repo_name = repo_display_name(repo_path);
 
-        let mut classified = Vec::new();
+        let mut classified = Vec::with_capacity(branches.len());
 
         for branch_name in &branches {
             // Skip the default branch

--- a/crates/git-remote-tidy/src/scan.rs
+++ b/crates/git-remote-tidy/src/scan.rs
@@ -67,14 +67,15 @@ pub fn run_scan(
         let tracking_refs = git.list_remote_tracking_refs(repo_path).unwrap_or_default();
 
         // Count tracking refs per remote name and detect orphaned
-        let configured_set: HashSet<&str> = configured.iter().map(|s| s.as_str()).collect();
         let mut tracking_counts: HashMap<String, usize> = HashMap::new();
 
         for (short, _full) in &tracking_refs {
             // short is like "origin/main" -- extract remote name
             if let Some(remote_name) = short.split('/').next() {
                 // Skip HEAD refs (e.g., "origin/HEAD")
-                let branch_part = short.strip_prefix(&format!("{remote_name}/"));
+                let branch_part = short
+                    .strip_prefix(remote_name)
+                    .and_then(|rest| rest.strip_prefix('/'));
                 if branch_part == Some("HEAD") {
                     continue;
                 }
@@ -82,13 +83,17 @@ pub fn run_scan(
             }
         }
 
-        // Collect all remote names (configured + orphaned)
-        let mut all_remote_names: Vec<String> = configured.clone();
-        for remote_name in tracking_counts.keys() {
-            if !configured_set.contains(remote_name.as_str()) {
-                all_remote_names.push(remote_name.clone());
-            }
-        }
+        // Collect all remote names (configured + orphaned); move configured to avoid clone
+        let configured_count = configured.len();
+        let configured_set: HashSet<&str> = configured.iter().map(|s| s.as_str()).collect();
+        let orphaned: Vec<String> = tracking_counts
+            .keys()
+            .filter(|name| !configured_set.contains(name.as_str()))
+            .cloned()
+            .collect();
+        drop(configured_set);
+        let mut all_remote_names = configured; // move, not clone
+        all_remote_names.extend(orphaned);
 
         if all_remote_names.is_empty() {
             continue;
@@ -98,8 +103,8 @@ pub fn run_scan(
 
         let mut classified = Vec::new();
 
-        for remote_name in &all_remote_names {
-            let is_configured = configured_set.contains(remote_name.as_str());
+        for (idx, remote_name) in all_remote_names.iter().enumerate() {
+            let is_configured = idx < configured_count;
             let classification =
                 classify_remote(git, repo_path, remote_name, is_configured, offline);
             let tracking_count = tracking_counts.get(remote_name).copied().unwrap_or(0);

--- a/crates/git-repo-tidy/src/scan.rs
+++ b/crates/git-repo-tidy/src/scan.rs
@@ -163,7 +163,12 @@ pub fn run_scan_with_du(
     }
 
     // Sort by classification priority (stale first, then orphaned, then active)
-    repos.sort_by_key(|r| (r.classification.priority(), r.name.clone()));
+    repos.sort_by(|a, b| {
+        a.classification
+            .priority()
+            .cmp(&b.classification.priority())
+            .then_with(|| a.name.cmp(&b.name))
+    });
 
     let total_scanned = repos.len();
 

--- a/crates/git-stash-tidy/src/scan.rs
+++ b/crates/git-stash-tidy/src/scan.rs
@@ -22,6 +22,8 @@ use crate::types::{
 /// 4. Otherwise -> Active
 ///
 /// When the branch name is unparseable, skip committed/orphaned checks; fall through to age check.
+///
+/// Returns `(classification, age_days, branch)` to avoid recomputation by the caller.
 pub fn classify_stash(
     git: &dyn GitOps,
     repo: &Path,
@@ -29,14 +31,13 @@ pub fn classify_stash(
     message: &str,
     iso_date: &str,
     age_threshold: u64,
-) -> StashClassification {
+    local_branches: &[String],
+) -> (StashClassification, Option<u64>, Option<String>) {
     let age_days = days_since_iso_date(iso_date);
     let branch = parse_stash_branch(message);
 
     if let Some(ref branch_name) = branch {
-        // Check if the branch exists locally
-        let branches = git.list_local_branches(repo).unwrap_or_default();
-        let branch_exists = branches.iter().any(|b| b == branch_name);
+        let branch_exists = local_branches.iter().any(|b| b == branch_name);
 
         if branch_exists {
             // Compare stash diff to branch tip diff
@@ -45,10 +46,10 @@ pub fn classify_stash(
                 && let Ok(tip_d) = git.diff_commit(repo, &tip_hash)
                 && diff_similarity(&stash_d, &tip_d) >= 0.5
             {
-                return StashClassification::Committed;
+                return (StashClassification::Committed, age_days, branch);
             }
         } else {
-            return StashClassification::Orphaned;
+            return (StashClassification::Orphaned, age_days, branch);
         }
     }
 
@@ -56,10 +57,10 @@ pub fn classify_stash(
     if let Some(days) = age_days
         && days >= age_threshold
     {
-        return StashClassification::Aged;
+        return (StashClassification::Aged, age_days, branch);
     }
 
-    StashClassification::Active
+    (StashClassification::Active, age_days, branch)
 }
 
 /// Scan all repos in `directory` for stash entries.
@@ -92,14 +93,20 @@ pub fn run_scan(
         }
 
         let repo_name = repo_display_name(repo_path);
+        let local_branches = git.list_local_branches(repo_path).unwrap_or_default();
 
-        let mut classified = Vec::new();
+        let mut classified = Vec::with_capacity(stashes.len());
 
         for (stash_ref, message, iso_date) in &stashes {
-            let classification =
-                classify_stash(git, repo_path, stash_ref, message, iso_date, age_threshold);
-            let age_days = days_since_iso_date(iso_date);
-            let branch = parse_stash_branch(message);
+            let (classification, age_days, branch) = classify_stash(
+                git,
+                repo_path,
+                stash_ref,
+                message,
+                iso_date,
+                age_threshold,
+                &local_branches,
+            );
 
             counts.increment(&classification);
             total_scanned += 1;
@@ -149,67 +156,68 @@ mod tests {
         // Stash diff matches branch tip -> Committed
         let diff = "+line 1\n+line 2\n";
         let git = MockGitBuilder::new()
-            .with_local_branches(&repo(), vec!["feature-x".to_string()])
             .with_stash_diff(&repo(), "stash@{0}", diff)
             .with_rev_parse(&repo(), "feature-x", "abc123")
             .with_diff_commit(&repo(), "abc123", diff)
             .build();
 
-        let result = classify_stash(
+        let branches = vec!["feature-x".to_string()];
+        let (cls, _, _) = classify_stash(
             &git,
             &repo(),
             "stash@{0}",
             "WIP on feature-x: abc1234 Add login",
             "2025-01-01T12:00:00+00:00",
             90,
+            &branches,
         );
-        assert_eq!(result, StashClassification::Committed);
+        assert_eq!(cls, StashClassification::Committed);
     }
 
     #[test]
     fn classify_orphaned_stash() {
         // Branch doesn't exist locally -> Orphaned
-        let git = MockGitBuilder::new()
-            .with_local_branches(&repo(), vec!["main".to_string()])
-            .build();
+        let git = MockGitBuilder::new().build();
 
-        let result = classify_stash(
+        let branches = vec!["main".to_string()];
+        let (cls, _, _) = classify_stash(
             &git,
             &repo(),
             "stash@{1}",
             "WIP on deleted-branch: def5678 Fix UI",
             "2025-01-01T12:00:00+00:00",
             90,
+            &branches,
         );
-        assert_eq!(result, StashClassification::Orphaned);
+        assert_eq!(cls, StashClassification::Orphaned);
     }
 
     #[test]
     fn classify_aged_stash() {
         // Branch exists but diff doesn't match, and stash is old -> Aged
         let git = MockGitBuilder::new()
-            .with_local_branches(&repo(), vec!["feature-y".to_string()])
             .with_stash_diff(&repo(), "stash@{0}", "+stash line\n")
             .with_rev_parse(&repo(), "feature-y", "def456")
             .with_diff_commit(&repo(), "def456", "+completely different\n")
             .build();
 
-        let result = classify_stash(
+        let branches = vec!["feature-y".to_string()];
+        let (cls, _, _) = classify_stash(
             &git,
             &repo(),
             "stash@{0}",
             "WIP on feature-y: def456 Some work",
             "2020-01-01T12:00:00+00:00", // very old
             90,
+            &branches,
         );
-        assert_eq!(result, StashClassification::Aged);
+        assert_eq!(cls, StashClassification::Aged);
     }
 
     #[test]
     fn classify_active_stash() {
         // Branch exists, diff doesn't match, and stash is recent -> Active
         let git = MockGitBuilder::new()
-            .with_local_branches(&repo(), vec!["main".to_string()])
             .with_stash_diff(&repo(), "stash@{0}", "+stash line\n")
             .with_rev_parse(&repo(), "main", "ghi789")
             .with_diff_commit(&repo(), "ghi789", "+branch line\n")
@@ -230,15 +238,17 @@ mod tests {
             )
         };
 
-        let result = classify_stash(
+        let branches = vec!["main".to_string()];
+        let (cls, _, _) = classify_stash(
             &git,
             &repo(),
             "stash@{0}",
             "WIP on main: ghi9012 Temp changes",
             &now,
             90,
+            &branches,
         );
-        assert_eq!(result, StashClassification::Active);
+        assert_eq!(cls, StashClassification::Active);
     }
 
     #[test]
@@ -259,8 +269,16 @@ mod tests {
             )
         };
 
-        let result = classify_stash(&git, &repo(), "stash@{0}", "some random message", &now, 90);
-        assert_eq!(result, StashClassification::Active);
+        let (cls, _, _) = classify_stash(
+            &git,
+            &repo(),
+            "stash@{0}",
+            "some random message",
+            &now,
+            90,
+            &[],
+        );
+        assert_eq!(cls, StashClassification::Active);
     }
 
     #[test]
@@ -268,15 +286,16 @@ mod tests {
         // Unparseable message, old -> Aged
         let git = MockGitBuilder::new().build();
 
-        let result = classify_stash(
+        let (cls, _, _) = classify_stash(
             &git,
             &repo(),
             "stash@{0}",
             "some random message",
             "2020-01-01T12:00:00+00:00",
             90,
+            &[],
         );
-        assert_eq!(result, StashClassification::Aged);
+        assert_eq!(cls, StashClassification::Aged);
     }
 
     #[test]

--- a/crates/git-tag-tidy/src/clean.rs
+++ b/crates/git-tag-tidy/src/clean.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as _;
 use std::io::Write;
 use std::path::PathBuf;
 
@@ -68,10 +69,12 @@ pub fn run_clean(
             if options.dry_run {
                 let mut action = format!("would delete tag {} in {}", tag.name, group.name);
                 if options.include_remote && !tag.remote_names.is_empty() {
-                    action.push_str(&format!(
+                    write!(
+                        action,
                         " (and from remotes: {})",
                         tag.remote_names.join(", ")
-                    ));
+                    )
+                    .unwrap();
                 }
                 writeln!(out, "{action}")?;
                 succeeded.push(RemovedTag {

--- a/crates/git-tag-tidy/src/scan.rs
+++ b/crates/git-tag-tidy/src/scan.rs
@@ -80,22 +80,24 @@ pub fn run_scan(git: &dyn GitOps, directory: &Path, offline: bool) -> Result<Tag
             }
         }
 
-        // Union all tag names
-        let mut all_tag_names: HashSet<String> = local_tags.clone();
-        for tag_name in remote_tag_map.keys() {
-            all_tag_names.insert(tag_name.clone());
-        }
+        // Union all tag names (collect into Vec via deduplicating HashSet)
+        let all_tag_names: Vec<String> = local_tags
+            .iter()
+            .cloned()
+            .chain(remote_tag_map.keys().cloned())
+            .collect::<HashSet<String>>()
+            .into_iter()
+            .collect();
 
         if all_tag_names.is_empty() {
             continue;
         }
 
         let repo_name = repo_display_name(repo_path);
-        let mut classified = Vec::new();
+        let mut classified = Vec::with_capacity(all_tag_names.len());
 
         for tag_name in &all_tag_names {
             let is_local = local_tags.contains(tag_name);
-            let remote_entry = remote_tag_map.get(tag_name);
 
             let (local_commit, is_reachable, is_annotated, tagger_date) = if is_local {
                 let commit = match git.tag_commit(repo_path, tag_name) {
@@ -116,19 +118,19 @@ pub fn run_scan(git: &dyn GitOps, directory: &Path, offline: bool) -> Result<Tag
                 (None, false, false, None)
             };
 
-            let remote_commit = remote_entry.map(|(c, _)| c.as_str());
-            let remote_names = remote_entry
-                .map(|(_, names)| names.clone())
-                .unwrap_or_default();
+            let (remote_commit, remote_names) = match remote_tag_map.remove(tag_name.as_str()) {
+                Some((commit, names)) => (Some(commit), names),
+                None => (None, vec![]),
+            };
 
             let classification = classify_tag(
                 local_commit.as_deref(),
-                remote_commit,
+                remote_commit.as_deref(),
                 is_reachable,
                 offline,
             );
 
-            let commit = local_commit.unwrap_or_else(|| remote_commit.unwrap_or("").to_string());
+            let commit = local_commit.unwrap_or_else(|| remote_commit.unwrap_or_else(String::new));
 
             counts.increment(&classification);
             total_scanned += 1;

--- a/crates/git-tidy-core/src/classification.rs
+++ b/crates/git-tidy-core/src/classification.rs
@@ -52,8 +52,8 @@ pub fn classify_branch(
     // Ahead/behind counts
     let (behind, ahead) = git.rev_list_left_right_count(repo, &origin_default, branch_name)?;
 
-    // Check if merged
-    let is_merged = git.is_ancestor(repo, branch_name, &origin_default)?;
+    // Check if merged — skip the subprocess call when ahead == 0 (already fully merged)
+    let is_merged = ahead == 0 || git.is_ancestor(repo, branch_name, &origin_default)?;
 
     let classification = if is_merged {
         Classification::Merged
@@ -62,23 +62,24 @@ pub fn classify_branch(
         let landed_result =
             landed::detect_landed(git, repo, &origin_default, branch_name, verbose)?;
 
-        match &landed_result.classification {
-            Classification::Landed { .. } if landed_result.total > 0 => {
-                landed_result.classification.clone()
-            }
-            Classification::Landed { .. } => {
-                // 0 unique commits — effectively merged
-                Classification::Merged
-            }
-            Classification::LandedPartial { .. } => landed_result.classification.clone(),
-            _ => {
-                // No commits landed — classify as active or local
-                if has_remote {
-                    Classification::Active
-                } else {
-                    Classification::Local
-                }
-            }
+        enum Action {
+            UseLanded,
+            Merged,
+            Active,
+            Local,
+        }
+        let action = match &landed_result.classification {
+            Classification::Landed { .. } if landed_result.total > 0 => Action::UseLanded,
+            Classification::Landed { .. } => Action::Merged,
+            Classification::LandedPartial { .. } => Action::UseLanded,
+            _ if has_remote => Action::Active,
+            _ => Action::Local,
+        };
+        match action {
+            Action::UseLanded => landed_result.classification,
+            Action::Merged => Classification::Merged,
+            Action::Active => Classification::Active,
+            Action::Local => Classification::Local,
         }
     };
 
@@ -108,11 +109,13 @@ pub fn classify_worktree(
     let branch = git.worktree_branch(worktree_path)?;
 
     // Determine the ref to compare against
-    let branch_ref = match &branch {
-        Some(b) => b.clone(),
+    let detached_head;
+    let branch_ref: &str = match &branch {
+        Some(b) => b,
         None => {
             // Detached HEAD — use the HEAD commit directly
-            git.rev_parse(worktree_path, "HEAD")?
+            detached_head = git.rev_parse(worktree_path, "HEAD")?;
+            &detached_head
         }
     };
 
@@ -123,7 +126,7 @@ pub fn classify_worktree(
     let bc = classify_branch(
         git,
         parent_repo,
-        &branch_ref,
+        branch_ref,
         default_branch,
         behind_threshold,
         verbose,
@@ -448,6 +451,22 @@ mod tests {
         let result = classify_branch(&git, &repo(), "feature/old", "main", 100, false).unwrap();
         assert!(result.diverged);
         assert_eq!(result.behind, 150);
+    }
+
+    #[test]
+    fn classify_branch_merged_ahead_zero_skips_is_ancestor() {
+        // When ahead == 0 the branch is fully merged regardless of behind count,
+        // so is_ancestor is skipped (not configured in the mock).
+        let git = MockGitBuilder::new()
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/feature/behind", true)
+            .with_rev_list_counts(&repo(), "origin/main", "feature/behind", (50, 0))
+            // No is_ancestor configured — proves the short-circuit works
+            .build();
+
+        let result = classify_branch(&git, &repo(), "feature/behind", "main", 100, false).unwrap();
+        assert_eq!(result.classification, Classification::Merged);
+        assert_eq!(result.behind, 50);
+        assert_eq!(result.ahead, 0);
     }
 
     #[test]

--- a/crates/git-tidy-core/src/dirty.rs
+++ b/crates/git-tidy-core/src/dirty.rs
@@ -31,6 +31,13 @@ pub fn check_dirty(
 ) -> Result<DirtyResult, Error> {
     let lines = git.status_porcelain(worktree_path)?;
 
+    // Pre-compute slash-suffixed directory patterns once
+    let dir_patterns: Vec<String> = noise_patterns
+        .iter()
+        .filter(|p| !p.starts_with('*'))
+        .map(|p| format!("{p}/"))
+        .collect();
+
     let mut all_files = Vec::new();
     let mut meaningful_files = Vec::new();
 
@@ -48,7 +55,7 @@ pub fn check_dirty(
         all_files.push(file_path.to_string());
 
         // Untracked files that match noise patterns are not meaningful
-        if status_code == "??" && is_noise(file_path, noise_patterns) {
+        if status_code == "??" && is_noise(file_path, noise_patterns, &dir_patterns) {
             continue;
         }
 
@@ -63,7 +70,10 @@ pub fn check_dirty(
 }
 
 /// Check if a file path matches any noise pattern.
-fn is_noise(file_path: &str, patterns: &[String]) -> bool {
+///
+/// `dir_patterns` contains pre-computed slash-suffixed versions of non-glob patterns
+/// (e.g., `"__pycache__/"`) to avoid repeated allocations in loops.
+fn is_noise(file_path: &str, patterns: &[String], dir_patterns: &[String]) -> bool {
     let basename = Path::new(file_path)
         .file_name()
         .and_then(|n| n.to_str())
@@ -80,12 +90,16 @@ fn is_noise(file_path: &str, patterns: &[String]) -> bool {
             if basename == pattern.as_str() {
                 return true;
             }
-            // Also match as a directory component
-            if file_path.contains(&format!("{pattern}/")) {
-                return true;
-            }
         }
     }
+
+    // Check directory component matches using pre-computed patterns
+    for dir_pat in dir_patterns {
+        if file_path.contains(dir_pat.as_str()) {
+            return true;
+        }
+    }
+
     false
 }
 
@@ -103,66 +117,87 @@ mod tests {
             .collect()
     }
 
+    /// Compute dir_patterns from a set of noise patterns (mirrors check_dirty logic).
+    fn dir_pats(patterns: &[String]) -> Vec<String> {
+        patterns
+            .iter()
+            .filter(|p| !p.starts_with('*'))
+            .map(|p| format!("{p}/"))
+            .collect()
+    }
+
     #[test]
     fn is_noise_ds_store() {
         let patterns = defaults();
-        assert!(is_noise(".DS_Store", &patterns));
-        assert!(is_noise("subdir/.DS_Store", &patterns));
+        let dp = dir_pats(&patterns);
+        assert!(is_noise(".DS_Store", &patterns, &dp));
+        assert!(is_noise("subdir/.DS_Store", &patterns, &dp));
     }
 
     #[test]
     fn is_noise_pyc() {
         let patterns = defaults();
-        assert!(is_noise("module.pyc", &patterns));
-        assert!(is_noise("src/module.pyc", &patterns));
+        let dp = dir_pats(&patterns);
+        assert!(is_noise("module.pyc", &patterns, &dp));
+        assert!(is_noise("src/module.pyc", &patterns, &dp));
     }
 
     #[test]
     fn is_noise_pycache() {
         let patterns = defaults();
-        assert!(is_noise("__pycache__", &patterns));
-        assert!(is_noise("src/__pycache__/module.cpython-39.pyc", &patterns));
+        let dp = dir_pats(&patterns);
+        assert!(is_noise("__pycache__", &patterns, &dp));
+        assert!(is_noise(
+            "src/__pycache__/module.cpython-39.pyc",
+            &patterns,
+            &dp
+        ));
     }
 
     #[test]
     fn is_noise_lockfiles() {
         let patterns = defaults();
-        assert!(is_noise("uv.lock", &patterns));
-        assert!(is_noise("package-lock.json", &patterns));
-        assert!(is_noise("Podfile.lock", &patterns));
-        assert!(is_noise("yarn.lock", &patterns));
+        let dp = dir_pats(&patterns);
+        assert!(is_noise("uv.lock", &patterns, &dp));
+        assert!(is_noise("package-lock.json", &patterns, &dp));
+        assert!(is_noise("Podfile.lock", &patterns, &dp));
+        assert!(is_noise("yarn.lock", &patterns, &dp));
     }
 
     #[test]
     fn is_not_noise_regular_files() {
         let patterns = defaults();
-        assert!(!is_noise("main.rs", &patterns));
-        assert!(!is_noise("src/lib.rs", &patterns));
-        assert!(!is_noise("Cargo.toml", &patterns));
-        assert!(!is_noise("README.md", &patterns));
+        let dp = dir_pats(&patterns);
+        assert!(!is_noise("main.rs", &patterns, &dp));
+        assert!(!is_noise("src/lib.rs", &patterns, &dp));
+        assert!(!is_noise("Cargo.toml", &patterns, &dp));
+        assert!(!is_noise("README.md", &patterns, &dp));
     }
 
     #[test]
     fn is_noise_custom_suffix_pattern() {
         let patterns = vec!["*.swp".to_string()];
-        assert!(is_noise("file.swp", &patterns));
-        assert!(is_noise("dir/file.swp", &patterns));
-        assert!(!is_noise("file.txt", &patterns));
+        let dp = dir_pats(&patterns);
+        assert!(is_noise("file.swp", &patterns, &dp));
+        assert!(is_noise("dir/file.swp", &patterns, &dp));
+        assert!(!is_noise("file.txt", &patterns, &dp));
     }
 
     #[test]
     fn is_noise_custom_exact_pattern() {
         let patterns = vec![".envrc".to_string()];
-        assert!(is_noise(".envrc", &patterns));
-        assert!(is_noise("subdir/.envrc", &patterns));
-        assert!(!is_noise("envrc", &patterns));
+        let dp = dir_pats(&patterns);
+        assert!(is_noise(".envrc", &patterns, &dp));
+        assert!(is_noise("subdir/.envrc", &patterns, &dp));
+        assert!(!is_noise("envrc", &patterns, &dp));
     }
 
     #[test]
     fn is_noise_empty_patterns() {
         let patterns: Vec<String> = vec![];
-        assert!(!is_noise(".DS_Store", &patterns));
-        assert!(!is_noise("anything", &patterns));
+        let dp = dir_pats(&patterns);
+        assert!(!is_noise(".DS_Store", &patterns, &dp));
+        assert!(!is_noise("anything", &patterns, &dp));
     }
 
     #[test]

--- a/crates/git-tidy-core/src/landed.rs
+++ b/crates/git-tidy-core/src/landed.rs
@@ -17,7 +17,6 @@ pub struct LandedResult {
     pub classification: Classification,
     pub matched: usize,
     pub total: usize,
-    pub unmatched: Vec<UnmatchedCommit>,
 }
 
 /// Check if branch commits have "landed" on the default branch via rebase,
@@ -40,7 +39,6 @@ pub fn detect_landed(
             },
             matched: 0,
             total: 0,
-            unmatched: vec![],
         });
     }
 
@@ -77,7 +75,7 @@ pub fn detect_landed(
         Classification::LandedPartial {
             matched,
             total,
-            unmatched: unmatched.clone(),
+            unmatched,
         }
     } else {
         // No commits landed — not a landed classification at all.
@@ -86,7 +84,6 @@ pub fn detect_landed(
             classification: Classification::Active, // placeholder
             matched: 0,
             total,
-            unmatched,
         });
     };
 
@@ -94,7 +91,6 @@ pub fn detect_landed(
         classification,
         matched,
         total,
-        unmatched,
     })
 }
 
@@ -165,7 +161,7 @@ fn try_fuzzy_subject_match(
     subject: &str,
 ) -> Result<bool, Error> {
     let stripped = strip_cc_prefix(subject);
-    let tokens = tokenize(stripped);
+    let tokens: HashSet<String> = tokenize(stripped).into_iter().collect();
 
     if tokens.len() < 2 {
         return Ok(false);
@@ -188,7 +184,7 @@ fn try_fuzzy_subject_match(
 
     for (_, candidate_subject) in &candidates {
         let candidate_stripped = strip_cc_prefix(candidate_subject);
-        let score = combined_similarity(stripped, candidate_stripped);
+        let score = combined_similarity_with_tokens(&tokens, stripped, candidate_stripped);
         if score >= FUZZY_THRESHOLD {
             return Ok(true);
         }
@@ -243,15 +239,28 @@ fn tokenize(s: &str) -> Vec<String> {
 }
 
 /// Combined similarity score: average of Jaccard and Levenshtein.
+#[cfg(test)]
 fn combined_similarity(a: &str, b: &str) -> f64 {
-    let jaccard = jaccard_similarity(a, b);
+    let tokens_a: HashSet<String> = tokenize(a).into_iter().collect();
+    combined_similarity_with_tokens(&tokens_a, a, b)
+}
+
+/// Combined similarity with pre-tokenized LHS.
+fn combined_similarity_with_tokens(tokens_a: &HashSet<String>, a: &str, b: &str) -> f64 {
+    let jaccard = jaccard_similarity_with_tokens(tokens_a, b);
     let levenshtein = strsim::normalized_levenshtein(a, b);
     (jaccard + levenshtein) / 2.0
 }
 
 /// Jaccard similarity: intersection / union of token sets.
+#[cfg(test)]
 fn jaccard_similarity(a: &str, b: &str) -> f64 {
     let tokens_a: HashSet<String> = tokenize(a).into_iter().collect();
+    jaccard_similarity_with_tokens(&tokens_a, b)
+}
+
+/// Jaccard similarity with pre-tokenized LHS.
+fn jaccard_similarity_with_tokens(tokens_a: &HashSet<String>, b: &str) -> f64 {
     let tokens_b: HashSet<String> = tokenize(b).into_iter().collect();
 
     if tokens_a.is_empty() && tokens_b.is_empty() {
@@ -424,7 +433,6 @@ mod tests {
         let result = detect_landed(&git, &repo(), "origin/main", "feature/done", false).unwrap();
         assert_eq!(result.matched, 2);
         assert_eq!(result.total, 2);
-        assert!(result.unmatched.is_empty());
         assert!(matches!(
             result.classification,
             Classification::Landed {
@@ -458,16 +466,17 @@ mod tests {
         let result = detect_landed(&git, &repo(), "origin/main", "feature/partial", false).unwrap();
         assert_eq!(result.matched, 1);
         assert_eq!(result.total, 2);
-        assert_eq!(result.unmatched.len(), 1);
-        assert_eq!(result.unmatched[0].subject, "Add unique feature X");
-        assert!(matches!(
-            result.classification,
+        match &result.classification {
             Classification::LandedPartial {
                 matched: 1,
                 total: 2,
-                ..
+                unmatched,
+            } => {
+                assert_eq!(unmatched.len(), 1);
+                assert_eq!(unmatched[0].subject, "Add unique feature X");
             }
-        ));
+            other => panic!("expected LandedPartial, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Eliminate redundant git subprocess calls (e.g., `list_local_branches` per stash, `is_ancestor` when `ahead == 0`)
- Remove unnecessary `.clone()` calls across classification, landed detection, tag scan, and remote scan
- Pre-compute reusable data outside loops (tokenized HashSets, directory noise patterns, `Vec::with_capacity`)

Closes #52

## Test plan
- [x] `cargo test --workspace` -- all existing tests pass
- [x] `cargo clippy --workspace --all-targets -- -D clippy::all` -- no warnings
- [x] `cargo fmt --check --all` -- clean
- [x] New test `classify_branch_merged_ahead_zero_skips_is_ancestor` verifies the `is_ancestor` short-circuit