### PR TITLE
Parallelize git fetch --prune across repos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,16 +33,16 @@ This is a Cargo workspace with a shared core library and seven binary crates.
 
 ### Core patterns
 
-- **`GitOps` trait** (`git-tidy-core/src/git.rs`): All git operations go through this trait. `RealGit` shells out to `git`; `MockGit` (in `testutil.rs`) returns canned data.
+- **`GitOps` trait** (`git-tidy-core/src/git.rs`): All git operations go through this trait (`Send + Sync` for thread safety). `RealGit` shells out to `git`; `MockGit` (in `testutil.rs`) returns canned data. `MockGit` uses `Mutex` for call-tracking fields.
 - **Output to `&mut dyn Write`**: Enables unit testing output formatters without process capture.
 - **Shared output helpers** (`git-tidy-core/src/output.rs`): `write_summary_line`, `write_warnings`, `format_ahead_behind`, `format_annotations`, `format_landed_ratio`, `repo_display_name`, `write_json_pretty`. All tools call these to avoid duplicating formatting logic.
 - **Shared CLI utilities** (`git-tidy-core/src/cli.rs`): `resolve_directory` for resolving optional directory arguments, used by all tools.
 - **Shared error handling** (`git-tidy-core/src/error.rs`): `exit_with_error` for consistent error-exit behavior across all tools.
 - **Shared type helpers** (`git-tidy-core/src/types.rs`): `extract_landed_fields` for extracting landed ratio/total/unmatched from `Classification` for JSON serialization.
 - **`thiserror`** for errors: Known, finite variants with exit code mapping (1=error, 2=dirty-blocked).
-- **Sequential repo processing**: No parallelism needed for typical workloads (~9 repos, ~39 worktrees).
+- **Parallel fetch** (`git-tidy-core/src/fetch.rs`): `parallel_fetch` runs `git fetch --prune` concurrently across repos using `thread::scope`. Used by worktree-tidy and branch-tidy before classification.
 - **Library-first design**: `scan.rs` and `clean.rs` are library functions; `main.rs` is thin dispatch. Enables `git-tidy` to call each tool's scan/lint as a library.
-- **`CachingGitOps`** (`git-tidy-core/src/caching.rs`): `GitOps` wrapper that memoizes read-only queries (`fetch_prune`, `list_local_branches`, `list_remotes`, `ls_remote_check`, etc.) via `RefCell<HashMap>`. Used by the in-process audit runner to avoid redundant git calls across tools. A `delegate_git_ops!` macro forwards uncached methods to the inner `GitOps`.
+- **`CachingGitOps`** (`git-tidy-core/src/caching.rs`): `GitOps` wrapper that memoizes read-only queries (`fetch_prune`, `list_local_branches`, `list_remotes`, `ls_remote_check`, etc.) via `Mutex<HashMap>`. Used by the in-process audit runner to avoid redundant git calls across tools. A `delegate_git_ops!` macro forwards uncached methods to the inner `GitOps`.
 
 ### CLI pattern (shared `resolve_directory`, per-crate `clap` definitions)
 
@@ -96,6 +96,7 @@ crates/
       git.rs                                  # GitOps trait + RealGit implementation
       types.rs                                # Classification, BranchClassification, WorktreeInfo, etc.
       error.rs                                # thiserror Error enum + exit_with_error
+      fetch.rs                               # parallel_fetch: concurrent git fetch --prune via thread::scope
       classification.rs                       # classify_branch + classify_worktree
       config.rs                               # Noise pattern configuration (file + CLI + defaults)
       dirty.rs                                # Status parsing with noise filtering

--- a/crates/git-branch-tidy/src/scan.rs
+++ b/crates/git-branch-tidy/src/scan.rs
@@ -18,17 +18,14 @@ pub fn run_scan(
 ) -> Result<BranchScanResult, Error> {
     let repo_paths = discovery::discover_repos(directory)?;
 
+    let fetch_paths: Vec<&Path> = repo_paths.iter().map(|p| p.as_path()).collect();
+    let mut warnings = git_tidy_core::fetch::parallel_fetch(git, &fetch_paths);
+
     let mut repos = Vec::new();
     let mut counts = ScanCounts::default();
-    let mut warnings = Vec::new();
     let mut total_scanned = 0;
 
     for repo_path in &repo_paths {
-        // Fetch to get current remote state
-        if let Err(e) = git.fetch_prune(repo_path) {
-            warnings.push(format!("fetch failed for {}: {e}", repo_path.display()));
-        }
-
         // Detect default branch
         let default_branch = match classification::detect_default_branch(git, repo_path) {
             Ok(b) => b,

--- a/crates/git-tidy-core/src/caching.rs
+++ b/crates/git-tidy-core/src/caching.rs
@@ -1,6 +1,6 @@
-use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use crate::git::{GitOps, GitResult};
 
@@ -27,14 +27,14 @@ macro_rules! delegate_git_ops {
 /// `CachingGitOps` is shared across all tool scans.
 pub struct CachingGitOps<'a> {
     inner: &'a dyn GitOps,
-    fetched_repos: RefCell<HashSet<PathBuf>>,
-    symbolic_ref_cache: RefCell<HashMap<PathBuf, Option<String>>>,
-    rev_parse_verify_cache: RefCell<HashMap<(PathBuf, String), bool>>,
-    local_branches_cache: RefCell<HashMap<PathBuf, Vec<String>>>,
-    list_remotes_cache: RefCell<HashMap<PathBuf, Vec<String>>>,
-    ls_remote_check_cache: RefCell<HashMap<(PathBuf, String), bool>>,
-    builtin_commands_cache: RefCell<Option<Vec<String>>>,
-    lfs_installed_cache: RefCell<Option<bool>>,
+    fetched_repos: Mutex<HashSet<PathBuf>>,
+    symbolic_ref_cache: Mutex<HashMap<PathBuf, Option<String>>>,
+    rev_parse_verify_cache: Mutex<HashMap<(PathBuf, String), bool>>,
+    local_branches_cache: Mutex<HashMap<PathBuf, Vec<String>>>,
+    list_remotes_cache: Mutex<HashMap<PathBuf, Vec<String>>>,
+    ls_remote_check_cache: Mutex<HashMap<(PathBuf, String), bool>>,
+    builtin_commands_cache: Mutex<Option<Vec<String>>>,
+    lfs_installed_cache: Mutex<Option<bool>>,
 }
 
 impl<'a> CachingGitOps<'a> {
@@ -42,14 +42,14 @@ impl<'a> CachingGitOps<'a> {
     pub fn new(inner: &'a dyn GitOps) -> Self {
         Self {
             inner,
-            fetched_repos: RefCell::new(HashSet::new()),
-            symbolic_ref_cache: RefCell::new(HashMap::new()),
-            rev_parse_verify_cache: RefCell::new(HashMap::new()),
-            local_branches_cache: RefCell::new(HashMap::new()),
-            list_remotes_cache: RefCell::new(HashMap::new()),
-            ls_remote_check_cache: RefCell::new(HashMap::new()),
-            builtin_commands_cache: RefCell::new(None),
-            lfs_installed_cache: RefCell::new(None),
+            fetched_repos: Mutex::new(HashSet::new()),
+            symbolic_ref_cache: Mutex::new(HashMap::new()),
+            rev_parse_verify_cache: Mutex::new(HashMap::new()),
+            local_branches_cache: Mutex::new(HashMap::new()),
+            list_remotes_cache: Mutex::new(HashMap::new()),
+            ls_remote_check_cache: Mutex::new(HashMap::new()),
+            builtin_commands_cache: Mutex::new(None),
+            lfs_installed_cache: Mutex::new(None),
         }
     }
 }
@@ -57,87 +57,96 @@ impl<'a> CachingGitOps<'a> {
 impl GitOps for CachingGitOps<'_> {
     fn fetch_prune(&self, repo: &Path) -> GitResult<()> {
         let key = repo.to_path_buf();
-        if self.fetched_repos.borrow().contains(&key) {
+        if self.fetched_repos.lock().unwrap().contains(&key) {
             return Ok(());
         }
         let result = self.inner.fetch_prune(repo);
         if result.is_ok() {
-            self.fetched_repos.borrow_mut().insert(key);
+            self.fetched_repos.lock().unwrap().insert(key);
         }
         result
     }
 
     fn symbolic_ref_origin_head(&self, repo: &Path) -> GitResult<Option<String>> {
         let key = repo.to_path_buf();
-        if let Some(cached) = self.symbolic_ref_cache.borrow().get(&key) {
+        if let Some(cached) = self.symbolic_ref_cache.lock().unwrap().get(&key) {
             return Ok(cached.clone());
         }
         let result = self.inner.symbolic_ref_origin_head(repo)?;
         self.symbolic_ref_cache
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .insert(key, result.clone());
         Ok(result)
     }
 
     fn rev_parse_verify(&self, repo: &Path, refspec: &str) -> GitResult<bool> {
         let key = (repo.to_path_buf(), refspec.to_string());
-        if let Some(&cached) = self.rev_parse_verify_cache.borrow().get(&key) {
+        if let Some(&cached) = self.rev_parse_verify_cache.lock().unwrap().get(&key) {
             return Ok(cached);
         }
         let result = self.inner.rev_parse_verify(repo, refspec)?;
-        self.rev_parse_verify_cache.borrow_mut().insert(key, result);
+        self.rev_parse_verify_cache
+            .lock()
+            .unwrap()
+            .insert(key, result);
         Ok(result)
     }
 
     fn list_local_branches(&self, repo: &Path) -> GitResult<Vec<String>> {
         let key = repo.to_path_buf();
-        if let Some(cached) = self.local_branches_cache.borrow().get(&key) {
+        if let Some(cached) = self.local_branches_cache.lock().unwrap().get(&key) {
             return Ok(cached.clone());
         }
         let result = self.inner.list_local_branches(repo)?;
         self.local_branches_cache
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .insert(key, result.clone());
         Ok(result)
     }
 
     fn list_remotes(&self, repo: &Path) -> GitResult<Vec<String>> {
         let key = repo.to_path_buf();
-        if let Some(cached) = self.list_remotes_cache.borrow().get(&key) {
+        if let Some(cached) = self.list_remotes_cache.lock().unwrap().get(&key) {
             return Ok(cached.clone());
         }
         let result = self.inner.list_remotes(repo)?;
         self.list_remotes_cache
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .insert(key, result.clone());
         Ok(result)
     }
 
     fn ls_remote_check(&self, repo: &Path, remote: &str) -> GitResult<bool> {
         let key = (repo.to_path_buf(), remote.to_string());
-        if let Some(&cached) = self.ls_remote_check_cache.borrow().get(&key) {
+        if let Some(&cached) = self.ls_remote_check_cache.lock().unwrap().get(&key) {
             return Ok(cached);
         }
         let result = self.inner.ls_remote_check(repo, remote)?;
-        self.ls_remote_check_cache.borrow_mut().insert(key, result);
+        self.ls_remote_check_cache
+            .lock()
+            .unwrap()
+            .insert(key, result);
         Ok(result)
     }
 
     fn list_builtin_commands(&self) -> GitResult<Vec<String>> {
-        if let Some(cached) = self.builtin_commands_cache.borrow().as_ref() {
+        if let Some(cached) = self.builtin_commands_cache.lock().unwrap().as_ref() {
             return Ok(cached.clone());
         }
         let result = self.inner.list_builtin_commands()?;
-        *self.builtin_commands_cache.borrow_mut() = Some(result.clone());
+        *self.builtin_commands_cache.lock().unwrap() = Some(result.clone());
         Ok(result)
     }
 
     fn lfs_installed(&self) -> GitResult<bool> {
-        if let Some(cached) = *self.lfs_installed_cache.borrow() {
+        if let Some(cached) = *self.lfs_installed_cache.lock().unwrap() {
             return Ok(cached);
         }
         let result = self.inner.lfs_installed()?;
-        *self.lfs_installed_cache.borrow_mut() = Some(result);
+        *self.lfs_installed_cache.lock().unwrap() = Some(result);
         Ok(result)
     }
 
@@ -192,8 +201,8 @@ impl GitOps for CachingGitOps<'_> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
     use std::path::Path;
+    use std::sync::Mutex;
 
     use super::*;
 
@@ -202,70 +211,70 @@ mod tests {
     /// all methods delegate to the inner MockGit.
     struct CountingGitOps<'a> {
         inner: &'a dyn GitOps,
-        fetch_prune_count: RefCell<usize>,
-        symbolic_ref_count: RefCell<usize>,
-        rev_parse_verify_count: RefCell<usize>,
-        list_local_branches_count: RefCell<usize>,
-        list_remotes_count: RefCell<usize>,
-        ls_remote_check_count: RefCell<usize>,
-        list_builtin_commands_count: RefCell<usize>,
-        lfs_installed_count: RefCell<usize>,
+        fetch_prune_count: Mutex<usize>,
+        symbolic_ref_count: Mutex<usize>,
+        rev_parse_verify_count: Mutex<usize>,
+        list_local_branches_count: Mutex<usize>,
+        list_remotes_count: Mutex<usize>,
+        ls_remote_check_count: Mutex<usize>,
+        list_builtin_commands_count: Mutex<usize>,
+        lfs_installed_count: Mutex<usize>,
     }
 
     impl<'a> CountingGitOps<'a> {
         fn new(inner: &'a dyn GitOps) -> Self {
             Self {
                 inner,
-                fetch_prune_count: RefCell::new(0),
-                symbolic_ref_count: RefCell::new(0),
-                rev_parse_verify_count: RefCell::new(0),
-                list_local_branches_count: RefCell::new(0),
-                list_remotes_count: RefCell::new(0),
-                ls_remote_check_count: RefCell::new(0),
-                list_builtin_commands_count: RefCell::new(0),
-                lfs_installed_count: RefCell::new(0),
+                fetch_prune_count: Mutex::new(0),
+                symbolic_ref_count: Mutex::new(0),
+                rev_parse_verify_count: Mutex::new(0),
+                list_local_branches_count: Mutex::new(0),
+                list_remotes_count: Mutex::new(0),
+                ls_remote_check_count: Mutex::new(0),
+                list_builtin_commands_count: Mutex::new(0),
+                lfs_installed_count: Mutex::new(0),
             }
         }
     }
 
     impl GitOps for CountingGitOps<'_> {
         fn fetch_prune(&self, repo: &Path) -> GitResult<()> {
-            *self.fetch_prune_count.borrow_mut() += 1;
+            *self.fetch_prune_count.lock().unwrap() += 1;
             self.inner.fetch_prune(repo)
         }
 
         fn symbolic_ref_origin_head(&self, repo: &Path) -> GitResult<Option<String>> {
-            *self.symbolic_ref_count.borrow_mut() += 1;
+            *self.symbolic_ref_count.lock().unwrap() += 1;
             self.inner.symbolic_ref_origin_head(repo)
         }
 
         fn rev_parse_verify(&self, repo: &Path, refspec: &str) -> GitResult<bool> {
-            *self.rev_parse_verify_count.borrow_mut() += 1;
+            *self.rev_parse_verify_count.lock().unwrap() += 1;
             self.inner.rev_parse_verify(repo, refspec)
         }
 
         fn list_local_branches(&self, repo: &Path) -> GitResult<Vec<String>> {
-            *self.list_local_branches_count.borrow_mut() += 1;
+            *self.list_local_branches_count.lock().unwrap() += 1;
             self.inner.list_local_branches(repo)
         }
 
         fn list_remotes(&self, repo: &Path) -> GitResult<Vec<String>> {
-            *self.list_remotes_count.borrow_mut() += 1;
+            *self.list_remotes_count.lock().unwrap() += 1;
             self.inner.list_remotes(repo)
         }
 
         fn ls_remote_check(&self, repo: &Path, remote: &str) -> GitResult<bool> {
-            *self.ls_remote_check_count.borrow_mut() += 1;
+            *self.ls_remote_check_count.lock().unwrap() += 1;
             self.inner.ls_remote_check(repo, remote)
         }
 
         fn list_builtin_commands(&self) -> GitResult<Vec<String>> {
-            *self.list_builtin_commands_count.borrow_mut() += 1;
+            *self.list_builtin_commands_count.lock().unwrap() += 1;
             self.inner.list_builtin_commands()
         }
 
         fn lfs_installed(&self) -> GitResult<bool> {
-            *self.lfs_installed_count.borrow_mut() += 1;
+            *self.lfs_installed_count.lock().unwrap() += 1;
             self.inner.lfs_installed()
         }
 
@@ -345,7 +354,7 @@ mod tests {
         caching.fetch_prune(Path::new("/repo")).unwrap();
         caching.fetch_prune(Path::new("/repo")).unwrap();
 
-        assert_eq!(*counter.fetch_prune_count.borrow(), 1);
+        assert_eq!(*counter.fetch_prune_count.lock().unwrap(), 1);
     }
 
     #[test]
@@ -357,7 +366,7 @@ mod tests {
         caching.fetch_prune(Path::new("/repo")).unwrap();
         caching.fetch_prune(Path::new("/other")).unwrap();
 
-        assert_eq!(*counter.fetch_prune_count.borrow(), 2);
+        assert_eq!(*counter.fetch_prune_count.lock().unwrap(), 2);
     }
 
     #[test]
@@ -375,7 +384,7 @@ mod tests {
 
         assert_eq!(r1, Some("main".to_string()));
         assert_eq!(r1, r2);
-        assert_eq!(*counter.symbolic_ref_count.borrow(), 1);
+        assert_eq!(*counter.symbolic_ref_count.lock().unwrap(), 1);
     }
 
     #[test]
@@ -393,7 +402,7 @@ mod tests {
 
         assert!(r1);
         assert_eq!(r1, r2);
-        assert_eq!(*counter.rev_parse_verify_count.borrow(), 1);
+        assert_eq!(*counter.rev_parse_verify_count.lock().unwrap(), 1);
     }
 
     #[test]
@@ -414,7 +423,7 @@ mod tests {
 
         assert!(r1);
         assert!(!r2);
-        assert_eq!(*counter.rev_parse_verify_count.borrow(), 2);
+        assert_eq!(*counter.rev_parse_verify_count.lock().unwrap(), 2);
     }
 
     #[test]
@@ -428,7 +437,7 @@ mod tests {
 
         assert_eq!(r1, vec!["main", "feature"]);
         assert_eq!(r1, r2);
-        assert_eq!(*counter.list_local_branches_count.borrow(), 1);
+        assert_eq!(*counter.list_local_branches_count.lock().unwrap(), 1);
     }
 
     #[test]
@@ -442,7 +451,7 @@ mod tests {
 
         assert_eq!(r1, vec!["origin"]);
         assert_eq!(r1, r2);
-        assert_eq!(*counter.list_remotes_count.borrow(), 1);
+        assert_eq!(*counter.list_remotes_count.lock().unwrap(), 1);
     }
 
     #[test]
@@ -460,7 +469,7 @@ mod tests {
 
         assert!(r1);
         assert_eq!(r1, r2);
-        assert_eq!(*counter.ls_remote_check_count.borrow(), 1);
+        assert_eq!(*counter.ls_remote_check_count.lock().unwrap(), 1);
     }
 
     #[test]
@@ -474,7 +483,7 @@ mod tests {
 
         assert_eq!(r1, vec!["add", "commit"]);
         assert_eq!(r1, r2);
-        assert_eq!(*counter.list_builtin_commands_count.borrow(), 1);
+        assert_eq!(*counter.list_builtin_commands_count.lock().unwrap(), 1);
     }
 
     #[test]
@@ -488,7 +497,7 @@ mod tests {
 
         assert!(r1);
         assert_eq!(r1, r2);
-        assert_eq!(*counter.lfs_installed_count.borrow(), 1);
+        assert_eq!(*counter.lfs_installed_count.lock().unwrap(), 1);
     }
 
     #[test]

--- a/crates/git-tidy-core/src/fetch.rs
+++ b/crates/git-tidy-core/src/fetch.rs
@@ -1,0 +1,87 @@
+use std::path::Path;
+use std::thread;
+
+use crate::git::GitOps;
+
+/// Fetch from all repos concurrently using `thread::scope`.
+///
+/// Returns a `Vec<String>` of warning messages for repos where fetch failed.
+/// Single-repo and empty inputs skip thread overhead.
+pub fn parallel_fetch(git: &dyn GitOps, repo_paths: &[&Path]) -> Vec<String> {
+    match repo_paths.len() {
+        0 => Vec::new(),
+        1 => {
+            let mut warnings = Vec::new();
+            if let Err(e) = git.fetch_prune(repo_paths[0]) {
+                warnings.push(format!("fetch failed for {}: {e}", repo_paths[0].display()));
+            }
+            warnings
+        }
+        _ => {
+            let warnings = std::sync::Mutex::new(Vec::new());
+            thread::scope(|s| {
+                for &repo_path in repo_paths {
+                    s.spawn(|| {
+                        if let Err(e) = git.fetch_prune(repo_path) {
+                            warnings
+                                .lock()
+                                .unwrap()
+                                .push(format!("fetch failed for {}: {e}", repo_path.display()));
+                        }
+                    });
+                }
+            });
+            warnings.into_inner().unwrap()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::testutil::MockGitBuilder;
+
+    use super::*;
+
+    #[test]
+    fn parallel_fetch_collects_all_repos() {
+        let git = MockGitBuilder::new().build();
+        let paths = [
+            PathBuf::from("/repo1"),
+            PathBuf::from("/repo2"),
+            PathBuf::from("/repo3"),
+        ];
+        let path_refs: Vec<&Path> = paths.iter().map(|p| p.as_path()).collect();
+
+        let warnings = parallel_fetch(&git, &path_refs);
+
+        assert!(warnings.is_empty());
+        let calls = git.fetch_prune_calls();
+        assert_eq!(calls.len(), 3);
+        assert!(calls.contains(&PathBuf::from("/repo1")));
+        assert!(calls.contains(&PathBuf::from("/repo2")));
+        assert!(calls.contains(&PathBuf::from("/repo3")));
+    }
+
+    #[test]
+    fn parallel_fetch_empty_repos() {
+        let git = MockGitBuilder::new().build();
+
+        let warnings = parallel_fetch(&git, &[]);
+
+        assert!(warnings.is_empty());
+        assert!(git.fetch_prune_calls().is_empty());
+    }
+
+    #[test]
+    fn parallel_fetch_single_repo() {
+        let git = MockGitBuilder::new().build();
+        let path = PathBuf::from("/solo");
+
+        let warnings = parallel_fetch(&git, &[path.as_path()]);
+
+        assert!(warnings.is_empty());
+        assert_eq!(git.fetch_prune_calls(), vec![PathBuf::from("/solo")]);
+    }
+}

--- a/crates/git-tidy-core/src/git.rs
+++ b/crates/git-tidy-core/src/git.rs
@@ -8,7 +8,7 @@ use crate::error::Error;
 pub type GitResult<T> = Result<T, Error>;
 
 /// Abstraction over git CLI operations for testability.
-pub trait GitOps {
+pub trait GitOps: Send + Sync {
     /// Run `git fetch --prune --quiet` on the repo.
     fn fetch_prune(&self, repo: &Path) -> GitResult<()>;
 

--- a/crates/git-tidy-core/src/lib.rs
+++ b/crates/git-tidy-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod date;
 pub mod dirty;
 pub mod discovery;
 pub mod error;
+pub mod fetch;
 pub mod git;
 pub mod landed;
 pub mod output;

--- a/crates/git-tidy-core/src/testutil.rs
+++ b/crates/git-tidy-core/src/testutil.rs
@@ -24,43 +24,43 @@ pub struct MockGitBuilder {
     rev_parse: HashMap<(PathBuf, String), String>,
     is_branch_checked_out: HashMap<(PathBuf, String), bool>,
     log_file_history: HashMap<(PathBuf, String, String), Vec<(String, String)>>,
-    fetch_prune_calls: std::cell::RefCell<Vec<PathBuf>>,
-    remove_calls: std::cell::RefCell<Vec<(PathBuf, PathBuf)>>,
-    remove_force_calls: std::cell::RefCell<Vec<(PathBuf, PathBuf)>>,
-    prune_calls: std::cell::RefCell<Vec<PathBuf>>,
-    branch_delete_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    fetch_prune_calls: std::sync::Mutex<Vec<PathBuf>>,
+    remove_calls: std::sync::Mutex<Vec<(PathBuf, PathBuf)>>,
+    remove_force_calls: std::sync::Mutex<Vec<(PathBuf, PathBuf)>>,
+    prune_calls: std::sync::Mutex<Vec<PathBuf>>,
+    branch_delete_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
     worktree_remove_errors: HashMap<PathBuf, String>,
     worktree_remove_force_errors: HashMap<PathBuf, String>,
     local_branches: HashMap<PathBuf, Vec<String>>,
     current_branch: HashMap<PathBuf, Option<String>>,
     upstream_branch: HashMap<(PathBuf, String), Option<String>>,
-    branch_delete_safe_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    branch_delete_safe_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
     branch_delete_safe_errors: HashMap<(PathBuf, String), String>,
-    delete_remote_branch_calls: std::cell::RefCell<Vec<(PathBuf, String, String)>>,
+    delete_remote_branch_calls: std::sync::Mutex<Vec<(PathBuf, String, String)>>,
     delete_remote_branch_errors: HashMap<(PathBuf, String, String), String>,
     // Stash operations
     stash_list: HashMap<PathBuf, Vec<(String, String, String)>>,
     stash_diff: HashMap<(PathBuf, String), String>,
     stash_drop_errors: HashMap<(PathBuf, String), String>,
-    stash_drop_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    stash_drop_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
     // Remote operations
     list_remotes: HashMap<PathBuf, Vec<String>>,
     remote_url: HashMap<(PathBuf, String), String>,
     ls_remote_check: HashMap<(PathBuf, String), bool>,
     remote_remove_errors: HashMap<(PathBuf, String), String>,
-    remote_remove_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    remote_remove_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
     remote_tracking_refs: HashMap<PathBuf, Vec<(String, String)>>,
     prune_remote_refs_result: HashMap<(PathBuf, String), usize>,
-    prune_remote_refs_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    prune_remote_refs_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
     // Tag operations
     local_tags: HashMap<PathBuf, Vec<String>>,
     remote_tags: HashMap<(PathBuf, String), Vec<(String, String)>>,
     tag_commit: HashMap<(PathBuf, String), String>,
     is_commit_reachable: HashMap<(PathBuf, String), bool>,
     tag_delete_errors: HashMap<(PathBuf, String), String>,
-    tag_delete_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    tag_delete_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
     tag_delete_remote_errors: HashMap<(PathBuf, String, String), String>,
-    tag_delete_remote_calls: std::cell::RefCell<Vec<(PathBuf, String, String)>>,
+    tag_delete_remote_calls: std::sync::Mutex<Vec<(PathBuf, String, String)>>,
     is_tag_annotated: HashMap<(PathBuf, String), bool>,
     tag_date: HashMap<(PathBuf, String), Option<String>>,
     // Repo-level operations
@@ -68,7 +68,7 @@ pub struct MockGitBuilder {
     // Config operations
     config_list_local: HashMap<PathBuf, Vec<(String, String)>>,
     config_remove_section_errors: HashMap<(PathBuf, String), String>,
-    config_remove_section_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    config_remove_section_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
     builtin_commands: Vec<String>,
     // LFS operations
     lfs_installed: bool,
@@ -76,7 +76,7 @@ pub struct MockGitBuilder {
     lfs_track_patterns: HashMap<PathBuf, Vec<String>>,
     lfs_prune_dry_run: HashMap<PathBuf, (usize, u64)>,
     lfs_prune_errors: HashMap<PathBuf, String>,
-    lfs_prune_calls: std::cell::RefCell<Vec<PathBuf>>,
+    lfs_prune_calls: std::sync::Mutex<Vec<PathBuf>>,
     find_large_blobs: HashMap<PathBuf, Vec<(String, u64, String)>>,
 }
 
@@ -558,43 +558,43 @@ pub struct MockGit {
     rev_parse: HashMap<(PathBuf, String), String>,
     is_branch_checked_out: HashMap<(PathBuf, String), bool>,
     log_file_history: HashMap<(PathBuf, String, String), Vec<(String, String)>>,
-    fetch_prune_calls: std::cell::RefCell<Vec<PathBuf>>,
-    remove_calls: std::cell::RefCell<Vec<(PathBuf, PathBuf)>>,
-    remove_force_calls: std::cell::RefCell<Vec<(PathBuf, PathBuf)>>,
-    prune_calls: std::cell::RefCell<Vec<PathBuf>>,
-    branch_delete_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    fetch_prune_calls: std::sync::Mutex<Vec<PathBuf>>,
+    remove_calls: std::sync::Mutex<Vec<(PathBuf, PathBuf)>>,
+    remove_force_calls: std::sync::Mutex<Vec<(PathBuf, PathBuf)>>,
+    prune_calls: std::sync::Mutex<Vec<PathBuf>>,
+    branch_delete_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
     worktree_remove_errors: HashMap<PathBuf, String>,
     worktree_remove_force_errors: HashMap<PathBuf, String>,
     local_branches: HashMap<PathBuf, Vec<String>>,
     current_branch: HashMap<PathBuf, Option<String>>,
     upstream_branch: HashMap<(PathBuf, String), Option<String>>,
-    branch_delete_safe_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    branch_delete_safe_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
     branch_delete_safe_errors: HashMap<(PathBuf, String), String>,
-    delete_remote_branch_calls: std::cell::RefCell<Vec<(PathBuf, String, String)>>,
+    delete_remote_branch_calls: std::sync::Mutex<Vec<(PathBuf, String, String)>>,
     delete_remote_branch_errors: HashMap<(PathBuf, String, String), String>,
     // Stash operations
     stash_list: HashMap<PathBuf, Vec<(String, String, String)>>,
     stash_diff: HashMap<(PathBuf, String), String>,
     stash_drop_errors: HashMap<(PathBuf, String), String>,
-    stash_drop_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    stash_drop_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
     // Remote operations
     list_remotes: HashMap<PathBuf, Vec<String>>,
     remote_url: HashMap<(PathBuf, String), String>,
     ls_remote_check: HashMap<(PathBuf, String), bool>,
     remote_remove_errors: HashMap<(PathBuf, String), String>,
-    remote_remove_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    remote_remove_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
     remote_tracking_refs: HashMap<PathBuf, Vec<(String, String)>>,
     prune_remote_refs_result: HashMap<(PathBuf, String), usize>,
-    prune_remote_refs_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    prune_remote_refs_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
     // Tag operations
     local_tags: HashMap<PathBuf, Vec<String>>,
     remote_tags: HashMap<(PathBuf, String), Vec<(String, String)>>,
     tag_commit: HashMap<(PathBuf, String), String>,
     is_commit_reachable: HashMap<(PathBuf, String), bool>,
     tag_delete_errors: HashMap<(PathBuf, String), String>,
-    tag_delete_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    tag_delete_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
     tag_delete_remote_errors: HashMap<(PathBuf, String, String), String>,
-    tag_delete_remote_calls: std::cell::RefCell<Vec<(PathBuf, String, String)>>,
+    tag_delete_remote_calls: std::sync::Mutex<Vec<(PathBuf, String, String)>>,
     is_tag_annotated: HashMap<(PathBuf, String), bool>,
     tag_date: HashMap<(PathBuf, String), Option<String>>,
     // Repo-level operations
@@ -602,7 +602,7 @@ pub struct MockGit {
     // Config operations
     config_list_local: HashMap<PathBuf, Vec<(String, String)>>,
     config_remove_section_errors: HashMap<(PathBuf, String), String>,
-    config_remove_section_calls: std::cell::RefCell<Vec<(PathBuf, String)>>,
+    config_remove_section_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
     builtin_commands: Vec<String>,
     // LFS operations
     lfs_installed: bool,
@@ -610,67 +610,70 @@ pub struct MockGit {
     lfs_track_patterns: HashMap<PathBuf, Vec<String>>,
     lfs_prune_dry_run: HashMap<PathBuf, (usize, u64)>,
     lfs_prune_errors: HashMap<PathBuf, String>,
-    lfs_prune_calls: std::cell::RefCell<Vec<PathBuf>>,
+    lfs_prune_calls: std::sync::Mutex<Vec<PathBuf>>,
     find_large_blobs: HashMap<PathBuf, Vec<(String, u64, String)>>,
 }
 
 impl MockGit {
     pub fn fetch_prune_calls(&self) -> Vec<PathBuf> {
-        self.fetch_prune_calls.borrow().clone()
+        self.fetch_prune_calls.lock().unwrap().clone()
     }
 
     pub fn remove_calls(&self) -> Vec<(PathBuf, PathBuf)> {
-        self.remove_calls.borrow().clone()
+        self.remove_calls.lock().unwrap().clone()
     }
 
     pub fn remove_force_calls(&self) -> Vec<(PathBuf, PathBuf)> {
-        self.remove_force_calls.borrow().clone()
+        self.remove_force_calls.lock().unwrap().clone()
     }
 
     pub fn branch_delete_calls(&self) -> Vec<(PathBuf, String)> {
-        self.branch_delete_calls.borrow().clone()
+        self.branch_delete_calls.lock().unwrap().clone()
     }
 
     pub fn branch_delete_safe_calls(&self) -> Vec<(PathBuf, String)> {
-        self.branch_delete_safe_calls.borrow().clone()
+        self.branch_delete_safe_calls.lock().unwrap().clone()
     }
 
     pub fn delete_remote_branch_calls(&self) -> Vec<(PathBuf, String, String)> {
-        self.delete_remote_branch_calls.borrow().clone()
+        self.delete_remote_branch_calls.lock().unwrap().clone()
     }
 
     pub fn stash_drop_calls(&self) -> Vec<(PathBuf, String)> {
-        self.stash_drop_calls.borrow().clone()
+        self.stash_drop_calls.lock().unwrap().clone()
     }
 
     pub fn remote_remove_calls(&self) -> Vec<(PathBuf, String)> {
-        self.remote_remove_calls.borrow().clone()
+        self.remote_remove_calls.lock().unwrap().clone()
     }
 
     pub fn prune_remote_refs_calls(&self) -> Vec<(PathBuf, String)> {
-        self.prune_remote_refs_calls.borrow().clone()
+        self.prune_remote_refs_calls.lock().unwrap().clone()
     }
 
     pub fn tag_delete_calls(&self) -> Vec<(PathBuf, String)> {
-        self.tag_delete_calls.borrow().clone()
+        self.tag_delete_calls.lock().unwrap().clone()
     }
 
     pub fn tag_delete_remote_calls(&self) -> Vec<(PathBuf, String, String)> {
-        self.tag_delete_remote_calls.borrow().clone()
+        self.tag_delete_remote_calls.lock().unwrap().clone()
     }
 
     pub fn config_remove_section_calls(&self) -> Vec<(PathBuf, String)> {
-        self.config_remove_section_calls.borrow().clone()
+        self.config_remove_section_calls.lock().unwrap().clone()
     }
 
     pub fn lfs_prune_calls(&self) -> Vec<PathBuf> {
-        self.lfs_prune_calls.borrow().clone()
+        self.lfs_prune_calls.lock().unwrap().clone()
     }
 }
 
 impl GitOps for MockGit {
     fn fetch_prune(&self, repo: &Path) -> GitResult<()> {
-        self.fetch_prune_calls.borrow_mut().push(repo.to_path_buf());
+        self.fetch_prune_calls
+            .lock()
+            .unwrap()
+            .push(repo.to_path_buf());
         Ok(())
     }
 
@@ -812,7 +815,8 @@ impl GitOps for MockGit {
             });
         }
         self.remove_calls
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .push((repo.to_path_buf(), worktree_path.to_path_buf()));
         Ok(())
     }
@@ -828,19 +832,21 @@ impl GitOps for MockGit {
             });
         }
         self.remove_force_calls
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .push((repo.to_path_buf(), worktree_path.to_path_buf()));
         Ok(())
     }
 
     fn worktree_prune(&self, repo: &Path) -> GitResult<()> {
-        self.prune_calls.borrow_mut().push(repo.to_path_buf());
+        self.prune_calls.lock().unwrap().push(repo.to_path_buf());
         Ok(())
     }
 
     fn branch_delete(&self, repo: &Path, branch: &str) -> GitResult<()> {
         self.branch_delete_calls
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .push((repo.to_path_buf(), branch.to_string()));
         Ok(())
     }
@@ -884,7 +890,8 @@ impl GitOps for MockGit {
             });
         }
         self.branch_delete_safe_calls
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .push((repo.to_path_buf(), branch.to_string()));
         Ok(())
     }
@@ -916,7 +923,7 @@ impl GitOps for MockGit {
                 message: err.clone(),
             });
         }
-        self.delete_remote_branch_calls.borrow_mut().push((
+        self.delete_remote_branch_calls.lock().unwrap().push((
             repo.to_path_buf(),
             remote.to_string(),
             branch.to_string(),
@@ -963,7 +970,8 @@ impl GitOps for MockGit {
             });
         }
         self.remote_remove_calls
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .push((repo.to_path_buf(), remote.to_string()));
         Ok(())
     }
@@ -978,7 +986,8 @@ impl GitOps for MockGit {
 
     fn prune_remote_refs(&self, repo: &Path, remote: &str) -> GitResult<usize> {
         self.prune_remote_refs_calls
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .push((repo.to_path_buf(), remote.to_string()));
         Ok(*self
             .prune_remote_refs_result
@@ -1016,7 +1025,8 @@ impl GitOps for MockGit {
             });
         }
         self.stash_drop_calls
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .push((repo.to_path_buf(), stash_ref.to_string()));
         Ok(())
     }
@@ -1068,7 +1078,8 @@ impl GitOps for MockGit {
             });
         }
         self.tag_delete_calls
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .push((repo.to_path_buf(), tag.to_string()));
         Ok(())
     }
@@ -1085,7 +1096,7 @@ impl GitOps for MockGit {
                 reason: err.clone(),
             });
         }
-        self.tag_delete_remote_calls.borrow_mut().push((
+        self.tag_delete_remote_calls.lock().unwrap().push((
             repo.to_path_buf(),
             remote.to_string(),
             tag.to_string(),
@@ -1153,7 +1164,8 @@ impl GitOps for MockGit {
             });
         }
         self.config_remove_section_calls
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .push((repo.to_path_buf(), section.to_string()));
         Ok(())
     }
@@ -1184,7 +1196,10 @@ impl GitOps for MockGit {
                 reason: err.clone(),
             });
         }
-        self.lfs_prune_calls.borrow_mut().push(repo.to_path_buf());
+        self.lfs_prune_calls
+            .lock()
+            .unwrap()
+            .push(repo.to_path_buf());
         Ok(())
     }
 

--- a/crates/git-worktree-tidy/src/scan.rs
+++ b/crates/git-worktree-tidy/src/scan.rs
@@ -18,17 +18,14 @@ pub fn run_scan(
 ) -> Result<ScanResult, Error> {
     let groups = discovery::discover_worktrees(directory)?;
 
+    let repo_paths: Vec<&std::path::Path> = groups.keys().map(|p| p.as_path()).collect();
+    let mut warnings = git_tidy_core::fetch::parallel_fetch(git, &repo_paths);
+
     let mut repos = Vec::new();
     let mut counts = ScanCounts::default();
-    let mut warnings = Vec::new();
     let mut total_scanned = 0;
 
     for (repo_path, worktrees) in &groups {
-        // Fetch to get current remote state
-        if let Err(e) = git.fetch_prune(repo_path) {
-            warnings.push(format!("fetch failed for {}: {e}", repo_path.display()));
-        }
-
         // Detect default branch
         let default_branch = match classification::detect_default_branch(git, repo_path) {
             Ok(b) => b,


### PR DESCRIPTION
## Summary
- Add shared `parallel_fetch` helper in `git-tidy-core` using `std::thread::scope` to run `git fetch --prune` concurrently across discovered repos
- Add `Send + Sync` supertraits to `GitOps`; migrate `MockGit`, `CachingGitOps`, and test helpers from `RefCell` to `Mutex` for thread safety
- Update `git-worktree-tidy` and `git-branch-tidy` to use `parallel_fetch` instead of sequential per-repo fetching

## Test plan
- [x] Unit tests for `parallel_fetch`: empty input, single repo, multiple repos
- [x] All existing workspace tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy --workspace --all-targets -- -D clippy::all`)
- [ ] Manual smoke test: `cargo run -p git-worktree-tidy -- scan` and `cargo run -p git-branch-tidy -- scan` on a directory with multiple repos

Closes #56