### PR TITLE
Add indicatif progress bars to all tools and audit runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6f81257d10a0f602a294ae4182251151ff97dbb504ef9afcdda4a64b24d9b4"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +374,7 @@ dependencies = [
 name = "git-tidy-core"
 version = "0.1.0"
 dependencies = [
+ "indicatif",
  "serde",
  "serde_json",
  "strsim",
@@ -431,6 +438,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +461,16 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -488,6 +518,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +534,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "predicates"
@@ -604,6 +646,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "semver"
@@ -838,6 +886,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +962,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/git-branch-tidy/src/main.rs
+++ b/crates/git-branch-tidy/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use git_tidy_core::cli::{OutputFormat, validate_directory};
 use git_tidy_core::error;
 use git_tidy_core::git;
+use git_tidy_core::progress::Progress;
 
 mod clean;
 mod cli;
@@ -22,6 +23,7 @@ fn main() {
     }
 
     let git = git::RealGit;
+    let progress = Progress::new();
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -33,7 +35,13 @@ fn main() {
                 _ => OutputFormat::Human,
             };
 
-            match scan::run_scan(&git, &directory, cli.behind_threshold, cli.verbose) {
+            match scan::run_scan(
+                &git,
+                &directory,
+                cli.behind_threshold,
+                cli.verbose,
+                &progress,
+            ) {
                 Ok(result) => {
                     let write_result = match format {
                         OutputFormat::Json => output::write_json(&mut stdout, &result),
@@ -59,7 +67,13 @@ fn main() {
             ..
         }) => {
             // First, scan to get the current state
-            match scan::run_scan(&git, &directory, cli.behind_threshold, cli.verbose) {
+            match scan::run_scan(
+                &git,
+                &directory,
+                cli.behind_threshold,
+                cli.verbose,
+                &progress,
+            ) {
                 Ok(scan_result) => {
                     let options = clean::CleanOptions {
                         dry_run: *dry_run,

--- a/crates/git-branch-tidy/src/scan.rs
+++ b/crates/git-branch-tidy/src/scan.rs
@@ -4,6 +4,7 @@ use git_tidy_core::classification;
 use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
+use git_tidy_core::progress::Progress;
 use git_tidy_core::types::{ClassificationLabel, ScanCounts};
 
 use crate::discovery;
@@ -15,16 +16,18 @@ pub fn run_scan(
     directory: &Path,
     behind_threshold: usize,
     verbose: bool,
+    progress: &Progress,
 ) -> Result<BranchScanResult, Error> {
     let repo_paths = discovery::discover_repos(directory)?;
 
     let fetch_paths: Vec<&Path> = repo_paths.iter().map(|p| p.as_path()).collect();
-    let mut warnings = git_tidy_core::fetch::parallel_fetch(git, &fetch_paths);
+    let mut warnings = git_tidy_core::fetch::parallel_fetch(git, &fetch_paths, progress);
 
     let mut repos = Vec::new();
     let mut counts = ScanCounts::default();
     let mut total_scanned = 0;
 
+    let pb = progress.bar(repo_paths.len() as u64, "Scanning branches");
     for repo_path in &repo_paths {
         // Detect default branch
         let default_branch = match classification::detect_default_branch(git, repo_path) {
@@ -109,7 +112,9 @@ pub fn run_scan(
                 branches: classified,
             });
         }
+        pb.inc(1);
     }
+    pb.finish_and_clear();
 
     Ok(BranchScanResult {
         repos,

--- a/crates/git-branch-tidy/tests/integration_clean.rs
+++ b/crates/git-branch-tidy/tests/integration_clean.rs
@@ -45,7 +45,14 @@ fn clean_deletes_merged_branch_in_real_repo() {
     assert!(branches.contains(&"feature/done".to_string()));
 
     // Scan then clean
-    let scan_result = git_branch_tidy::scan::run_scan(&git_ops, &scan_dir, 100, false).unwrap();
+    let scan_result = git_branch_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        100,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let options = git_branch_tidy::clean::CleanOptions {
         dry_run: false,
@@ -77,7 +84,14 @@ fn clean_dry_run_does_not_delete() {
 
     git(&repo, &["branch", "feature/done"]);
 
-    let scan_result = git_branch_tidy::scan::run_scan(&git_ops, &scan_dir, 100, false).unwrap();
+    let scan_result = git_branch_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        100,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let options = git_branch_tidy::clean::CleanOptions {
         dry_run: true,
@@ -117,7 +131,14 @@ fn clean_safe_refuses_unmerged_branch() {
     git(&repo, &["commit", "-m", "wip"]);
     git(&repo, &["checkout", "main"]);
 
-    let scan_result = git_branch_tidy::scan::run_scan(&git_ops, &scan_dir, 100, false).unwrap();
+    let scan_result = git_branch_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        100,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     // Use --all to include it, but without --force (so -d will fail)
     let options = git_branch_tidy::clean::CleanOptions {

--- a/crates/git-branch-tidy/tests/integration_scan.rs
+++ b/crates/git-branch-tidy/tests/integration_scan.rs
@@ -56,7 +56,14 @@ fn scan_real_repo_with_mixed_branches() {
     git(&repo, &["commit", "-m", "wip commit"]);
     git(&repo, &["checkout", "main"]);
 
-    let result = git_branch_tidy::scan::run_scan(&git_ops, &scan_dir, 100, false).unwrap();
+    let result = git_branch_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        100,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     // Should find our repo
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
@@ -104,7 +111,14 @@ fn scan_marks_current_branch_in_real_repo() {
     git(&repo, &["commit", "-m", "commit on feature"]);
     // Don't switch back -- my-feature is the current branch
 
-    let result = git_branch_tidy::scan::run_scan(&git_ops, &scan_dir, 100, false).unwrap();
+    let result = git_branch_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        100,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     let branch = &result.repos[0].branches[0];
@@ -128,7 +142,14 @@ fn scan_skips_repo_without_default_branch() {
     git(&repo, &["commit", "-m", "init"]);
 
     let git_ops = RealGit;
-    let result = git_branch_tidy::scan::run_scan(&git_ops, &base, 100, false).unwrap();
+    let result = git_branch_tidy::scan::run_scan(
+        &git_ops,
+        &base,
+        100,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     // Repo should be skipped with a warning
     assert!(result.repos.is_empty());

--- a/crates/git-config-tidy/src/lint.rs
+++ b/crates/git-config-tidy/src/lint.rs
@@ -5,6 +5,7 @@ use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
+use git_tidy_core::progress::Progress;
 
 use crate::types::{
     ConfigIssue, ConfigLintResult, ConfigRepoGroup, IssueCounts, IssueKind,
@@ -69,7 +70,11 @@ pub fn lint_repo(
 }
 
 /// Run a config lint across all repos discovered under `directory`.
-pub fn run_lint(git: &dyn GitOps, directory: &Path) -> Result<ConfigLintResult, Error> {
+pub fn run_lint(
+    git: &dyn GitOps,
+    directory: &Path,
+    progress: &Progress,
+) -> Result<ConfigLintResult, Error> {
     let repo_paths = discover_repos(directory)?;
 
     let mut repos = Vec::new();
@@ -86,6 +91,7 @@ pub fn run_lint(git: &dyn GitOps, directory: &Path) -> Result<ConfigLintResult, 
         }
     };
 
+    let pb = progress.bar(repo_paths.len() as u64, "Linting config");
     for repo_path in &repo_paths {
         let issues = match lint_repo(git, repo_path, &builtin_commands) {
             Ok(issues) => issues,
@@ -112,7 +118,9 @@ pub fn run_lint(git: &dyn GitOps, directory: &Path) -> Result<ConfigLintResult, 
             name: repo_name,
             issues,
         });
+        pb.inc(1);
     }
+    pb.finish_and_clear();
 
     Ok(ConfigLintResult {
         repos,

--- a/crates/git-config-tidy/src/main.rs
+++ b/crates/git-config-tidy/src/main.rs
@@ -4,6 +4,7 @@ use std::process;
 use clap::Parser;
 use git_tidy_core::error;
 use git_tidy_core::git;
+use git_tidy_core::progress::Progress;
 
 mod cli;
 mod fix;
@@ -21,6 +22,7 @@ fn main() {
     }
 
     let git = git::RealGit;
+    let progress = Progress::new();
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -30,7 +32,7 @@ fn main() {
                 _ => (false, false),
             };
 
-            match lint::run_lint(&git, &directory) {
+            match lint::run_lint(&git, &directory, &progress) {
                 Ok(result) => {
                     let write_result = if json {
                         output::write_json(&mut stdout, &result)
@@ -52,7 +54,7 @@ fn main() {
             yes,
             json,
             porcelain,
-        }) => match lint::run_lint(&git, &directory) {
+        }) => match lint::run_lint(&git, &directory, &progress) {
             Ok(lint_result) => {
                 // Show lint results first if requested
                 let write_result = if *json {

--- a/crates/git-lfs-tidy/src/main.rs
+++ b/crates/git-lfs-tidy/src/main.rs
@@ -4,6 +4,7 @@ use std::process;
 use clap::Parser;
 use git_tidy_core::error;
 use git_tidy_core::git;
+use git_tidy_core::progress::Progress;
 
 mod clean;
 mod cli;
@@ -21,6 +22,7 @@ fn main() {
     }
 
     let git = git::RealGit;
+    let progress = Progress::new();
     let mut stdout = io::stdout().lock();
 
     // Extract scan parameters from whichever subcommand is active.
@@ -55,7 +57,7 @@ fn main() {
                 _ => (false, false),
             };
 
-            match scan::run_scan(&git, &directory, size_threshold, depth) {
+            match scan::run_scan(&git, &directory, size_threshold, depth, &progress) {
                 Ok(result) => {
                     let write_result = if json {
                         output::write_json(&mut stdout, &result)
@@ -77,7 +79,7 @@ fn main() {
             yes,
             prune,
             ..
-        }) => match scan::run_scan(&git, &directory, size_threshold, depth) {
+        }) => match scan::run_scan(&git, &directory, size_threshold, depth, &progress) {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,

--- a/crates/git-lfs-tidy/src/scan.rs
+++ b/crates/git-lfs-tidy/src/scan.rs
@@ -5,6 +5,7 @@ use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
+use git_tidy_core::progress::Progress;
 
 use crate::types::{LfsClassification, LfsCounts, LfsInfo, LfsRepoGroup, LfsScanResult};
 
@@ -44,6 +45,7 @@ pub fn run_scan(
     directory: &Path,
     size_threshold: u64,
     depth: usize,
+    progress: &Progress,
 ) -> Result<LfsScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
 
@@ -58,6 +60,7 @@ pub fn run_scan(
         warnings.push("git-lfs is not installed; skipping LFS-specific checks".to_string());
     }
 
+    let pb = progress.bar(repo_paths.len() as u64, "Scanning LFS");
     for repo_path in &repo_paths {
         let repo_name = repo_display_name(repo_path);
         let mut items = Vec::new();
@@ -167,7 +170,9 @@ pub fn run_scan(
             lfs_available: lfs_installed,
             track_patterns,
         });
+        pb.inc(1);
     }
+    pb.finish_and_clear();
 
     Ok(LfsScanResult {
         repos,

--- a/crates/git-lfs-tidy/tests/integration_clean.rs
+++ b/crates/git-lfs-tidy/tests/integration_clean.rs
@@ -32,7 +32,14 @@ fn run_scan_and_clean(
     options: &CleanOptions,
 ) -> (git_lfs_tidy::types::LfsScanResult, CleanResult) {
     let git_ops = RealGit;
-    let scan_result = git_lfs_tidy::scan::run_scan(&git_ops, scan_dir, 100_000, 1000).unwrap();
+    let scan_result = git_lfs_tidy::scan::run_scan(
+        &git_ops,
+        scan_dir,
+        100_000,
+        1000,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
     let mut buf = Vec::new();
     let clean_result =
         git_lfs_tidy::clean::run_clean(&git_ops, &scan_result, options, &mut buf).unwrap();

--- a/crates/git-lfs-tidy/tests/integration_scan.rs
+++ b/crates/git-lfs-tidy/tests/integration_scan.rs
@@ -33,7 +33,14 @@ fn scan_repo_with_no_large_blobs() {
     let git_ops = RealGit;
 
     // Default threshold is 1MB, README.md is tiny
-    let result = git_lfs_tidy::scan::run_scan(&git_ops, &scan_dir, 1_000_000, 1000).unwrap();
+    let result = git_lfs_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        1_000_000,
+        1000,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     // Should find the repo but no items (all blobs below threshold)
     assert!(result.repos.is_empty() || result.repos[0].items.is_empty());
@@ -51,7 +58,14 @@ fn scan_repo_with_large_blob() {
     git(&repo, &["add", "large.bin"]);
     git(&repo, &["commit", "-m", "Add large file"]);
 
-    let result = git_lfs_tidy::scan::run_scan(&git_ops, &scan_dir, 100_000, 1000).unwrap();
+    let result = git_lfs_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        100_000,
+        1000,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
 
@@ -82,7 +96,14 @@ fn scan_repo_with_large_blob_below_threshold() {
     git(&repo, &["add", "medium.bin"]);
     git(&repo, &["commit", "-m", "Add medium file"]);
 
-    let result = git_lfs_tidy::scan::run_scan(&git_ops, &scan_dir, 100_000, 1000).unwrap();
+    let result = git_lfs_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        100_000,
+        1000,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     // Should not flag medium.bin since it's below threshold
     let untracked_count: usize = result
@@ -123,7 +144,14 @@ fn scan_multiple_repos() {
     git(&repo_b, &["commit", "-m", "Add small file"]);
 
     let git_ops = RealGit;
-    let result = git_lfs_tidy::scan::run_scan(&git_ops, &scan_dir, 100_000, 1000).unwrap();
+    let result = git_lfs_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        100_000,
+        1000,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     // Only repo-a should have items (untracked large blob)
     let repos_with_items: Vec<_> = result
@@ -148,7 +176,14 @@ fn scan_repo_with_no_commits() {
 
     let git_ops = RealGit;
     // Should not crash on an empty repo
-    let result = git_lfs_tidy::scan::run_scan(&git_ops, &scan_dir, 1_000_000, 1000).unwrap();
+    let result = git_lfs_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        1_000_000,
+        1000,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     // Empty repo should have no items
     let total_items: usize = result.repos.iter().map(|r| r.items.len()).sum();
@@ -168,7 +203,14 @@ fn scan_threshold_edge_case() {
     git(&repo, &["commit", "-m", "Add edge-case file"]);
 
     // Threshold = 1000: file is exactly at threshold, should be flagged (>= comparison)
-    let result = git_lfs_tidy::scan::run_scan(&git_ops, &scan_dir, 1000, 1000).unwrap();
+    let result = git_lfs_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        1000,
+        1000,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let untracked: Vec<_> = result
         .repos

--- a/crates/git-remote-tidy/src/main.rs
+++ b/crates/git-remote-tidy/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use git_tidy_core::cli::{OutputFormat, validate_directory};
 use git_tidy_core::error;
 use git_tidy_core::git;
+use git_tidy_core::progress::Progress;
 
 mod clean;
 mod cli;
@@ -21,6 +22,7 @@ fn main() {
     }
 
     let git = git::RealGit;
+    let progress = Progress::new();
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -32,7 +34,7 @@ fn main() {
                 _ => OutputFormat::Human,
             };
 
-            match scan::run_scan(&git, &directory, cli.offline) {
+            match scan::run_scan(&git, &directory, cli.offline, &progress) {
                 Ok(result) => {
                     let write_result = match format {
                         OutputFormat::Json => output::write_json(&mut stdout, &result),
@@ -53,7 +55,7 @@ fn main() {
             force,
             all,
             ..
-        }) => match scan::run_scan(&git, &directory, cli.offline) {
+        }) => match scan::run_scan(&git, &directory, cli.offline, &progress) {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,

--- a/crates/git-remote-tidy/src/scan.rs
+++ b/crates/git-remote-tidy/src/scan.rs
@@ -5,6 +5,7 @@ use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
+use git_tidy_core::progress::Progress;
 use git_tidy_core::types::ClassificationLabel;
 
 use crate::types::{
@@ -42,6 +43,7 @@ pub fn run_scan(
     git: &dyn GitOps,
     directory: &Path,
     offline: bool,
+    progress: &Progress,
 ) -> Result<RemoteScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
 
@@ -50,6 +52,7 @@ pub fn run_scan(
     let mut warnings = Vec::new();
     let mut total_scanned = 0;
 
+    let pb = progress.bar(repo_paths.len() as u64, "Scanning remotes");
     for repo_path in &repo_paths {
         // Get configured remotes
         let configured = match git.list_remotes(repo_path) {
@@ -136,7 +139,9 @@ pub fn run_scan(
             name: repo_name,
             remotes: classified,
         });
+        pb.inc(1);
     }
+    pb.finish_and_clear();
 
     Ok(RemoteScanResult {
         repos,

--- a/crates/git-remote-tidy/tests/integration_clean.rs
+++ b/crates/git-remote-tidy/tests/integration_clean.rs
@@ -41,7 +41,13 @@ fn clean_removes_remote_in_real_repo() {
     assert!(remotes.contains(&"stale".to_string()));
 
     // Scan then clean
-    let scan_result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+    let scan_result = git_remote_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let options = git_remote_tidy::clean::CleanOptions {
         dry_run: false,
@@ -72,7 +78,13 @@ fn clean_dry_run_does_not_remove() {
         &["remote", "add", "stale", "/nonexistent/path/repo.git"],
     );
 
-    let scan_result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+    let scan_result = git_remote_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let options = git_remote_tidy::clean::CleanOptions {
         dry_run: true,
@@ -122,7 +134,13 @@ fn clean_prunes_orphaned_refs() {
     assert_eq!(stale_refs.len(), 2);
 
     // Scan then clean with --all
-    let scan_result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+    let scan_result = git_remote_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let options = git_remote_tidy::clean::CleanOptions {
         dry_run: false,

--- a/crates/git-remote-tidy/tests/integration_scan.rs
+++ b/crates/git-remote-tidy/tests/integration_scan.rs
@@ -39,7 +39,13 @@ fn scan_real_repo_with_reachable_remote() {
     git(&repo, &["remote", "add", "origin", &bare.to_string_lossy()]);
     git(&repo, &["push", "-u", "origin", "main"]);
 
-    let result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+    let result = git_remote_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     assert_eq!(result.total_scanned, 1);
@@ -63,7 +69,13 @@ fn scan_repo_with_unreachable_remote() {
         &["remote", "add", "origin", "/nonexistent/path/repo.git"],
     );
 
-    let result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+    let result = git_remote_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     assert_eq!(result.total_scanned, 1);
@@ -86,7 +98,13 @@ fn scan_repo_with_orphaned_refs() {
         &["update-ref", "refs/remotes/stale/main", &head_hash],
     );
 
-    let result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+    let result = git_remote_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
 
@@ -108,7 +126,13 @@ fn scan_empty_repo_no_remotes() {
     let scan_dir = dir.path().canonicalize().unwrap().join("projects");
     let git_ops = RealGit;
 
-    let result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+    let result = git_remote_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     // Repo has no remotes, so no groups
     assert!(result.repos.is_empty());
@@ -127,7 +151,13 @@ fn scan_offline_mode() {
         &["remote", "add", "origin", "/nonexistent/path/repo.git"],
     );
 
-    let result = git_remote_tidy::scan::run_scan(&git_ops, &scan_dir, true).unwrap();
+    let result = git_remote_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        true,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
 

--- a/crates/git-repo-tidy/src/main.rs
+++ b/crates/git-repo-tidy/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use git_tidy_core::config::{NoiseConfig, default_config_path, load_config_file};
 use git_tidy_core::error;
 use git_tidy_core::git;
+use git_tidy_core::progress::Progress;
 
 mod clean;
 mod cli;
@@ -22,6 +23,7 @@ fn main() {
     }
 
     let git = git::RealGit;
+    let progress = Progress::new();
     let mut stdout = io::stdout().lock();
 
     // Resolve noise patterns
@@ -46,7 +48,14 @@ fn main() {
                 _ => (false, false),
             };
 
-            match scan::run_scan(&git, &directory, stale_days, &noise_patterns, cli.offline) {
+            match scan::run_scan(
+                &git,
+                &directory,
+                stale_days,
+                &noise_patterns,
+                cli.offline,
+                &progress,
+            ) {
                 Ok(result) => {
                     let write_result = if json {
                         output::write_json(&mut stdout, &result)
@@ -71,7 +80,14 @@ fn main() {
             orphaned_only,
             all,
             ..
-        }) => match scan::run_scan(&git, &directory, stale_days, &noise_patterns, cli.offline) {
+        }) => match scan::run_scan(
+            &git,
+            &directory,
+            stale_days,
+            &noise_patterns,
+            cli.offline,
+            &progress,
+        ) {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,

--- a/crates/git-repo-tidy/src/scan.rs
+++ b/crates/git-repo-tidy/src/scan.rs
@@ -7,6 +7,7 @@ use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
+use git_tidy_core::progress::Progress;
 
 use crate::types::{RepoClassification, RepoCounts, RepoInfo, RepoScanResult};
 
@@ -118,6 +119,7 @@ pub fn run_scan(
     stale_days: u64,
     noise_patterns: &[String],
     offline: bool,
+    progress: &Progress,
 ) -> Result<RepoScanResult, Error> {
     run_scan_with_du(
         git,
@@ -126,6 +128,7 @@ pub fn run_scan(
         noise_patterns,
         offline,
         &disk_usage,
+        progress,
     )
 }
 
@@ -137,6 +140,7 @@ pub fn run_scan_with_du(
     noise_patterns: &[String],
     offline: bool,
     du_fn: &dyn Fn(&Path) -> u64,
+    progress: &Progress,
 ) -> Result<RepoScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
 
@@ -146,6 +150,7 @@ pub fn run_scan_with_du(
     let mut total_disk_usage_bytes = 0u64;
     let mut reclaimable_bytes = 0u64;
 
+    let pb = progress.bar(repo_paths.len() as u64, "Scanning repos");
     for repo_path in &repo_paths {
         let info = classify_repo(git, repo_path, stale_days, noise_patterns, offline, du_fn);
 
@@ -160,7 +165,9 @@ pub fn run_scan_with_du(
         }
 
         repos.push(info);
+        pb.inc(1);
     }
+    pb.finish_and_clear();
 
     // Sort by classification priority (stale first, then orphaned, then active)
     repos.sort_by(|a, b| {

--- a/crates/git-repo-tidy/tests/integration_clean.rs
+++ b/crates/git-repo-tidy/tests/integration_clean.rs
@@ -44,7 +44,15 @@ fn clean_removes_orphaned_repo() {
     assert!(repo.exists());
 
     let git_ops = RealGit;
-    let scan_result = git_repo_tidy::scan::run_scan(&git_ops, &scan_dir, 180, &[], false).unwrap();
+    let scan_result = git_repo_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        180,
+        &[],
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let delete_fn = |path: &std::path::Path| std::fs::remove_dir_all(path);
     let mut buf = Vec::new();
@@ -63,7 +71,15 @@ fn clean_dry_run_preserves_repo() {
     let scan_dir = base.join("projects");
 
     let git_ops = RealGit;
-    let scan_result = git_repo_tidy::scan::run_scan(&git_ops, &scan_dir, 180, &[], false).unwrap();
+    let scan_result = git_repo_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        180,
+        &[],
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let delete_fn = |path: &std::path::Path| std::fs::remove_dir_all(path);
     let mut buf = Vec::new();
@@ -92,7 +108,15 @@ fn clean_skips_dirty_repo() {
     std::fs::write(repo.join("dirty.txt"), "uncommitted").unwrap();
 
     let git_ops = RealGit;
-    let scan_result = git_repo_tidy::scan::run_scan(&git_ops, &scan_dir, 180, &[], false).unwrap();
+    let scan_result = git_repo_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        180,
+        &[],
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let delete_fn = |path: &std::path::Path| std::fs::remove_dir_all(path);
     let mut buf = Vec::new();
@@ -115,7 +139,15 @@ fn clean_force_deletes_dirty_repo() {
     std::fs::write(repo.join("dirty.txt"), "uncommitted").unwrap();
 
     let git_ops = RealGit;
-    let scan_result = git_repo_tidy::scan::run_scan(&git_ops, &scan_dir, 180, &[], false).unwrap();
+    let scan_result = git_repo_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        180,
+        &[],
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let delete_fn = |path: &std::path::Path| std::fs::remove_dir_all(path);
     let mut buf = Vec::new();

--- a/crates/git-repo-tidy/tests/integration_scan.rs
+++ b/crates/git-repo-tidy/tests/integration_scan.rs
@@ -38,7 +38,15 @@ fn scan_active_repo_with_remote() {
     git(&repo, &["push", "-u", "origin", "main"]);
 
     let git_ops = RealGit;
-    let result = git_repo_tidy::scan::run_scan(&git_ops, &scan_dir, 180, &[], false).unwrap();
+    let result = git_repo_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        180,
+        &[],
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     assert_eq!(result.repos[0].classification, RepoClassification::Active);
@@ -55,7 +63,15 @@ fn scan_orphaned_no_remote() {
     let scan_dir = base.join("projects");
 
     let git_ops = RealGit;
-    let result = git_repo_tidy::scan::run_scan(&git_ops, &scan_dir, 180, &[], false).unwrap();
+    let result = git_repo_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        180,
+        &[],
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     assert_eq!(result.repos[0].classification, RepoClassification::Orphaned);
@@ -89,7 +105,15 @@ fn scan_stale_repo() {
 
     let git_ops = RealGit;
     // stale_days = 180 (6 months); commit is ~2 years old
-    let result = git_repo_tidy::scan::run_scan(&git_ops, &scan_dir, 180, &[], false).unwrap();
+    let result = git_repo_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        180,
+        &[],
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     assert_eq!(result.repos[0].classification, RepoClassification::Stale);
@@ -106,7 +130,15 @@ fn scan_dirty_repo() {
     std::fs::write(repo.join("dirty.txt"), "uncommitted").unwrap();
 
     let git_ops = RealGit;
-    let result = git_repo_tidy::scan::run_scan(&git_ops, &scan_dir, 180, &[], false).unwrap();
+    let result = git_repo_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        180,
+        &[],
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     assert!(result.repos[0].is_dirty);
@@ -121,7 +153,15 @@ fn scan_reclaimable_bytes() {
     let scan_dir = base.join("projects");
 
     let git_ops = RealGit;
-    let result = git_repo_tidy::scan::run_scan(&git_ops, &scan_dir, 180, &[], false).unwrap();
+    let result = git_repo_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        180,
+        &[],
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     // Orphaned repo's disk usage should be reclaimable
     assert_eq!(result.repos.len(), 1);

--- a/crates/git-stash-tidy/src/main.rs
+++ b/crates/git-stash-tidy/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use git_tidy_core::cli::{OutputFormat, validate_directory};
 use git_tidy_core::error;
 use git_tidy_core::git;
+use git_tidy_core::progress::Progress;
 
 mod clean;
 mod cli;
@@ -21,6 +22,7 @@ fn main() {
     }
 
     let git = git::RealGit;
+    let progress = Progress::new();
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -32,7 +34,7 @@ fn main() {
                 _ => OutputFormat::Human,
             };
 
-            match scan::run_scan(&git, &directory, cli.age_threshold) {
+            match scan::run_scan(&git, &directory, cli.age_threshold, &progress) {
                 Ok(result) => {
                     let write_result = match format {
                         OutputFormat::Json => output::write_json(&mut stdout, &result),
@@ -54,7 +56,7 @@ fn main() {
             aged_only,
             all,
             ..
-        }) => match scan::run_scan(&git, &directory, cli.age_threshold) {
+        }) => match scan::run_scan(&git, &directory, cli.age_threshold, &progress) {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,

--- a/crates/git-stash-tidy/src/scan.rs
+++ b/crates/git-stash-tidy/src/scan.rs
@@ -6,6 +6,7 @@ use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
 use git_tidy_core::landed::diff_similarity;
 use git_tidy_core::output::repo_display_name;
+use git_tidy_core::progress::Progress;
 use git_tidy_core::types::ClassificationLabel;
 
 use crate::types::{
@@ -68,6 +69,7 @@ pub fn run_scan(
     git: &dyn GitOps,
     directory: &Path,
     age_threshold: u64,
+    progress: &Progress,
 ) -> Result<StashScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
 
@@ -76,6 +78,7 @@ pub fn run_scan(
     let mut warnings = Vec::new();
     let mut total_scanned = 0;
 
+    let pb = progress.bar(repo_paths.len() as u64, "Scanning stashes");
     for repo_path in &repo_paths {
         let stashes = match git.list_stashes(repo_path) {
             Ok(s) => s,
@@ -129,7 +132,9 @@ pub fn run_scan(
             name: repo_name,
             stashes: classified,
         });
+        pb.inc(1);
     }
+    pb.finish_and_clear();
 
     Ok(StashScanResult {
         repos,

--- a/crates/git-stash-tidy/tests/integration_clean.rs
+++ b/crates/git-stash-tidy/tests/integration_clean.rs
@@ -43,7 +43,13 @@ fn clean_drops_stash_in_real_repo() {
     assert_eq!(stashes.len(), 1);
 
     // Scan then clean
-    let scan_result = git_stash_tidy::scan::run_scan(&git_ops, &scan_dir, 90).unwrap();
+    let scan_result = git_stash_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        90,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let options = git_stash_tidy::clean::CleanOptions {
         dry_run: false,
@@ -78,7 +84,13 @@ fn clean_dry_run_does_not_drop() {
     git(&repo, &["checkout", "main"]);
     git(&repo, &["branch", "-D", "temp"]);
 
-    let scan_result = git_stash_tidy::scan::run_scan(&git_ops, &scan_dir, 90).unwrap();
+    let scan_result = git_stash_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        90,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let options = git_stash_tidy::clean::CleanOptions {
         dry_run: true,

--- a/crates/git-stash-tidy/tests/integration_scan.rs
+++ b/crates/git-stash-tidy/tests/integration_scan.rs
@@ -37,7 +37,13 @@ fn scan_real_repo_with_stashes() {
     git(&repo, &["add", "temp.txt"]);
     git(&repo, &["stash"]);
 
-    let result = git_stash_tidy::scan::run_scan(&git_ops, &scan_dir, 90).unwrap();
+    let result = git_stash_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        90,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     assert_eq!(result.total_scanned, 1);
@@ -64,7 +70,13 @@ fn scan_repo_with_orphaned_stash() {
     git(&repo, &["checkout", "main"]);
     git(&repo, &["branch", "-D", "temp-feature"]);
 
-    let result = git_stash_tidy::scan::run_scan(&git_ops, &scan_dir, 90).unwrap();
+    let result = git_stash_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        90,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     assert_eq!(result.total_scanned, 1);
@@ -80,7 +92,13 @@ fn scan_empty_repo_no_stashes() {
     let scan_dir = dir.path().canonicalize().unwrap().join("projects");
     let git_ops = RealGit;
 
-    let result = git_stash_tidy::scan::run_scan(&git_ops, &scan_dir, 90).unwrap();
+    let result = git_stash_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        90,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     // Repo exists but has no stashes, so no groups reported
     assert!(result.repos.is_empty());

--- a/crates/git-tag-tidy/src/main.rs
+++ b/crates/git-tag-tidy/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use git_tidy_core::cli::{OutputFormat, validate_directory};
 use git_tidy_core::error;
 use git_tidy_core::git;
+use git_tidy_core::progress::Progress;
 
 mod clean;
 mod cli;
@@ -21,6 +22,7 @@ fn main() {
     }
 
     let git = git::RealGit;
+    let progress = Progress::new();
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -32,7 +34,7 @@ fn main() {
                 _ => OutputFormat::Human,
             };
 
-            match scan::run_scan(&git, &directory, cli.offline) {
+            match scan::run_scan(&git, &directory, cli.offline, &progress) {
                 Ok(result) => {
                     let write_result = match format {
                         OutputFormat::Json => output::write_json(&mut stdout, &result),
@@ -56,7 +58,7 @@ fn main() {
             include_remote,
             all,
             ..
-        }) => match scan::run_scan(&git, &directory, cli.offline) {
+        }) => match scan::run_scan(&git, &directory, cli.offline, &progress) {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,

--- a/crates/git-tag-tidy/src/scan.rs
+++ b/crates/git-tag-tidy/src/scan.rs
@@ -5,6 +5,7 @@ use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
+use git_tidy_core::progress::Progress;
 use git_tidy_core::types::ClassificationLabel;
 
 use crate::types::{
@@ -34,7 +35,12 @@ pub fn classify_tag(
 }
 
 /// Scan all repos in `directory` for tags.
-pub fn run_scan(git: &dyn GitOps, directory: &Path, offline: bool) -> Result<TagScanResult, Error> {
+pub fn run_scan(
+    git: &dyn GitOps,
+    directory: &Path,
+    offline: bool,
+    progress: &Progress,
+) -> Result<TagScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
 
     let mut repos = Vec::new();
@@ -42,6 +48,7 @@ pub fn run_scan(git: &dyn GitOps, directory: &Path, offline: bool) -> Result<Tag
     let mut warnings = Vec::new();
     let mut total_scanned = 0;
 
+    let pb = progress.bar(repo_paths.len() as u64, "Scanning tags");
     for repo_path in &repo_paths {
         // Get local tags
         let local_tags: HashSet<String> = match git.list_local_tags(repo_path) {
@@ -160,7 +167,9 @@ pub fn run_scan(git: &dyn GitOps, directory: &Path, offline: bool) -> Result<Tag
             name: repo_name,
             tags: classified,
         });
+        pb.inc(1);
     }
+    pb.finish_and_clear();
 
     Ok(TagScanResult {
         repos,

--- a/crates/git-tag-tidy/tests/integration_clean.rs
+++ b/crates/git-tag-tidy/tests/integration_clean.rs
@@ -45,7 +45,13 @@ fn clean_removes_local_only_tag() {
     assert!(tags.contains(&"local-wip".to_string()));
 
     // Scan then clean
-    let scan_result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+    let scan_result = git_tag_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let options = git_tag_tidy::clean::CleanOptions {
         dry_run: false,
@@ -83,7 +89,13 @@ fn clean_dry_run_preserves_tags() {
 
     git(&repo, &["tag", "local-wip"]);
 
-    let scan_result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+    let scan_result = git_tag_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let options = git_tag_tidy::clean::CleanOptions {
         dry_run: true,
@@ -130,7 +142,13 @@ fn clean_removes_stale_tag() {
     assert!(tags.contains(&"stale-tag".to_string()));
 
     // Scan (offline since no remote) then clean
-    let scan_result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, true).unwrap();
+    let scan_result = git_tag_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        true,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let options = git_tag_tidy::clean::CleanOptions {
         dry_run: false,
@@ -177,7 +195,13 @@ fn clean_include_remote_deletes_from_remote() {
     git(&repo, &["branch", "-D", "orphan-branch"]);
 
     // Scan then clean with --include-remote
-    let scan_result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+    let scan_result = git_tag_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     let options = git_tag_tidy::clean::CleanOptions {
         dry_run: false,

--- a/crates/git-tag-tidy/tests/integration_scan.rs
+++ b/crates/git-tag-tidy/tests/integration_scan.rs
@@ -43,7 +43,13 @@ fn scan_synced_tag() {
     git(&repo, &["tag", "v1.0.0"]);
     git(&repo, &["push", "origin", "v1.0.0"]);
 
-    let result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+    let result = git_tag_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     assert!(result.total_scanned >= 1);
@@ -75,7 +81,13 @@ fn scan_local_only_tag() {
     // Create a tag but don't push it
     git(&repo, &["tag", "local-only-tag"]);
 
-    let result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, false).unwrap();
+    let result = git_tag_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        false,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
 
@@ -104,7 +116,13 @@ fn scan_stale_tag() {
     git(&repo, &["checkout", "main"]);
     git(&repo, &["branch", "-D", "orphan-branch"]);
 
-    let result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, true).unwrap();
+    let result = git_tag_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        true,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
 
@@ -126,7 +144,13 @@ fn scan_annotated_tag() {
     // Create an annotated tag
     git(&repo, &["tag", "-a", "v2.0.0", "-m", "Release 2.0.0"]);
 
-    let result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, true).unwrap();
+    let result = git_tag_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        true,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
 
@@ -147,7 +171,13 @@ fn scan_empty_repo_no_tags() {
     let scan_dir = dir.path().canonicalize().unwrap().join("projects");
     let git_ops = RealGit;
 
-    let result = git_tag_tidy::scan::run_scan(&git_ops, &scan_dir, true).unwrap();
+    let result = git_tag_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        true,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
 
     // Repo has no tags, so no groups
     assert!(result.repos.is_empty());

--- a/crates/git-tidy-core/Cargo.toml
+++ b/crates/git-tidy-core/Cargo.toml
@@ -8,6 +8,7 @@ description = "Shared classification logic and git abstraction for git-worktree-
 testutil = ["dep:tempfile"]
 
 [dependencies]
+indicatif = "0.17"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strsim = "0.11"

--- a/crates/git-tidy-core/src/fetch.rs
+++ b/crates/git-tidy-core/src/fetch.rs
@@ -2,19 +2,27 @@ use std::path::Path;
 use std::thread;
 
 use crate::git::GitOps;
+use crate::progress::Progress;
 
 /// Fetch from all repos concurrently using `thread::scope`.
 ///
 /// Returns a `Vec<String>` of warning messages for repos where fetch failed.
 /// Single-repo and empty inputs skip thread overhead.
-pub fn parallel_fetch(git: &dyn GitOps, repo_paths: &[&Path]) -> Vec<String> {
+pub fn parallel_fetch(git: &dyn GitOps, repo_paths: &[&Path], progress: &Progress) -> Vec<String> {
+    let pb = progress.bar(repo_paths.len() as u64, "Fetching");
+
     match repo_paths.len() {
-        0 => Vec::new(),
+        0 => {
+            pb.finish_and_clear();
+            Vec::new()
+        }
         1 => {
             let mut warnings = Vec::new();
             if let Err(e) = git.fetch_prune(repo_paths[0]) {
                 warnings.push(format!("fetch failed for {}: {e}", repo_paths[0].display()));
             }
+            pb.inc(1);
+            pb.finish_and_clear();
             warnings
         }
         _ => {
@@ -28,9 +36,11 @@ pub fn parallel_fetch(git: &dyn GitOps, repo_paths: &[&Path]) -> Vec<String> {
                                 .unwrap()
                                 .push(format!("fetch failed for {}: {e}", repo_path.display()));
                         }
+                        pb.inc(1);
                     });
                 }
             });
+            pb.finish_and_clear();
             warnings.into_inner().unwrap()
         }
     }
@@ -54,7 +64,7 @@ mod tests {
         ];
         let path_refs: Vec<&Path> = paths.iter().map(|p| p.as_path()).collect();
 
-        let warnings = parallel_fetch(&git, &path_refs);
+        let warnings = parallel_fetch(&git, &path_refs, &Progress::disabled());
 
         assert!(warnings.is_empty());
         let calls = git.fetch_prune_calls();
@@ -68,7 +78,7 @@ mod tests {
     fn parallel_fetch_empty_repos() {
         let git = MockGitBuilder::new().build();
 
-        let warnings = parallel_fetch(&git, &[]);
+        let warnings = parallel_fetch(&git, &[], &Progress::disabled());
 
         assert!(warnings.is_empty());
         assert!(git.fetch_prune_calls().is_empty());
@@ -79,7 +89,7 @@ mod tests {
         let git = MockGitBuilder::new().build();
         let path = PathBuf::from("/solo");
 
-        let warnings = parallel_fetch(&git, &[path.as_path()]);
+        let warnings = parallel_fetch(&git, &[path.as_path()], &Progress::disabled());
 
         assert!(warnings.is_empty());
         assert_eq!(git.fetch_prune_calls(), vec![PathBuf::from("/solo")]);

--- a/crates/git-tidy-core/src/lib.rs
+++ b/crates/git-tidy-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod fetch;
 pub mod git;
 pub mod landed;
 pub mod output;
+pub mod progress;
 pub mod types;
 
 #[cfg(any(test, feature = "testutil"))]

--- a/crates/git-tidy-core/src/progress.rs
+++ b/crates/git-tidy-core/src/progress.rs
@@ -1,0 +1,122 @@
+use std::io::IsTerminal;
+
+use indicatif::{ProgressBar, ProgressStyle};
+
+/// Factory for creating progress bars that respect TTY detection.
+///
+/// When `enabled` is true, creates visible progress bars on stderr.
+/// When `enabled` is false (non-TTY, tests, nested contexts), creates
+/// hidden no-op bars so callers never need conditionals.
+pub struct Progress {
+    enabled: bool,
+}
+
+impl Default for Progress {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Progress {
+    /// Create a new `Progress` with TTY auto-detection on stderr.
+    pub fn new() -> Self {
+        Self {
+            enabled: std::io::stderr().is_terminal(),
+        }
+    }
+
+    /// Create a disabled `Progress` that always returns hidden bars.
+    /// Use in tests and nested contexts (e.g., audit runner calling sub-tools).
+    pub fn disabled() -> Self {
+        Self { enabled: false }
+    }
+
+    /// Returns whether progress display is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Create a progress bar with a known length (e.g., repo count).
+    ///
+    /// Displays: `⠋ Fetching  ████████░░░░░░  3/5`
+    pub fn bar(&self, len: u64, msg: &str) -> ProgressBar {
+        if !self.enabled {
+            return ProgressBar::hidden();
+        }
+        let pb = ProgressBar::new(len);
+        pb.set_style(
+            ProgressStyle::with_template("{spinner:.cyan} {msg}  {wide_bar:.cyan} {pos}/{len}")
+                .unwrap()
+                .progress_chars("██░"),
+        );
+        pb.set_message(msg.to_string());
+        pb
+    }
+
+    /// Create a spinner with a message (no known length).
+    ///
+    /// Displays: `⠋ [3/8] Scanning branches...`
+    pub fn spinner(&self, msg: &str) -> ProgressBar {
+        if !self.enabled {
+            return ProgressBar::hidden();
+        }
+        let pb = ProgressBar::new_spinner();
+        pb.set_style(ProgressStyle::with_template("{spinner:.cyan} {msg}").unwrap());
+        pb.set_message(msg.to_string());
+        pb.enable_steady_tick(std::time::Duration::from_millis(100));
+        pb
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_returns_hidden_bar() {
+        let p = Progress::disabled();
+        assert!(!p.is_enabled());
+
+        let bar = p.bar(10, "test");
+        assert!(bar.is_hidden());
+    }
+
+    #[test]
+    fn disabled_returns_hidden_spinner() {
+        let p = Progress::disabled();
+        let spinner = p.spinner("test");
+        assert!(spinner.is_hidden());
+    }
+
+    #[test]
+    fn bar_sets_length_and_message() {
+        // Force-enable even in test (non-TTY) context.
+        // Note: indicatif may still hide the bar if stderr is not a TTY,
+        // so we only verify length/message, not visibility.
+        let p = Progress { enabled: true };
+
+        let bar = p.bar(5, "Fetching");
+        assert_eq!(bar.length(), Some(5));
+        assert_eq!(bar.message(), "Fetching");
+        bar.finish_and_clear();
+    }
+
+    #[test]
+    fn spinner_sets_message() {
+        let p = Progress { enabled: true };
+
+        let spinner = p.spinner("Scanning...");
+        assert_eq!(spinner.message(), "Scanning...");
+        spinner.finish_and_clear();
+    }
+
+    #[test]
+    fn new_detects_tty() {
+        // In test context, stderr is typically not a TTY
+        let p = Progress::new();
+        // We can't assert the exact value since it depends on the test runner,
+        // but we can verify it doesn't panic and returns a valid Progress
+        let bar = p.bar(1, "test");
+        bar.finish_and_clear();
+    }
+}

--- a/crates/git-tidy/src/inprocess.rs
+++ b/crates/git-tidy/src/inprocess.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use git_tidy_core::caching::CachingGitOps;
 use git_tidy_core::config;
 use git_tidy_core::git::{GitOps, RealGit};
+use git_tidy_core::progress::Progress;
 
 use crate::runner::matches_filter;
 use crate::types::{AuditResult, TOOL_SPECS, ToolResult};
@@ -23,28 +24,55 @@ const DEFAULT_LFS_DEPTH: usize = 1000;
 
 /// Run an audit by calling each tool's scan/lint function in-process,
 /// sharing a `CachingGitOps` to avoid redundant git calls.
-pub fn run_audit_inprocess(directory: &Path, tool_filter: Option<&[String]>) -> AuditResult {
+pub fn run_audit_inprocess(
+    directory: &Path,
+    tool_filter: Option<&[String]>,
+    progress: &Progress,
+) -> AuditResult {
     let git = RealGit;
     let caching = CachingGitOps::new(&git);
 
     // Resolve noise patterns from config file (no CLI overrides in audit mode).
     let noise_patterns = resolve_noise_patterns();
 
+    // Collect tools to run (for progress bar length).
+    let specs: Vec<_> = TOOL_SPECS
+        .iter()
+        .filter(|spec| {
+            tool_filter
+                .map(|f| f.iter().any(|entry| matches_filter(spec.binary, entry)))
+                .unwrap_or(true)
+        })
+        .collect();
+
+    let pb = progress.bar(specs.len() as u64, "Auditing");
     let mut results = Vec::new();
     let mut tools_found = Vec::new();
 
-    for spec in TOOL_SPECS {
-        if let Some(filter) = tool_filter
-            && !filter.iter().any(|f| matches_filter(spec.binary, f))
-        {
-            continue;
-        }
+    // Sub-tool scans get disabled progress to avoid visual conflicts.
+    let sub_progress = Progress::disabled();
+
+    for (idx, spec) in specs.iter().enumerate() {
+        pb.set_message(format!(
+            "[{}/{}] Scanning {}...",
+            idx + 1,
+            specs.len(),
+            spec.item_noun
+        ));
 
         tools_found.push(spec.binary.to_string());
 
-        let result = run_tool_scan(spec.binary, &caching, directory, &noise_patterns);
+        let result = run_tool_scan(
+            spec.binary,
+            &caching,
+            directory,
+            &noise_patterns,
+            &sub_progress,
+        );
         results.push(result);
+        pb.inc(1);
     }
+    pb.finish_and_clear();
 
     AuditResult {
         directory: directory.to_path_buf(),
@@ -74,16 +102,17 @@ fn run_tool_scan(
     git: &dyn GitOps,
     directory: &Path,
     noise_patterns: &[String],
+    progress: &Progress,
 ) -> ToolResult {
     match binary {
-        "git-worktree-tidy" => scan_worktrees(git, directory, noise_patterns),
-        "git-branch-tidy" => scan_branches(git, directory),
-        "git-stash-tidy" => scan_stashes(git, directory),
-        "git-remote-tidy" => scan_remotes(git, directory),
-        "git-tag-tidy" => scan_tags(git, directory),
-        "git-repo-tidy" => scan_repos(git, directory, noise_patterns),
-        "git-config-tidy" => lint_config(git, directory),
-        "git-lfs-tidy" => scan_lfs(git, directory),
+        "git-worktree-tidy" => scan_worktrees(git, directory, noise_patterns, progress),
+        "git-branch-tidy" => scan_branches(git, directory, progress),
+        "git-stash-tidy" => scan_stashes(git, directory, progress),
+        "git-remote-tidy" => scan_remotes(git, directory, progress),
+        "git-tag-tidy" => scan_tags(git, directory, progress),
+        "git-repo-tidy" => scan_repos(git, directory, noise_patterns, progress),
+        "git-config-tidy" => lint_config(git, directory, progress),
+        "git-lfs-tidy" => scan_lfs(git, directory, progress),
         _ => ToolResult {
             name: binary.to_string(),
             item_noun: "unknown".to_string(),
@@ -103,13 +132,19 @@ fn counts_map(entries: &[(&str, usize)]) -> BTreeMap<String, usize> {
         .collect()
 }
 
-fn scan_worktrees(git: &dyn GitOps, directory: &Path, noise_patterns: &[String]) -> ToolResult {
+fn scan_worktrees(
+    git: &dyn GitOps,
+    directory: &Path,
+    noise_patterns: &[String],
+    progress: &Progress,
+) -> ToolResult {
     match git_worktree_tidy::scan::run_scan(
         git,
         directory,
         DEFAULT_BEHIND_THRESHOLD,
         false,
         noise_patterns,
+        progress,
     ) {
         Ok(result) => {
             let c = &result.counts;
@@ -133,8 +168,9 @@ fn scan_worktrees(git: &dyn GitOps, directory: &Path, noise_patterns: &[String])
     }
 }
 
-fn scan_branches(git: &dyn GitOps, directory: &Path) -> ToolResult {
-    match git_branch_tidy::scan::run_scan(git, directory, DEFAULT_BEHIND_THRESHOLD, false) {
+fn scan_branches(git: &dyn GitOps, directory: &Path, progress: &Progress) -> ToolResult {
+    match git_branch_tidy::scan::run_scan(git, directory, DEFAULT_BEHIND_THRESHOLD, false, progress)
+    {
         Ok(result) => {
             let c = &result.counts;
             let counts = counts_map(&[
@@ -157,8 +193,8 @@ fn scan_branches(git: &dyn GitOps, directory: &Path) -> ToolResult {
     }
 }
 
-fn scan_stashes(git: &dyn GitOps, directory: &Path) -> ToolResult {
-    match git_stash_tidy::scan::run_scan(git, directory, DEFAULT_AGE_THRESHOLD) {
+fn scan_stashes(git: &dyn GitOps, directory: &Path, progress: &Progress) -> ToolResult {
+    match git_stash_tidy::scan::run_scan(git, directory, DEFAULT_AGE_THRESHOLD, progress) {
         Ok(result) => {
             let c = &result.counts;
             let counts = counts_map(&[
@@ -180,8 +216,8 @@ fn scan_stashes(git: &dyn GitOps, directory: &Path) -> ToolResult {
     }
 }
 
-fn scan_remotes(git: &dyn GitOps, directory: &Path) -> ToolResult {
-    match git_remote_tidy::scan::run_scan(git, directory, false) {
+fn scan_remotes(git: &dyn GitOps, directory: &Path, progress: &Progress) -> ToolResult {
+    match git_remote_tidy::scan::run_scan(git, directory, false, progress) {
         Ok(result) => {
             let c = &result.counts;
             let counts = counts_map(&[
@@ -202,8 +238,8 @@ fn scan_remotes(git: &dyn GitOps, directory: &Path) -> ToolResult {
     }
 }
 
-fn scan_tags(git: &dyn GitOps, directory: &Path) -> ToolResult {
-    match git_tag_tidy::scan::run_scan(git, directory, false) {
+fn scan_tags(git: &dyn GitOps, directory: &Path, progress: &Progress) -> ToolResult {
+    match git_tag_tidy::scan::run_scan(git, directory, false, progress) {
         Ok(result) => {
             let c = &result.counts;
             let counts = counts_map(&[
@@ -225,8 +261,20 @@ fn scan_tags(git: &dyn GitOps, directory: &Path) -> ToolResult {
     }
 }
 
-fn scan_repos(git: &dyn GitOps, directory: &Path, noise_patterns: &[String]) -> ToolResult {
-    match git_repo_tidy::scan::run_scan(git, directory, DEFAULT_STALE_DAYS, noise_patterns, false) {
+fn scan_repos(
+    git: &dyn GitOps,
+    directory: &Path,
+    noise_patterns: &[String],
+    progress: &Progress,
+) -> ToolResult {
+    match git_repo_tidy::scan::run_scan(
+        git,
+        directory,
+        DEFAULT_STALE_DAYS,
+        noise_patterns,
+        false,
+        progress,
+    ) {
         Ok(result) => {
             let c = &result.counts;
             let counts = counts_map(&[
@@ -247,8 +295,8 @@ fn scan_repos(git: &dyn GitOps, directory: &Path, noise_patterns: &[String]) -> 
     }
 }
 
-fn lint_config(git: &dyn GitOps, directory: &Path) -> ToolResult {
-    match git_config_tidy::lint::run_lint(git, directory) {
+fn lint_config(git: &dyn GitOps, directory: &Path, progress: &Progress) -> ToolResult {
+    match git_config_tidy::lint::run_lint(git, directory, progress) {
         Ok(result) => {
             let c = &result.counts;
             let counts = counts_map(&[
@@ -268,12 +316,13 @@ fn lint_config(git: &dyn GitOps, directory: &Path) -> ToolResult {
     }
 }
 
-fn scan_lfs(git: &dyn GitOps, directory: &Path) -> ToolResult {
+fn scan_lfs(git: &dyn GitOps, directory: &Path, progress: &Progress) -> ToolResult {
     match git_lfs_tidy::scan::run_scan(
         git,
         directory,
         DEFAULT_LFS_SIZE_THRESHOLD,
         DEFAULT_LFS_DEPTH,
+        progress,
     ) {
         Ok(result) => {
             let c = &result.counts;
@@ -331,7 +380,8 @@ mod tests {
     fn scan_worktrees_with_empty_mock() {
         // MockGit with no data will produce zero worktrees
         let mock = MockGitBuilder::new().build();
-        let result = scan_worktrees(&mock, Path::new("/nonexistent"), &[]);
+        let p = Progress::disabled();
+        let result = scan_worktrees(&mock, Path::new("/nonexistent"), &[], &p);
         // discover_worktrees will fail on nonexistent dir, giving an error
         assert!(result.error.is_some() || result.total == 0);
     }
@@ -339,28 +389,32 @@ mod tests {
     #[test]
     fn scan_branches_with_empty_mock() {
         let mock = MockGitBuilder::new().build();
-        let result = scan_branches(&mock, Path::new("/nonexistent"));
+        let p = Progress::disabled();
+        let result = scan_branches(&mock, Path::new("/nonexistent"), &p);
         assert!(result.error.is_some() || result.total == 0);
     }
 
     #[test]
     fn scan_stashes_with_empty_mock() {
         let mock = MockGitBuilder::new().build();
-        let result = scan_stashes(&mock, Path::new("/nonexistent"));
+        let p = Progress::disabled();
+        let result = scan_stashes(&mock, Path::new("/nonexistent"), &p);
         assert!(result.error.is_some() || result.total == 0);
     }
 
     #[test]
     fn lint_config_with_empty_mock() {
         let mock = MockGitBuilder::new().build();
-        let result = lint_config(&mock, Path::new("/nonexistent"));
+        let p = Progress::disabled();
+        let result = lint_config(&mock, Path::new("/nonexistent"), &p);
         assert!(result.error.is_some() || result.total == 0);
     }
 
     #[test]
     fn scan_lfs_with_empty_mock() {
         let mock = MockGitBuilder::new().build();
-        let result = scan_lfs(&mock, Path::new("/nonexistent"));
+        let p = Progress::disabled();
+        let result = scan_lfs(&mock, Path::new("/nonexistent"), &p);
         assert!(result.error.is_some() || result.total == 0);
     }
 
@@ -384,7 +438,8 @@ mod tests {
     #[test]
     fn unknown_tool_returns_error() {
         let mock = MockGitBuilder::new().build();
-        let result = run_tool_scan("git-unknown-tidy", &mock, Path::new("/tmp"), &[]);
+        let p = Progress::disabled();
+        let result = run_tool_scan("git-unknown-tidy", &mock, Path::new("/tmp"), &[], &p);
         assert!(result.error.is_some());
         assert!(result.error.as_ref().unwrap().contains("unknown tool"));
     }

--- a/crates/git-tidy/src/main.rs
+++ b/crates/git-tidy/src/main.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::process;
 
 use clap::Parser;
+use git_tidy_core::progress::Progress;
 
 mod cli;
 mod dispatch;
@@ -39,11 +40,12 @@ fn main() {
         Some(tools.as_slice())
     };
 
+    let progress = Progress::new();
     let result = if subprocess {
         let runner = runner::RealToolRunner;
-        runner::run_audit(&runner, &directory, tool_filter)
+        runner::run_audit(&runner, &directory, tool_filter, &progress)
     } else {
-        inprocess::run_audit_inprocess(&directory, tool_filter)
+        inprocess::run_audit_inprocess(&directory, tool_filter, &progress)
     };
 
     let mut stdout = io::stdout().lock();

--- a/crates/git-tidy/src/runner.rs
+++ b/crates/git-tidy/src/runner.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use git_tidy_core::progress::Progress;
+
 use crate::types::{AuditResult, TOOL_SPECS, ToolResult, ToolSpec};
 
 /// Abstraction for finding and running git-tidy sub-tools.
@@ -88,21 +90,35 @@ pub fn run_audit(
     runner: &dyn ToolRunner,
     directory: &Path,
     tool_filter: Option<&[String]>,
+    progress: &Progress,
 ) -> AuditResult {
     let mut tools_found = Vec::new();
     let mut tools_missing = Vec::new();
     let mut results = Vec::new();
 
-    for spec in TOOL_SPECS {
-        // Apply filter if set
-        if let Some(filter) = tool_filter
-            && !filter.iter().any(|f| matches_filter(spec.binary, f))
-        {
-            continue;
-        }
+    // Collect matching specs for progress bar length.
+    let specs: Vec<_> = TOOL_SPECS
+        .iter()
+        .filter(|spec| {
+            tool_filter
+                .map(|f| f.iter().any(|entry| matches_filter(spec.binary, entry)))
+                .unwrap_or(true)
+        })
+        .collect();
+
+    let pb = progress.bar(specs.len() as u64, "Auditing");
+
+    for (idx, spec) in specs.iter().enumerate() {
+        pb.set_message(format!(
+            "[{}/{}] Scanning {}...",
+            idx + 1,
+            specs.len(),
+            spec.item_noun
+        ));
 
         let Some(path) = runner.find_tool(spec.binary) else {
             tools_missing.push(spec.binary.to_string());
+            pb.inc(1);
             continue;
         };
 
@@ -117,7 +133,9 @@ pub fn run_audit(
         };
 
         results.push(result);
+        pb.inc(1);
     }
+    pb.finish_and_clear();
 
     AuditResult {
         directory: directory.to_path_buf(),
@@ -300,7 +318,7 @@ mod tests {
             ("git-lfs-tidy", Ok("[]")),
         ]);
 
-        let result = run_audit(&runner, Path::new("/dev"), None);
+        let result = run_audit(&runner, Path::new("/dev"), None, &Progress::disabled());
         assert_eq!(result.tools_found.len(), 8);
         assert!(result.tools_missing.is_empty());
         assert_eq!(result.results.len(), 8);
@@ -325,7 +343,7 @@ mod tests {
             Ok(r#"[{"classification":"active"}]"#),
         )]);
 
-        let result = run_audit(&runner, Path::new("/dev"), None);
+        let result = run_audit(&runner, Path::new("/dev"), None, &Progress::disabled());
         assert_eq!(result.tools_found, vec!["git-branch-tidy"]);
         assert!(
             result
@@ -340,7 +358,7 @@ mod tests {
     fn audit_tool_returns_error() {
         let runner = MockToolRunner::new(vec![("git-branch-tidy", Err("process failed"))]);
 
-        let result = run_audit(&runner, Path::new("/dev"), None);
+        let result = run_audit(&runner, Path::new("/dev"), None, &Progress::disabled());
         assert_eq!(result.results.len(), 1);
         assert_eq!(result.results[0].error.as_deref(), Some("process failed"));
         assert_eq!(result.results[0].total, 0);
@@ -350,7 +368,7 @@ mod tests {
     fn audit_tool_returns_invalid_json() {
         let runner = MockToolRunner::new(vec![("git-branch-tidy", Ok("not json"))]);
 
-        let result = run_audit(&runner, Path::new("/dev"), None);
+        let result = run_audit(&runner, Path::new("/dev"), None, &Progress::disabled());
         assert_eq!(result.results.len(), 1);
         assert!(result.results[0].error.is_some());
         assert!(
@@ -371,7 +389,12 @@ mod tests {
         ]);
 
         let filter = vec!["branch".to_string(), "tag".to_string()];
-        let result = run_audit(&runner, Path::new("/dev"), Some(&filter));
+        let result = run_audit(
+            &runner,
+            Path::new("/dev"),
+            Some(&filter),
+            &Progress::disabled(),
+        );
 
         // Only branch and tag should be checked
         assert_eq!(result.tools_found, vec!["git-branch-tidy", "git-tag-tidy"]);
@@ -383,7 +406,7 @@ mod tests {
     fn audit_no_tools_found() {
         let runner = MockToolRunner::new(vec![]);
 
-        let result = run_audit(&runner, Path::new("/dev"), None);
+        let result = run_audit(&runner, Path::new("/dev"), None, &Progress::disabled());
         assert!(result.tools_found.is_empty());
         assert_eq!(result.tools_missing.len(), 8);
         assert!(result.results.is_empty());

--- a/crates/git-tidy/tests/integration.rs
+++ b/crates/git-tidy/tests/integration.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use git_tidy::runner::{ToolRunner, run_audit};
+use git_tidy_core::progress::Progress;
 
 /// A test runner that simulates installed tools with canned responses.
 struct FakeToolRunner {
@@ -63,7 +64,7 @@ fn full_audit_multiple_tools() {
         ),
     ]);
 
-    let result = run_audit(&runner, Path::new("/tmp/test"), None);
+    let result = run_audit(&runner, Path::new("/tmp/test"), None, &Progress::disabled());
 
     // Check found/missing
     assert!(
@@ -105,7 +106,7 @@ fn full_audit_json_roundtrip() {
         r#"[{"classification":"active"}]"#,
     )]);
 
-    let result = run_audit(&runner, Path::new("/tmp/test"), None);
+    let result = run_audit(&runner, Path::new("/tmp/test"), None, &Progress::disabled());
 
     // Serialize to JSON and parse back
     let mut buf = Vec::new();
@@ -124,7 +125,7 @@ fn full_audit_porcelain_roundtrip() {
         r#"[{"classification":"active"},{"classification":"merged"}]"#,
     )]);
 
-    let result = run_audit(&runner, Path::new("/tmp"), None);
+    let result = run_audit(&runner, Path::new("/tmp"), None, &Progress::disabled());
 
     let mut buf = Vec::new();
     git_tidy::output::write_porcelain(&mut buf, &result).unwrap();
@@ -147,7 +148,7 @@ fn full_audit_human_output_end_to_end() {
         r#"[{"classification":"active"},{"classification":"active"},{"classification":"merged"}]"#,
     )]);
 
-    let result = run_audit(&runner, Path::new("/tmp/dev"), None);
+    let result = run_audit(&runner, Path::new("/tmp/dev"), None, &Progress::disabled());
 
     let mut buf = Vec::new();
     git_tidy::output::write_human(&mut buf, &result, false).unwrap();
@@ -171,7 +172,12 @@ fn audit_filter_limits_tools() {
     ]);
 
     let filter = vec!["branch".to_string()];
-    let result = run_audit(&runner, Path::new("/tmp"), Some(&filter));
+    let result = run_audit(
+        &runner,
+        Path::new("/tmp"),
+        Some(&filter),
+        &Progress::disabled(),
+    );
 
     assert_eq!(result.tools_found, vec!["git-branch-tidy"]);
     assert!(result.tools_missing.is_empty());

--- a/crates/git-worktree-tidy/src/main.rs
+++ b/crates/git-worktree-tidy/src/main.rs
@@ -7,6 +7,7 @@ use git_tidy_core::cli::validate_directory;
 use git_tidy_core::config;
 use git_tidy_core::error;
 use git_tidy_core::git;
+use git_tidy_core::progress::Progress;
 
 mod clean;
 mod cli;
@@ -35,6 +36,7 @@ fn main() {
     let noise_patterns = noise_config.resolve();
 
     let git = git::RealGit;
+    let progress = Progress::new();
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -52,6 +54,7 @@ fn main() {
                 cli.behind_threshold,
                 cli.verbose,
                 &noise_patterns,
+                &progress,
             ) {
                 Ok(result) => {
                     let write_result = match format {
@@ -84,6 +87,7 @@ fn main() {
                 cli.behind_threshold,
                 cli.verbose,
                 &noise_patterns,
+                &progress,
             ) {
                 Ok(scan_result) => {
                     let options = clean::CleanOptions {

--- a/crates/git-worktree-tidy/src/scan.rs
+++ b/crates/git-worktree-tidy/src/scan.rs
@@ -4,6 +4,7 @@ use git_tidy_core::classification;
 use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
+use git_tidy_core::progress::Progress;
 use git_tidy_core::types::{ClassificationLabel, RepoGroup, ScanCounts, ScanResult};
 
 use crate::discovery;
@@ -15,16 +16,18 @@ pub fn run_scan(
     behind_threshold: usize,
     verbose: bool,
     noise_patterns: &[String],
+    progress: &Progress,
 ) -> Result<ScanResult, Error> {
     let groups = discovery::discover_worktrees(directory)?;
 
     let repo_paths: Vec<&std::path::Path> = groups.keys().map(|p| p.as_path()).collect();
-    let mut warnings = git_tidy_core::fetch::parallel_fetch(git, &repo_paths);
+    let mut warnings = git_tidy_core::fetch::parallel_fetch(git, &repo_paths, progress);
 
     let mut repos = Vec::new();
     let mut counts = ScanCounts::default();
     let mut total_scanned = 0;
 
+    let pb = progress.bar(groups.len() as u64, "Scanning worktrees");
     for (repo_path, worktrees) in &groups {
         // Detect default branch
         let default_branch = match classification::detect_default_branch(git, repo_path) {
@@ -72,7 +75,9 @@ pub fn run_scan(
                 worktrees: classified,
             });
         }
+        pb.inc(1);
     }
+    pb.finish_and_clear();
 
     Ok(ScanResult {
         repos,


### PR DESCRIPTION
## Summary

- Add a `Progress` factory struct in `git-tidy-core` that creates `indicatif` progress bars gated on TTY detection (hidden no-ops when stderr is not a terminal)
- `parallel_fetch` shows a fetch progress bar that increments as repos complete
- Each of the 8 tool scan/lint functions shows a per-repo progress bar
- Audit runner shows tool-level progress (`[3/8] Scanning branches...`), with sub-tool progress disabled to avoid visual conflicts
- All tests use `Progress::disabled()` for clean output

Closes #59

## Test plan

- [x] `cargo test --workspace` passes (all tests use `Progress::disabled()`)
- [x] `cargo clippy --workspace --all-targets -- -D clippy::all` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: `git tidy` shows tool-level progress bar on TTY
- [ ] Manual: `git worktree-tidy scan ~/Developer` shows fetch + scan bars
- [ ] Manual: `git tidy --json` produces clean JSON (no progress artifacts on stdout)
- [ ] Manual: `git tidy 2>/dev/null` suppresses progress, normal output on stdout