### PR TITLE
Add --match pattern filter to git-worktree-tidy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,8 @@ All tools follow a similar CLI shape:
 - **Global args**: `directory` (positional, default cwd), plus tool-specific thresholds
 - **Scan subcommand** (default): `--json`, `--porcelain`
 - **Clean subcommand**: `--dry-run` / `-n`, `--yes` / `-y`, classification filters, `--all`, `--json`, `--porcelain`
-- Worktree/branch-tidy global args: `--behind-threshold` (default 100), `--verbose` / `-v`
+- Worktree-tidy global args: `--behind-threshold` (default 100), `--verbose` / `-v`, `--match` (repeatable substring filter on worktree basenames, OR semantics, case-insensitive)
+- Branch-tidy global args: `--behind-threshold` (default 100), `--verbose` / `-v`
 - Stash-tidy global arg: `--age-threshold` (default 90) instead of `--behind-threshold`/`--verbose`
 - Remote-tidy global arg: `--offline` instead of `--behind-threshold`/`--verbose`
 - Tag-tidy global arg: `--offline` instead of `--behind-threshold`/`--verbose`

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ git-worktree-tidy clean ~/Developer                    # interactive
 git-worktree-tidy clean ~/Developer --merged-only --yes  # non-interactive, merged only
 git-worktree-tidy clean ~/Developer --landed --yes       # merged + fully landed
 git-worktree-tidy clean ~/Developer --dry-run            # preview removals
+
+# Filter by worktree name (substring match, case-insensitive)
+git-worktree-tidy --match tubafrenzy scan ~/Developer              # only tubafrenzy worktrees
+git-worktree-tidy --match tubafrenzy --match wxyc scan ~/Developer # OR semantics
+git-worktree-tidy --match tubafrenzy clean --dry-run ~/Developer   # clean only matching
 ```
 
 ### git-branch-tidy

--- a/crates/git-tidy/src/inprocess.rs
+++ b/crates/git-tidy/src/inprocess.rs
@@ -144,6 +144,7 @@ fn scan_worktrees(
         DEFAULT_BEHIND_THRESHOLD,
         false,
         noise_patterns,
+        &[],
         progress,
     ) {
         Ok(result) => {

--- a/crates/git-worktree-tidy/src/cli.rs
+++ b/crates/git-worktree-tidy/src/cli.rs
@@ -30,6 +30,10 @@ pub struct Cli {
     /// Disable all default noise patterns
     #[arg(long, global = true)]
     pub no_default_noise: bool,
+
+    /// Filter worktrees by name substring (can be repeated, OR semantics)
+    #[arg(long = "match", global = true)]
+    pub match_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -197,6 +201,34 @@ mod tests {
             }
             _ => panic!("expected Clean command"),
         }
+    }
+
+    #[test]
+    fn match_pattern_single() {
+        let cli = Cli::parse_from(["git-worktree-tidy", "--match", "tubafrenzy"]);
+        assert_eq!(cli.match_patterns, vec!["tubafrenzy".to_string()]);
+    }
+
+    #[test]
+    fn match_pattern_multiple() {
+        let cli = Cli::parse_from([
+            "git-worktree-tidy",
+            "--match",
+            "tubafrenzy",
+            "--match",
+            "wxyc",
+        ]);
+        assert_eq!(
+            cli.match_patterns,
+            vec!["tubafrenzy".to_string(), "wxyc".to_string()]
+        );
+    }
+
+    #[test]
+    fn match_pattern_with_subcommand() {
+        let cli = Cli::parse_from(["git-worktree-tidy", "--match", "tubafrenzy", "scan"]);
+        assert_eq!(cli.match_patterns, vec!["tubafrenzy".to_string()]);
+        assert!(matches!(cli.command, Some(Command::Scan { .. })));
     }
 
     #[test]

--- a/crates/git-worktree-tidy/src/discovery.rs
+++ b/crates/git-worktree-tidy/src/discovery.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use git_tidy_core::error::Error;
 
 /// A discovered linked worktree before classification.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DiscoveredWorktree {
     /// Absolute path to the worktree directory.
     pub path: PathBuf,

--- a/crates/git-worktree-tidy/src/main.rs
+++ b/crates/git-worktree-tidy/src/main.rs
@@ -54,6 +54,7 @@ fn main() {
                 cli.behind_threshold,
                 cli.verbose,
                 &noise_patterns,
+                &cli.match_patterns,
                 &progress,
             ) {
                 Ok(result) => {
@@ -87,6 +88,7 @@ fn main() {
                 cli.behind_threshold,
                 cli.verbose,
                 &noise_patterns,
+                &cli.match_patterns,
                 &progress,
             ) {
                 Ok(scan_result) => {

--- a/crates/git-worktree-tidy/src/scan.rs
+++ b/crates/git-worktree-tidy/src/scan.rs
@@ -1,4 +1,5 @@
-use std::path::Path;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 
 use git_tidy_core::classification;
 use git_tidy_core::error::Error;
@@ -7,7 +8,47 @@ use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
 use git_tidy_core::types::{ClassificationLabel, RepoGroup, ScanCounts, ScanResult};
 
-use crate::discovery;
+use crate::discovery::{self, DiscoveredWorktree};
+
+/// Filter discovered worktrees by basename substring match.
+///
+/// Retains only worktrees whose directory basename contains at least one of the
+/// given patterns (case-insensitive, OR semantics). Repos with no remaining
+/// worktrees are dropped entirely. An empty pattern list returns all worktrees.
+fn filter_worktrees(
+    groups: BTreeMap<PathBuf, Vec<DiscoveredWorktree>>,
+    patterns: &[String],
+) -> BTreeMap<PathBuf, Vec<DiscoveredWorktree>> {
+    if patterns.is_empty() {
+        return groups;
+    }
+
+    let lower_patterns: Vec<String> = patterns.iter().map(|p| p.to_lowercase()).collect();
+
+    groups
+        .into_iter()
+        .filter_map(|(repo, worktrees)| {
+            let matched: Vec<DiscoveredWorktree> = worktrees
+                .into_iter()
+                .filter(|wt| {
+                    let basename = wt
+                        .path
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("")
+                        .to_lowercase();
+                    lower_patterns.iter().any(|p| basename.contains(p.as_str()))
+                })
+                .collect();
+
+            if matched.is_empty() {
+                None
+            } else {
+                Some((repo, matched))
+            }
+        })
+        .collect()
+}
 
 /// Scan all worktrees under `directory` and classify them.
 pub fn run_scan(
@@ -16,9 +57,15 @@ pub fn run_scan(
     behind_threshold: usize,
     verbose: bool,
     noise_patterns: &[String],
+    match_patterns: &[String],
     progress: &Progress,
 ) -> Result<ScanResult, Error> {
     let groups = discovery::discover_worktrees(directory)?;
+    let groups = if match_patterns.is_empty() {
+        groups
+    } else {
+        filter_worktrees(groups, match_patterns)
+    };
 
     let repo_paths: Vec<&std::path::Path> = groups.keys().map(|p| p.as_path()).collect();
     let mut warnings = git_tidy_core::fetch::parallel_fetch(git, &repo_paths, progress);
@@ -85,4 +132,107 @@ pub fn run_scan(
         counts,
         warnings,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::discovery::DiscoveredWorktree;
+
+    fn make_worktree(name: &str, repo: &str) -> DiscoveredWorktree {
+        DiscoveredWorktree {
+            path: PathBuf::from(format!("/dev/{name}")),
+            parent_repo: PathBuf::from(format!("/dev/{repo}")),
+        }
+    }
+
+    fn make_groups(
+        entries: &[(&str, Vec<DiscoveredWorktree>)],
+    ) -> BTreeMap<PathBuf, Vec<DiscoveredWorktree>> {
+        entries
+            .iter()
+            .map(|(repo, wts)| (PathBuf::from(repo), wts.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn filter_worktrees_substring_match() {
+        let groups = make_groups(&[(
+            "/dev/MyRepo",
+            vec![
+                make_worktree("MyRepo-feature", "MyRepo"),
+                make_worktree("MyRepo-bugfix", "MyRepo"),
+                make_worktree("OtherProject-thing", "MyRepo"),
+            ],
+        )]);
+
+        let filtered = filter_worktrees(groups, &["MyRepo".to_string()]);
+        let wts = &filtered[&PathBuf::from("/dev/MyRepo")];
+        assert_eq!(wts.len(), 2);
+        assert!(wts.iter().all(|w| {
+            let name = w.path.file_name().unwrap().to_str().unwrap();
+            name.contains("MyRepo")
+        }));
+    }
+
+    #[test]
+    fn filter_worktrees_removes_empty_repos() {
+        let groups = make_groups(&[
+            ("/dev/RepoA", vec![make_worktree("RepoA-feat", "RepoA")]),
+            ("/dev/RepoB", vec![make_worktree("RepoB-fix", "RepoB")]),
+        ]);
+
+        let filtered = filter_worktrees(groups, &["RepoA".to_string()]);
+        assert_eq!(filtered.len(), 1);
+        assert!(filtered.contains_key(&PathBuf::from("/dev/RepoA")));
+        assert!(!filtered.contains_key(&PathBuf::from("/dev/RepoB")));
+    }
+
+    #[test]
+    fn filter_worktrees_case_insensitive() {
+        let groups = make_groups(&[(
+            "/dev/MyRepo",
+            vec![
+                make_worktree("myrepo-feature", "MyRepo"),
+                make_worktree("MYREPO-bugfix", "MyRepo"),
+            ],
+        )]);
+
+        let filtered = filter_worktrees(groups, &["MyRepo".to_string()]);
+        let wts = &filtered[&PathBuf::from("/dev/MyRepo")];
+        assert_eq!(wts.len(), 2);
+    }
+
+    #[test]
+    fn filter_worktrees_multiple_patterns_or() {
+        let groups = make_groups(&[(
+            "/dev/MyRepo",
+            vec![
+                make_worktree("alpha-feature", "MyRepo"),
+                make_worktree("beta-bugfix", "MyRepo"),
+                make_worktree("gamma-thing", "MyRepo"),
+            ],
+        )]);
+
+        let filtered = filter_worktrees(groups, &["alpha".to_string(), "gamma".to_string()]);
+        let wts = &filtered[&PathBuf::from("/dev/MyRepo")];
+        assert_eq!(wts.len(), 2);
+    }
+
+    #[test]
+    fn filter_worktrees_empty_patterns_passes_all() {
+        let groups = make_groups(&[(
+            "/dev/MyRepo",
+            vec![
+                make_worktree("MyRepo-feature", "MyRepo"),
+                make_worktree("MyRepo-bugfix", "MyRepo"),
+            ],
+        )]);
+
+        let filtered = filter_worktrees(groups.clone(), &[]);
+        assert_eq!(filtered, groups);
+    }
 }


### PR DESCRIPTION
## Summary

- Add `--match` global flag to `git-worktree-tidy` for filtering worktrees by basename substring (case-insensitive, repeatable with OR semantics)
- Filter is applied after discovery but before fetch/classify, avoiding expensive git operations on non-matching worktrees
- 8 new unit tests (5 for `filter_worktrees`, 3 for CLI parsing)

Closes #58

## Test plan

- [x] `cargo test --workspace` -- all existing + new tests pass
- [x] `cargo build --workspace` -- compiles cleanly
- [ ] Smoke test: `cargo run -p git-worktree-tidy -- --match tubafrenzy scan ~/Developer` -- shows only tubafrenzy worktrees
- [ ] Smoke test: `cargo run -p git-worktree-tidy -- --match tubafrenzy clean --dry-run ~/Developer` -- shows only tubafrenzy worktrees
- [ ] Verify no-filter: `cargo run -p git-worktree-tidy -- scan ~/Developer` -- shows all worktrees as before