### PR TITLE
Add shared NameFilter type and refactor worktree-tidy

### DIFF
--- a/crates/git-tidy-core/src/filter.rs
+++ b/crates/git-tidy-core/src/filter.rs
@@ -1,0 +1,219 @@
+use std::path::PathBuf;
+
+/// Case-insensitive substring name filter.
+///
+/// Include patterns use OR semantics (match any). Exclude takes precedence.
+/// An empty include list means "match all". An empty exclude list means "exclude none".
+#[derive(Debug, Clone, Default)]
+pub struct NameFilter {
+    include: Vec<String>,
+    exclude: Vec<String>,
+}
+
+impl NameFilter {
+    /// Create a new filter. Patterns are lowercased at construction time.
+    pub fn new(include: &[String], exclude: &[String]) -> Self {
+        Self {
+            include: include.iter().map(|p| p.to_lowercase()).collect(),
+            exclude: exclude.iter().map(|p| p.to_lowercase()).collect(),
+        }
+    }
+
+    /// Returns `true` when no filtering is needed (both lists empty).
+    pub fn is_empty(&self) -> bool {
+        self.include.is_empty() && self.exclude.is_empty()
+    }
+
+    /// Test whether `name` passes the filter.
+    ///
+    /// 1. If any exclude pattern matches (substring, case-insensitive) -> `false`
+    /// 2. If include is empty -> `true` (match all)
+    /// 3. If any include pattern matches -> `true`
+    /// 4. Otherwise -> `false`
+    pub fn matches(&self, name: &str) -> bool {
+        let lower = name.to_lowercase();
+
+        if self.exclude.iter().any(|p| lower.contains(p.as_str())) {
+            return false;
+        }
+
+        if self.include.is_empty() {
+            return true;
+        }
+
+        self.include.iter().any(|p| lower.contains(p.as_str()))
+    }
+}
+
+/// Filter a `Vec<PathBuf>` by basename using a `NameFilter`.
+///
+/// Extracts `file_name()` from each path and calls `filter.matches()`.
+/// Returns all paths unchanged when `filter.is_empty()`.
+pub fn filter_paths(paths: Vec<PathBuf>, filter: &NameFilter) -> Vec<PathBuf> {
+    if filter.is_empty() {
+        return paths;
+    }
+
+    paths
+        .into_iter()
+        .filter(|p| {
+            let basename = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            filter.matches(basename)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- NameFilter::new ---
+
+    #[test]
+    fn new_lowercases_patterns() {
+        let f = NameFilter::new(
+            &["FoO".to_string(), "BAR".to_string()],
+            &["Baz".to_string()],
+        );
+        assert_eq!(f.include, vec!["foo", "bar"]);
+        assert_eq!(f.exclude, vec!["baz"]);
+    }
+
+    // --- NameFilter::is_empty ---
+
+    #[test]
+    fn is_empty_when_both_empty() {
+        let f = NameFilter::default();
+        assert!(f.is_empty());
+    }
+
+    #[test]
+    fn is_empty_false_with_include() {
+        let f = NameFilter::new(&["foo".to_string()], &[]);
+        assert!(!f.is_empty());
+    }
+
+    #[test]
+    fn is_empty_false_with_exclude() {
+        let f = NameFilter::new(&[], &["foo".to_string()]);
+        assert!(!f.is_empty());
+    }
+
+    // --- NameFilter::matches ---
+
+    #[test]
+    fn empty_filter_matches_everything() {
+        let f = NameFilter::default();
+        assert!(f.matches("anything"));
+        assert!(f.matches(""));
+    }
+
+    #[test]
+    fn include_matches_substring() {
+        let f = NameFilter::new(&["feat".to_string()], &[]);
+        assert!(f.matches("my-feature-branch"));
+        assert!(!f.matches("bugfix-branch"));
+    }
+
+    #[test]
+    fn include_is_case_insensitive() {
+        let f = NameFilter::new(&["FEATURE".to_string()], &[]);
+        assert!(f.matches("my-feature-branch"));
+        assert!(f.matches("My-Feature-Branch"));
+        assert!(f.matches("MY-FEATURE-BRANCH"));
+    }
+
+    #[test]
+    fn multiple_include_patterns_use_or_semantics() {
+        let f = NameFilter::new(&["alpha".to_string(), "gamma".to_string()], &[]);
+        assert!(f.matches("alpha-thing"));
+        assert!(f.matches("gamma-thing"));
+        assert!(!f.matches("beta-thing"));
+    }
+
+    #[test]
+    fn exclude_rejects_matching_names() {
+        let f = NameFilter::new(&[], &["secret".to_string()]);
+        assert!(!f.matches("my-secret-project"));
+        assert!(f.matches("my-public-project"));
+    }
+
+    #[test]
+    fn exclude_is_case_insensitive() {
+        let f = NameFilter::new(&[], &["SECRET".to_string()]);
+        assert!(!f.matches("my-secret-project"));
+    }
+
+    #[test]
+    fn exclude_takes_precedence_over_include() {
+        let f = NameFilter::new(&["feat".to_string()], &["wip".to_string()]);
+        assert!(f.matches("feat-login"));
+        assert!(!f.matches("feat-wip-draft"));
+        assert!(!f.matches("wip-stuff"));
+    }
+
+    #[test]
+    fn include_without_match_rejects() {
+        let f = NameFilter::new(&["feat".to_string()], &[]);
+        assert!(!f.matches("bugfix-login"));
+    }
+
+    #[test]
+    fn exclude_only_passes_non_matching() {
+        let f = NameFilter::new(&[], &["test".to_string()]);
+        assert!(f.matches("production"));
+        assert!(!f.matches("test-branch"));
+    }
+
+    // --- filter_paths ---
+
+    #[test]
+    fn filter_paths_empty_filter_returns_all() {
+        let paths = vec![PathBuf::from("/dev/repo-a"), PathBuf::from("/dev/repo-b")];
+        let f = NameFilter::default();
+        let result = filter_paths(paths.clone(), &f);
+        assert_eq!(result, paths);
+    }
+
+    #[test]
+    fn filter_paths_filters_by_basename() {
+        let paths = vec![
+            PathBuf::from("/dev/my-feature"),
+            PathBuf::from("/dev/my-bugfix"),
+            PathBuf::from("/dev/other-feature"),
+        ];
+        let f = NameFilter::new(&["feature".to_string()], &[]);
+        let result = filter_paths(paths, &f);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], PathBuf::from("/dev/my-feature"));
+        assert_eq!(result[1], PathBuf::from("/dev/other-feature"));
+    }
+
+    #[test]
+    fn filter_paths_with_exclude() {
+        let paths = vec![
+            PathBuf::from("/dev/repo-alpha"),
+            PathBuf::from("/dev/repo-beta"),
+            PathBuf::from("/dev/repo-gamma"),
+        ];
+        let f = NameFilter::new(&[], &["beta".to_string()]);
+        let result = filter_paths(paths, &f);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], PathBuf::from("/dev/repo-alpha"));
+        assert_eq!(result[1], PathBuf::from("/dev/repo-gamma"));
+    }
+
+    #[test]
+    fn filter_paths_uses_basename_not_full_path() {
+        let paths = vec![PathBuf::from("/feature/bugfix-branch")];
+        let f = NameFilter::new(&["bugfix".to_string()], &[]);
+        let result = filter_paths(paths, &f);
+        assert_eq!(result.len(), 1);
+
+        // "feature" is in the parent dir, not the basename
+        let paths2 = vec![PathBuf::from("/feature/bugfix-branch")];
+        let f2 = NameFilter::new(&["feature".to_string()], &[]);
+        let result2 = filter_paths(paths2, &f2);
+        assert_eq!(result2.len(), 0);
+    }
+}

--- a/crates/git-tidy-core/src/lib.rs
+++ b/crates/git-tidy-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod dirty;
 pub mod discovery;
 pub mod error;
 pub mod fetch;
+pub mod filter;
 pub mod git;
 pub mod landed;
 pub mod output;

--- a/crates/git-tidy/src/inprocess.rs
+++ b/crates/git-tidy/src/inprocess.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use git_tidy_core::caching::CachingGitOps;
 use git_tidy_core::config;
+use git_tidy_core::filter::NameFilter;
 use git_tidy_core::git::{GitOps, RealGit};
 use git_tidy_core::progress::Progress;
 
@@ -144,7 +145,7 @@ fn scan_worktrees(
         DEFAULT_BEHIND_THRESHOLD,
         false,
         noise_patterns,
-        &[],
+        &NameFilter::default(),
         progress,
     ) {
         Ok(result) => {

--- a/crates/git-worktree-tidy/src/cli.rs
+++ b/crates/git-worktree-tidy/src/cli.rs
@@ -34,6 +34,10 @@ pub struct Cli {
     /// Filter worktrees by name substring (can be repeated, OR semantics)
     #[arg(long = "match", global = true)]
     pub match_patterns: Vec<String>,
+
+    /// Exclude worktrees by name substring (takes precedence over --match)
+    #[arg(long = "exclude", global = true)]
+    pub exclude_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -228,6 +232,42 @@ mod tests {
     fn match_pattern_with_subcommand() {
         let cli = Cli::parse_from(["git-worktree-tidy", "--match", "tubafrenzy", "scan"]);
         assert_eq!(cli.match_patterns, vec!["tubafrenzy".to_string()]);
+        assert!(matches!(cli.command, Some(Command::Scan { .. })));
+    }
+
+    #[test]
+    fn exclude_pattern_single() {
+        let cli = Cli::parse_from(["git-worktree-tidy", "--exclude", "wip"]);
+        assert_eq!(cli.exclude_patterns, vec!["wip".to_string()]);
+    }
+
+    #[test]
+    fn exclude_pattern_multiple() {
+        let cli = Cli::parse_from([
+            "git-worktree-tidy",
+            "--exclude",
+            "wip",
+            "--exclude",
+            "draft",
+        ]);
+        assert_eq!(
+            cli.exclude_patterns,
+            vec!["wip".to_string(), "draft".to_string()]
+        );
+    }
+
+    #[test]
+    fn match_and_exclude_combined() {
+        let cli = Cli::parse_from([
+            "git-worktree-tidy",
+            "--match",
+            "feat",
+            "--exclude",
+            "wip",
+            "scan",
+        ]);
+        assert_eq!(cli.match_patterns, vec!["feat".to_string()]);
+        assert_eq!(cli.exclude_patterns, vec!["wip".to_string()]);
         assert!(matches!(cli.command, Some(Command::Scan { .. })));
     }
 

--- a/crates/git-worktree-tidy/src/main.rs
+++ b/crates/git-worktree-tidy/src/main.rs
@@ -6,6 +6,7 @@ use git_tidy_core::cli::OutputFormat;
 use git_tidy_core::cli::validate_directory;
 use git_tidy_core::config;
 use git_tidy_core::error;
+use git_tidy_core::filter::NameFilter;
 use git_tidy_core::git;
 use git_tidy_core::progress::Progress;
 
@@ -35,6 +36,8 @@ fn main() {
     };
     let noise_patterns = noise_config.resolve();
 
+    let entity_filter = NameFilter::new(&cli.match_patterns, &cli.exclude_patterns);
+
     let git = git::RealGit;
     let progress = Progress::new();
     let mut stdout = io::stdout().lock();
@@ -54,7 +57,7 @@ fn main() {
                 cli.behind_threshold,
                 cli.verbose,
                 &noise_patterns,
-                &cli.match_patterns,
+                &entity_filter,
                 &progress,
             ) {
                 Ok(result) => {
@@ -88,7 +91,7 @@ fn main() {
                 cli.behind_threshold,
                 cli.verbose,
                 &noise_patterns,
-                &cli.match_patterns,
+                &entity_filter,
                 &progress,
             ) {
                 Ok(scan_result) => {

--- a/crates/git-worktree-tidy/src/scan.rs
+++ b/crates/git-worktree-tidy/src/scan.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use git_tidy_core::classification;
 use git_tidy_core::error::Error;
+use git_tidy_core::filter::NameFilter;
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
@@ -10,20 +11,18 @@ use git_tidy_core::types::{ClassificationLabel, RepoGroup, ScanCounts, ScanResul
 
 use crate::discovery::{self, DiscoveredWorktree};
 
-/// Filter discovered worktrees by basename substring match.
+/// Filter discovered worktrees by basename using a `NameFilter`.
 ///
-/// Retains only worktrees whose directory basename contains at least one of the
-/// given patterns (case-insensitive, OR semantics). Repos with no remaining
-/// worktrees are dropped entirely. An empty pattern list returns all worktrees.
+/// Retains only worktrees whose directory basename passes the filter.
+/// Repos with no remaining worktrees are dropped entirely.
+/// A default (empty) filter returns all worktrees unchanged.
 fn filter_worktrees(
     groups: BTreeMap<PathBuf, Vec<DiscoveredWorktree>>,
-    patterns: &[String],
+    filter: &NameFilter,
 ) -> BTreeMap<PathBuf, Vec<DiscoveredWorktree>> {
-    if patterns.is_empty() {
+    if filter.is_empty() {
         return groups;
     }
-
-    let lower_patterns: Vec<String> = patterns.iter().map(|p| p.to_lowercase()).collect();
 
     groups
         .into_iter()
@@ -31,13 +30,8 @@ fn filter_worktrees(
             let matched: Vec<DiscoveredWorktree> = worktrees
                 .into_iter()
                 .filter(|wt| {
-                    let basename = wt
-                        .path
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .unwrap_or("")
-                        .to_lowercase();
-                    lower_patterns.iter().any(|p| basename.contains(p.as_str()))
+                    let basename = wt.path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    filter.matches(basename)
                 })
                 .collect();
 
@@ -57,15 +51,11 @@ pub fn run_scan(
     behind_threshold: usize,
     verbose: bool,
     noise_patterns: &[String],
-    match_patterns: &[String],
+    entity_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<ScanResult, Error> {
     let groups = discovery::discover_worktrees(directory)?;
-    let groups = if match_patterns.is_empty() {
-        groups
-    } else {
-        filter_worktrees(groups, match_patterns)
-    };
+    let groups = filter_worktrees(groups, entity_filter);
 
     let repo_paths: Vec<&std::path::Path> = groups.keys().map(|p| p.as_path()).collect();
     let mut warnings = git_tidy_core::fetch::parallel_fetch(git, &repo_paths, progress);
@@ -169,7 +159,8 @@ mod tests {
             ],
         )]);
 
-        let filtered = filter_worktrees(groups, &["MyRepo".to_string()]);
+        let filter = NameFilter::new(&["MyRepo".to_string()], &[]);
+        let filtered = filter_worktrees(groups, &filter);
         let wts = &filtered[&PathBuf::from("/dev/MyRepo")];
         assert_eq!(wts.len(), 2);
         assert!(wts.iter().all(|w| {
@@ -185,7 +176,8 @@ mod tests {
             ("/dev/RepoB", vec![make_worktree("RepoB-fix", "RepoB")]),
         ]);
 
-        let filtered = filter_worktrees(groups, &["RepoA".to_string()]);
+        let filter = NameFilter::new(&["RepoA".to_string()], &[]);
+        let filtered = filter_worktrees(groups, &filter);
         assert_eq!(filtered.len(), 1);
         assert!(filtered.contains_key(&PathBuf::from("/dev/RepoA")));
         assert!(!filtered.contains_key(&PathBuf::from("/dev/RepoB")));
@@ -201,7 +193,8 @@ mod tests {
             ],
         )]);
 
-        let filtered = filter_worktrees(groups, &["MyRepo".to_string()]);
+        let filter = NameFilter::new(&["MyRepo".to_string()], &[]);
+        let filtered = filter_worktrees(groups, &filter);
         let wts = &filtered[&PathBuf::from("/dev/MyRepo")];
         assert_eq!(wts.len(), 2);
     }
@@ -217,13 +210,14 @@ mod tests {
             ],
         )]);
 
-        let filtered = filter_worktrees(groups, &["alpha".to_string(), "gamma".to_string()]);
+        let filter = NameFilter::new(&["alpha".to_string(), "gamma".to_string()], &[]);
+        let filtered = filter_worktrees(groups, &filter);
         let wts = &filtered[&PathBuf::from("/dev/MyRepo")];
         assert_eq!(wts.len(), 2);
     }
 
     #[test]
-    fn filter_worktrees_empty_patterns_passes_all() {
+    fn filter_worktrees_empty_filter_passes_all() {
         let groups = make_groups(&[(
             "/dev/MyRepo",
             vec![
@@ -232,7 +226,29 @@ mod tests {
             ],
         )]);
 
-        let filtered = filter_worktrees(groups.clone(), &[]);
+        let filter = NameFilter::default();
+        let filtered = filter_worktrees(groups.clone(), &filter);
         assert_eq!(filtered, groups);
+    }
+
+    #[test]
+    fn filter_worktrees_exclude_takes_precedence() {
+        let groups = make_groups(&[(
+            "/dev/MyRepo",
+            vec![
+                make_worktree("feat-login", "MyRepo"),
+                make_worktree("feat-wip-draft", "MyRepo"),
+                make_worktree("bugfix-urgent", "MyRepo"),
+            ],
+        )]);
+
+        let filter = NameFilter::new(&["feat".to_string()], &["wip".to_string()]);
+        let filtered = filter_worktrees(groups, &filter);
+        let wts = &filtered[&PathBuf::from("/dev/MyRepo")];
+        assert_eq!(wts.len(), 1);
+        assert_eq!(
+            wts[0].path.file_name().unwrap().to_str().unwrap(),
+            "feat-login"
+        );
     }
 }


### PR DESCRIPTION
Closes #62

## Summary

- Add `NameFilter` type to `git-tidy-core` for shared case-insensitive substring filtering with include/exclude support
- Add `filter_paths()` helper for filtering `Vec<PathBuf>` by basename
- Refactor worktree-tidy to use `NameFilter` instead of raw `&[String]`
- Add `--exclude` flag to worktree-tidy (takes precedence over `--match`)

## Test plan

- [x] 17 new unit tests for `NameFilter` and `filter_paths`
- [x] 3 new CLI tests for `--exclude` flag
- [x] Existing filter tests adapted to use `NameFilter`
- [x] New test for exclude-takes-precedence in worktree filtering
- [x] `cargo test --workspace` passes
- [x] `cargo fmt --check` clean