### PR TITLE
Add --match-repo/--exclude-repo filtering to all 8 tools

### DIFF
--- a/crates/git-branch-tidy/src/cli.rs
+++ b/crates/git-branch-tidy/src/cli.rs
@@ -22,6 +22,14 @@ pub struct Cli {
     /// Show commit-matching details during landed detection
     #[arg(short, long, global = true)]
     pub verbose: bool,
+
+    /// Filter repos by name substring (can be repeated, OR semantics)
+    #[arg(long = "match-repo", global = true)]
+    pub match_repo_patterns: Vec<String>,
+
+    /// Exclude repos by name substring (takes precedence over --match-repo)
+    #[arg(long = "exclude-repo", global = true)]
+    pub exclude_repo_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -174,5 +182,19 @@ mod tests {
             }
             _ => panic!("expected Clean command"),
         }
+    }
+
+    #[test]
+    fn match_repo_and_exclude_repo_flags() {
+        let cli = Cli::parse_from([
+            "git-branch-tidy",
+            "--match-repo",
+            "myproject",
+            "--exclude-repo",
+            "archive",
+            "scan",
+        ]);
+        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
+        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
     }
 }

--- a/crates/git-branch-tidy/src/main.rs
+++ b/crates/git-branch-tidy/src/main.rs
@@ -4,6 +4,7 @@ use std::process;
 use clap::Parser;
 use git_tidy_core::cli::{OutputFormat, validate_directory};
 use git_tidy_core::error;
+use git_tidy_core::filter::NameFilter;
 use git_tidy_core::git;
 use git_tidy_core::progress::Progress;
 
@@ -24,6 +25,7 @@ fn main() {
 
     let git = git::RealGit;
     let progress = Progress::new();
+    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -40,6 +42,7 @@ fn main() {
                 &directory,
                 cli.behind_threshold,
                 cli.verbose,
+                &repo_filter,
                 &progress,
             ) {
                 Ok(result) => {
@@ -71,6 +74,7 @@ fn main() {
                 &directory,
                 cli.behind_threshold,
                 cli.verbose,
+                &repo_filter,
                 &progress,
             ) {
                 Ok(scan_result) => {

--- a/crates/git-branch-tidy/src/scan.rs
+++ b/crates/git-branch-tidy/src/scan.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use git_tidy_core::classification;
 use git_tidy_core::error::Error;
+use git_tidy_core::filter::{NameFilter, filter_paths};
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
@@ -16,9 +17,11 @@ pub fn run_scan(
     directory: &Path,
     behind_threshold: usize,
     verbose: bool,
+    repo_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<BranchScanResult, Error> {
     let repo_paths = discovery::discover_repos(directory)?;
+    let repo_paths = filter_paths(repo_paths, repo_filter);
 
     let fetch_paths: Vec<&Path> = repo_paths.iter().map(|p| p.as_path()).collect();
     let mut warnings = git_tidy_core::fetch::parallel_fetch(git, &fetch_paths, progress);

--- a/crates/git-branch-tidy/tests/integration_clean.rs
+++ b/crates/git-branch-tidy/tests/integration_clean.rs
@@ -50,6 +50,7 @@ fn clean_deletes_merged_branch_in_real_repo() {
         &scan_dir,
         100,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -88,6 +89,7 @@ fn clean_dry_run_does_not_delete() {
         &scan_dir,
         100,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -134,6 +136,7 @@ fn clean_safe_refuses_unmerged_branch() {
         &scan_dir,
         100,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();

--- a/crates/git-branch-tidy/tests/integration_scan.rs
+++ b/crates/git-branch-tidy/tests/integration_scan.rs
@@ -61,6 +61,7 @@ fn scan_real_repo_with_mixed_branches() {
         &scan_dir,
         100,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -116,6 +117,7 @@ fn scan_marks_current_branch_in_real_repo() {
         &scan_dir,
         100,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -147,6 +149,7 @@ fn scan_skips_repo_without_default_branch() {
         &base,
         100,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();

--- a/crates/git-config-tidy/src/cli.rs
+++ b/crates/git-config-tidy/src/cli.rs
@@ -14,6 +14,14 @@ pub struct Cli {
     /// Directory to scan (default: current directory)
     #[arg(global = true)]
     pub directory: Option<PathBuf>,
+
+    /// Filter repos by name substring (can be repeated, OR semantics)
+    #[arg(long = "match-repo", global = true)]
+    pub match_repo_patterns: Vec<String>,
+
+    /// Exclude repos by name substring (takes precedence over --match-repo)
+    #[arg(long = "exclude-repo", global = true)]
+    pub exclude_repo_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -132,5 +140,19 @@ mod tests {
             }
             _ => panic!("expected Fix command"),
         }
+    }
+
+    #[test]
+    fn match_repo_and_exclude_repo_flags() {
+        let cli = Cli::parse_from([
+            "git-config-tidy",
+            "--match-repo",
+            "myproject",
+            "--exclude-repo",
+            "archive",
+            "lint",
+        ]);
+        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
+        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
     }
 }

--- a/crates/git-config-tidy/src/lint.rs
+++ b/crates/git-config-tidy/src/lint.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
+use git_tidy_core::filter::{NameFilter, filter_paths};
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
@@ -73,9 +74,11 @@ pub fn lint_repo(
 pub fn run_lint(
     git: &dyn GitOps,
     directory: &Path,
+    repo_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<ConfigLintResult, Error> {
     let repo_paths = discover_repos(directory)?;
+    let repo_paths = filter_paths(repo_paths, repo_filter);
 
     let mut repos = Vec::new();
     let mut counts = IssueCounts::default();

--- a/crates/git-config-tidy/src/main.rs
+++ b/crates/git-config-tidy/src/main.rs
@@ -3,6 +3,7 @@ use std::process;
 
 use clap::Parser;
 use git_tidy_core::error;
+use git_tidy_core::filter::NameFilter;
 use git_tidy_core::git;
 use git_tidy_core::progress::Progress;
 
@@ -23,6 +24,7 @@ fn main() {
 
     let git = git::RealGit;
     let progress = Progress::new();
+    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -32,7 +34,7 @@ fn main() {
                 _ => (false, false),
             };
 
-            match lint::run_lint(&git, &directory, &progress) {
+            match lint::run_lint(&git, &directory, &repo_filter, &progress) {
                 Ok(result) => {
                     let write_result = if json {
                         output::write_json(&mut stdout, &result)
@@ -54,7 +56,7 @@ fn main() {
             yes,
             json,
             porcelain,
-        }) => match lint::run_lint(&git, &directory, &progress) {
+        }) => match lint::run_lint(&git, &directory, &repo_filter, &progress) {
             Ok(lint_result) => {
                 // Show lint results first if requested
                 let write_result = if *json {

--- a/crates/git-lfs-tidy/src/cli.rs
+++ b/crates/git-lfs-tidy/src/cli.rs
@@ -14,6 +14,14 @@ pub struct Cli {
     /// Directory to scan (default: current directory)
     #[arg(global = true)]
     pub directory: Option<PathBuf>,
+
+    /// Filter repos by name substring (can be repeated, OR semantics)
+    #[arg(long = "match-repo", global = true)]
+    pub match_repo_patterns: Vec<String>,
+
+    /// Exclude repos by name substring (takes precedence over --match-repo)
+    #[arg(long = "exclude-repo", global = true)]
+    pub exclude_repo_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -163,5 +171,19 @@ mod tests {
             }
             _ => panic!("expected Clean command"),
         }
+    }
+
+    #[test]
+    fn match_repo_and_exclude_repo_flags() {
+        let cli = Cli::parse_from([
+            "git-lfs-tidy",
+            "--match-repo",
+            "myproject",
+            "--exclude-repo",
+            "archive",
+            "scan",
+        ]);
+        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
+        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
     }
 }

--- a/crates/git-lfs-tidy/src/main.rs
+++ b/crates/git-lfs-tidy/src/main.rs
@@ -3,6 +3,7 @@ use std::process;
 
 use clap::Parser;
 use git_tidy_core::error;
+use git_tidy_core::filter::NameFilter;
 use git_tidy_core::git;
 use git_tidy_core::progress::Progress;
 
@@ -23,6 +24,7 @@ fn main() {
 
     let git = git::RealGit;
     let progress = Progress::new();
+    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
     let mut stdout = io::stdout().lock();
 
     // Extract scan parameters from whichever subcommand is active.
@@ -57,7 +59,14 @@ fn main() {
                 _ => (false, false),
             };
 
-            match scan::run_scan(&git, &directory, size_threshold, depth, &progress) {
+            match scan::run_scan(
+                &git,
+                &directory,
+                size_threshold,
+                depth,
+                &repo_filter,
+                &progress,
+            ) {
                 Ok(result) => {
                     let write_result = if json {
                         output::write_json(&mut stdout, &result)
@@ -79,7 +88,14 @@ fn main() {
             yes,
             prune,
             ..
-        }) => match scan::run_scan(&git, &directory, size_threshold, depth, &progress) {
+        }) => match scan::run_scan(
+            &git,
+            &directory,
+            size_threshold,
+            depth,
+            &repo_filter,
+            &progress,
+        ) {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,

--- a/crates/git-lfs-tidy/src/scan.rs
+++ b/crates/git-lfs-tidy/src/scan.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
+use git_tidy_core::filter::{NameFilter, filter_paths};
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
@@ -45,9 +46,11 @@ pub fn run_scan(
     directory: &Path,
     size_threshold: u64,
     depth: usize,
+    repo_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<LfsScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
+    let repo_paths = filter_paths(repo_paths, repo_filter);
 
     let lfs_installed = git.lfs_installed().unwrap_or(false);
 

--- a/crates/git-lfs-tidy/tests/integration_clean.rs
+++ b/crates/git-lfs-tidy/tests/integration_clean.rs
@@ -37,6 +37,7 @@ fn run_scan_and_clean(
         scan_dir,
         100_000,
         1000,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();

--- a/crates/git-lfs-tidy/tests/integration_scan.rs
+++ b/crates/git-lfs-tidy/tests/integration_scan.rs
@@ -38,6 +38,7 @@ fn scan_repo_with_no_large_blobs() {
         &scan_dir,
         1_000_000,
         1000,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -63,6 +64,7 @@ fn scan_repo_with_large_blob() {
         &scan_dir,
         100_000,
         1000,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -101,6 +103,7 @@ fn scan_repo_with_large_blob_below_threshold() {
         &scan_dir,
         100_000,
         1000,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -149,6 +152,7 @@ fn scan_multiple_repos() {
         &scan_dir,
         100_000,
         1000,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -181,6 +185,7 @@ fn scan_repo_with_no_commits() {
         &scan_dir,
         1_000_000,
         1000,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -208,6 +213,7 @@ fn scan_threshold_edge_case() {
         &scan_dir,
         1000,
         1000,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();

--- a/crates/git-remote-tidy/src/cli.rs
+++ b/crates/git-remote-tidy/src/cli.rs
@@ -18,6 +18,14 @@ pub struct Cli {
     /// Skip reachability checks (no network access)
     #[arg(long, global = true)]
     pub offline: bool,
+
+    /// Filter repos by name substring (can be repeated, OR semantics)
+    #[arg(long = "match-repo", global = true)]
+    pub match_repo_patterns: Vec<String>,
+
+    /// Exclude repos by name substring (takes precedence over --match-repo)
+    #[arg(long = "exclude-repo", global = true)]
+    pub exclude_repo_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -143,5 +151,19 @@ mod tests {
             Some(Command::Clean { dry_run, .. }) => assert!(dry_run),
             _ => panic!("expected Clean command"),
         }
+    }
+
+    #[test]
+    fn match_repo_and_exclude_repo_flags() {
+        let cli = Cli::parse_from([
+            "git-remote-tidy",
+            "--match-repo",
+            "myproject",
+            "--exclude-repo",
+            "archive",
+            "scan",
+        ]);
+        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
+        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
     }
 }

--- a/crates/git-remote-tidy/src/main.rs
+++ b/crates/git-remote-tidy/src/main.rs
@@ -4,6 +4,7 @@ use std::process;
 use clap::Parser;
 use git_tidy_core::cli::{OutputFormat, validate_directory};
 use git_tidy_core::error;
+use git_tidy_core::filter::NameFilter;
 use git_tidy_core::git;
 use git_tidy_core::progress::Progress;
 
@@ -23,6 +24,7 @@ fn main() {
 
     let git = git::RealGit;
     let progress = Progress::new();
+    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -34,7 +36,7 @@ fn main() {
                 _ => OutputFormat::Human,
             };
 
-            match scan::run_scan(&git, &directory, cli.offline, &progress) {
+            match scan::run_scan(&git, &directory, cli.offline, &repo_filter, &progress) {
                 Ok(result) => {
                     let write_result = match format {
                         OutputFormat::Json => output::write_json(&mut stdout, &result),
@@ -55,7 +57,7 @@ fn main() {
             force,
             all,
             ..
-        }) => match scan::run_scan(&git, &directory, cli.offline, &progress) {
+        }) => match scan::run_scan(&git, &directory, cli.offline, &repo_filter, &progress) {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,

--- a/crates/git-remote-tidy/src/scan.rs
+++ b/crates/git-remote-tidy/src/scan.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
+use git_tidy_core::filter::{NameFilter, filter_paths};
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
@@ -43,9 +44,11 @@ pub fn run_scan(
     git: &dyn GitOps,
     directory: &Path,
     offline: bool,
+    repo_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<RemoteScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
+    let repo_paths = filter_paths(repo_paths, repo_filter);
 
     let mut repos = Vec::new();
     let mut counts = RemoteCounts::default();

--- a/crates/git-remote-tidy/tests/integration_clean.rs
+++ b/crates/git-remote-tidy/tests/integration_clean.rs
@@ -45,6 +45,7 @@ fn clean_removes_remote_in_real_repo() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -82,6 +83,7 @@ fn clean_dry_run_does_not_remove() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -138,6 +140,7 @@ fn clean_prunes_orphaned_refs() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();

--- a/crates/git-remote-tidy/tests/integration_scan.rs
+++ b/crates/git-remote-tidy/tests/integration_scan.rs
@@ -43,6 +43,7 @@ fn scan_real_repo_with_reachable_remote() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -73,6 +74,7 @@ fn scan_repo_with_unreachable_remote() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -102,6 +104,7 @@ fn scan_repo_with_orphaned_refs() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -130,6 +133,7 @@ fn scan_empty_repo_no_remotes() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -155,6 +159,7 @@ fn scan_offline_mode() {
         &git_ops,
         &scan_dir,
         true,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();

--- a/crates/git-repo-tidy/src/cli.rs
+++ b/crates/git-repo-tidy/src/cli.rs
@@ -30,6 +30,14 @@ pub struct Cli {
     /// Disable default noise patterns
     #[arg(long, global = true)]
     pub no_default_noise: bool,
+
+    /// Filter repos by name substring (can be repeated, OR semantics)
+    #[arg(long = "match-repo", global = true)]
+    pub match_repo_patterns: Vec<String>,
+
+    /// Exclude repos by name substring (takes precedence over --match-repo)
+    #[arg(long = "exclude-repo", global = true)]
+    pub exclude_repo_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -208,5 +216,19 @@ mod tests {
     fn no_default_noise_flag() {
         let cli = Cli::parse_from(["git-repo-tidy", "--no-default-noise", "scan"]);
         assert!(cli.no_default_noise);
+    }
+
+    #[test]
+    fn match_repo_and_exclude_repo_flags() {
+        let cli = Cli::parse_from([
+            "git-repo-tidy",
+            "--match-repo",
+            "myproject",
+            "--exclude-repo",
+            "archive",
+            "scan",
+        ]);
+        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
+        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
     }
 }

--- a/crates/git-repo-tidy/src/main.rs
+++ b/crates/git-repo-tidy/src/main.rs
@@ -4,6 +4,7 @@ use std::process;
 use clap::Parser;
 use git_tidy_core::config::{NoiseConfig, default_config_path, load_config_file};
 use git_tidy_core::error;
+use git_tidy_core::filter::NameFilter;
 use git_tidy_core::git;
 use git_tidy_core::progress::Progress;
 
@@ -39,6 +40,8 @@ fn main() {
     };
     let noise_patterns = noise_config.resolve();
 
+    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+
     let stale_days = cli.stale_threshold_days();
 
     match &cli.command {
@@ -54,6 +57,7 @@ fn main() {
                 stale_days,
                 &noise_patterns,
                 cli.offline,
+                &repo_filter,
                 &progress,
             ) {
                 Ok(result) => {
@@ -86,6 +90,7 @@ fn main() {
             stale_days,
             &noise_patterns,
             cli.offline,
+            &repo_filter,
             &progress,
         ) {
             Ok(scan_result) => {

--- a/crates/git-repo-tidy/src/scan.rs
+++ b/crates/git-repo-tidy/src/scan.rs
@@ -5,6 +5,7 @@ use git_tidy_core::date::days_since_iso_date;
 use git_tidy_core::dirty::check_dirty;
 use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
+use git_tidy_core::filter::{NameFilter, filter_paths};
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
@@ -119,6 +120,7 @@ pub fn run_scan(
     stale_days: u64,
     noise_patterns: &[String],
     offline: bool,
+    repo_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<RepoScanResult, Error> {
     run_scan_with_du(
@@ -127,22 +129,26 @@ pub fn run_scan(
         stale_days,
         noise_patterns,
         offline,
+        repo_filter,
         &disk_usage,
         progress,
     )
 }
 
 /// Scan with an injectable disk-usage function (for testing).
+#[allow(clippy::too_many_arguments)]
 pub fn run_scan_with_du(
     git: &dyn GitOps,
     directory: &Path,
     stale_days: u64,
     noise_patterns: &[String],
     offline: bool,
+    repo_filter: &NameFilter,
     du_fn: &dyn Fn(&Path) -> u64,
     progress: &Progress,
 ) -> Result<RepoScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
+    let repo_paths = filter_paths(repo_paths, repo_filter);
 
     let mut repos = Vec::new();
     let mut counts = RepoCounts::default();

--- a/crates/git-repo-tidy/tests/integration_clean.rs
+++ b/crates/git-repo-tidy/tests/integration_clean.rs
@@ -50,6 +50,7 @@ fn clean_removes_orphaned_repo() {
         180,
         &[],
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -77,6 +78,7 @@ fn clean_dry_run_preserves_repo() {
         180,
         &[],
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -114,6 +116,7 @@ fn clean_skips_dirty_repo() {
         180,
         &[],
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -145,6 +148,7 @@ fn clean_force_deletes_dirty_repo() {
         180,
         &[],
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();

--- a/crates/git-repo-tidy/tests/integration_scan.rs
+++ b/crates/git-repo-tidy/tests/integration_scan.rs
@@ -44,6 +44,7 @@ fn scan_active_repo_with_remote() {
         180,
         &[],
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -69,6 +70,7 @@ fn scan_orphaned_no_remote() {
         180,
         &[],
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -111,6 +113,7 @@ fn scan_stale_repo() {
         180,
         &[],
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -136,6 +139,7 @@ fn scan_dirty_repo() {
         180,
         &[],
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -159,6 +163,7 @@ fn scan_reclaimable_bytes() {
         180,
         &[],
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();

--- a/crates/git-stash-tidy/src/cli.rs
+++ b/crates/git-stash-tidy/src/cli.rs
@@ -18,6 +18,14 @@ pub struct Cli {
     /// Days before a stash is considered aged
     #[arg(long, default_value_t = 90, global = true)]
     pub age_threshold: u64,
+
+    /// Filter repos by name substring (can be repeated, OR semantics)
+    #[arg(long = "match-repo", global = true)]
+    pub match_repo_patterns: Vec<String>,
+
+    /// Exclude repos by name substring (takes precedence over --match-repo)
+    #[arg(long = "exclude-repo", global = true)]
+    pub exclude_repo_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -171,5 +179,19 @@ mod tests {
             }
             _ => panic!("expected Clean command"),
         }
+    }
+
+    #[test]
+    fn match_repo_and_exclude_repo_flags() {
+        let cli = Cli::parse_from([
+            "git-stash-tidy",
+            "--match-repo",
+            "myproject",
+            "--exclude-repo",
+            "archive",
+            "scan",
+        ]);
+        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
+        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
     }
 }

--- a/crates/git-stash-tidy/src/main.rs
+++ b/crates/git-stash-tidy/src/main.rs
@@ -4,6 +4,7 @@ use std::process;
 use clap::Parser;
 use git_tidy_core::cli::{OutputFormat, validate_directory};
 use git_tidy_core::error;
+use git_tidy_core::filter::NameFilter;
 use git_tidy_core::git;
 use git_tidy_core::progress::Progress;
 
@@ -23,6 +24,7 @@ fn main() {
 
     let git = git::RealGit;
     let progress = Progress::new();
+    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -34,7 +36,7 @@ fn main() {
                 _ => OutputFormat::Human,
             };
 
-            match scan::run_scan(&git, &directory, cli.age_threshold, &progress) {
+            match scan::run_scan(&git, &directory, cli.age_threshold, &repo_filter, &progress) {
                 Ok(result) => {
                     let write_result = match format {
                         OutputFormat::Json => output::write_json(&mut stdout, &result),
@@ -56,7 +58,7 @@ fn main() {
             aged_only,
             all,
             ..
-        }) => match scan::run_scan(&git, &directory, cli.age_threshold, &progress) {
+        }) => match scan::run_scan(&git, &directory, cli.age_threshold, &repo_filter, &progress) {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,

--- a/crates/git-stash-tidy/src/scan.rs
+++ b/crates/git-stash-tidy/src/scan.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use git_tidy_core::date::days_since_iso_date;
 use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
+use git_tidy_core::filter::{NameFilter, filter_paths};
 use git_tidy_core::git::GitOps;
 use git_tidy_core::landed::diff_similarity;
 use git_tidy_core::output::repo_display_name;
@@ -69,9 +70,11 @@ pub fn run_scan(
     git: &dyn GitOps,
     directory: &Path,
     age_threshold: u64,
+    repo_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<StashScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
+    let repo_paths = filter_paths(repo_paths, repo_filter);
 
     let mut repos = Vec::new();
     let mut counts = StashCounts::default();

--- a/crates/git-stash-tidy/tests/integration_clean.rs
+++ b/crates/git-stash-tidy/tests/integration_clean.rs
@@ -47,6 +47,7 @@ fn clean_drops_stash_in_real_repo() {
         &git_ops,
         &scan_dir,
         90,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -88,6 +89,7 @@ fn clean_dry_run_does_not_drop() {
         &git_ops,
         &scan_dir,
         90,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();

--- a/crates/git-stash-tidy/tests/integration_scan.rs
+++ b/crates/git-stash-tidy/tests/integration_scan.rs
@@ -41,6 +41,7 @@ fn scan_real_repo_with_stashes() {
         &git_ops,
         &scan_dir,
         90,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -74,6 +75,7 @@ fn scan_repo_with_orphaned_stash() {
         &git_ops,
         &scan_dir,
         90,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -96,6 +98,7 @@ fn scan_empty_repo_no_stashes() {
         &git_ops,
         &scan_dir,
         90,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();

--- a/crates/git-tag-tidy/src/cli.rs
+++ b/crates/git-tag-tidy/src/cli.rs
@@ -18,6 +18,14 @@ pub struct Cli {
     /// Skip remote tag queries (no network access)
     #[arg(long, global = true)]
     pub offline: bool,
+
+    /// Filter repos by name substring (can be repeated, OR semantics)
+    #[arg(long = "match-repo", global = true)]
+    pub match_repo_patterns: Vec<String>,
+
+    /// Exclude repos by name substring (takes precedence over --match-repo)
+    #[arg(long = "exclude-repo", global = true)]
+    pub exclude_repo_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -188,5 +196,19 @@ mod tests {
             Some(Command::Clean { dry_run, .. }) => assert!(dry_run),
             _ => panic!("expected Clean command"),
         }
+    }
+
+    #[test]
+    fn match_repo_and_exclude_repo_flags() {
+        let cli = Cli::parse_from([
+            "git-tag-tidy",
+            "--match-repo",
+            "myproject",
+            "--exclude-repo",
+            "archive",
+            "scan",
+        ]);
+        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
+        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
     }
 }

--- a/crates/git-tag-tidy/src/main.rs
+++ b/crates/git-tag-tidy/src/main.rs
@@ -4,6 +4,7 @@ use std::process;
 use clap::Parser;
 use git_tidy_core::cli::{OutputFormat, validate_directory};
 use git_tidy_core::error;
+use git_tidy_core::filter::NameFilter;
 use git_tidy_core::git;
 use git_tidy_core::progress::Progress;
 
@@ -23,6 +24,7 @@ fn main() {
 
     let git = git::RealGit;
     let progress = Progress::new();
+    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -34,7 +36,7 @@ fn main() {
                 _ => OutputFormat::Human,
             };
 
-            match scan::run_scan(&git, &directory, cli.offline, &progress) {
+            match scan::run_scan(&git, &directory, cli.offline, &repo_filter, &progress) {
                 Ok(result) => {
                     let write_result = match format {
                         OutputFormat::Json => output::write_json(&mut stdout, &result),
@@ -58,7 +60,7 @@ fn main() {
             include_remote,
             all,
             ..
-        }) => match scan::run_scan(&git, &directory, cli.offline, &progress) {
+        }) => match scan::run_scan(&git, &directory, cli.offline, &repo_filter, &progress) {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,

--- a/crates/git-tag-tidy/src/scan.rs
+++ b/crates/git-tag-tidy/src/scan.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
+use git_tidy_core::filter::{NameFilter, filter_paths};
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
@@ -39,9 +40,11 @@ pub fn run_scan(
     git: &dyn GitOps,
     directory: &Path,
     offline: bool,
+    repo_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<TagScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
+    let repo_paths = filter_paths(repo_paths, repo_filter);
 
     let mut repos = Vec::new();
     let mut counts = TagCounts::default();

--- a/crates/git-tag-tidy/tests/integration_clean.rs
+++ b/crates/git-tag-tidy/tests/integration_clean.rs
@@ -49,6 +49,7 @@ fn clean_removes_local_only_tag() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -93,6 +94,7 @@ fn clean_dry_run_preserves_tags() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -146,6 +148,7 @@ fn clean_removes_stale_tag() {
         &git_ops,
         &scan_dir,
         true,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -199,6 +202,7 @@ fn clean_include_remote_deletes_from_remote() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();

--- a/crates/git-tag-tidy/tests/integration_scan.rs
+++ b/crates/git-tag-tidy/tests/integration_scan.rs
@@ -47,6 +47,7 @@ fn scan_synced_tag() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -85,6 +86,7 @@ fn scan_local_only_tag() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -120,6 +122,7 @@ fn scan_stale_tag() {
         &git_ops,
         &scan_dir,
         true,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -148,6 +151,7 @@ fn scan_annotated_tag() {
         &git_ops,
         &scan_dir,
         true,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -175,6 +179,7 @@ fn scan_empty_repo_no_tags() {
         &git_ops,
         &scan_dir,
         true,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();

--- a/crates/git-tidy/src/inprocess.rs
+++ b/crates/git-tidy/src/inprocess.rs
@@ -146,6 +146,7 @@ fn scan_worktrees(
         false,
         noise_patterns,
         &NameFilter::default(),
+        &NameFilter::default(),
         progress,
     ) {
         Ok(result) => {
@@ -171,8 +172,14 @@ fn scan_worktrees(
 }
 
 fn scan_branches(git: &dyn GitOps, directory: &Path, progress: &Progress) -> ToolResult {
-    match git_branch_tidy::scan::run_scan(git, directory, DEFAULT_BEHIND_THRESHOLD, false, progress)
-    {
+    match git_branch_tidy::scan::run_scan(
+        git,
+        directory,
+        DEFAULT_BEHIND_THRESHOLD,
+        false,
+        &NameFilter::default(),
+        progress,
+    ) {
         Ok(result) => {
             let c = &result.counts;
             let counts = counts_map(&[
@@ -196,7 +203,13 @@ fn scan_branches(git: &dyn GitOps, directory: &Path, progress: &Progress) -> Too
 }
 
 fn scan_stashes(git: &dyn GitOps, directory: &Path, progress: &Progress) -> ToolResult {
-    match git_stash_tidy::scan::run_scan(git, directory, DEFAULT_AGE_THRESHOLD, progress) {
+    match git_stash_tidy::scan::run_scan(
+        git,
+        directory,
+        DEFAULT_AGE_THRESHOLD,
+        &NameFilter::default(),
+        progress,
+    ) {
         Ok(result) => {
             let c = &result.counts;
             let counts = counts_map(&[
@@ -219,7 +232,7 @@ fn scan_stashes(git: &dyn GitOps, directory: &Path, progress: &Progress) -> Tool
 }
 
 fn scan_remotes(git: &dyn GitOps, directory: &Path, progress: &Progress) -> ToolResult {
-    match git_remote_tidy::scan::run_scan(git, directory, false, progress) {
+    match git_remote_tidy::scan::run_scan(git, directory, false, &NameFilter::default(), progress) {
         Ok(result) => {
             let c = &result.counts;
             let counts = counts_map(&[
@@ -241,7 +254,7 @@ fn scan_remotes(git: &dyn GitOps, directory: &Path, progress: &Progress) -> Tool
 }
 
 fn scan_tags(git: &dyn GitOps, directory: &Path, progress: &Progress) -> ToolResult {
-    match git_tag_tidy::scan::run_scan(git, directory, false, progress) {
+    match git_tag_tidy::scan::run_scan(git, directory, false, &NameFilter::default(), progress) {
         Ok(result) => {
             let c = &result.counts;
             let counts = counts_map(&[
@@ -275,6 +288,7 @@ fn scan_repos(
         DEFAULT_STALE_DAYS,
         noise_patterns,
         false,
+        &NameFilter::default(),
         progress,
     ) {
         Ok(result) => {
@@ -298,7 +312,7 @@ fn scan_repos(
 }
 
 fn lint_config(git: &dyn GitOps, directory: &Path, progress: &Progress) -> ToolResult {
-    match git_config_tidy::lint::run_lint(git, directory, progress) {
+    match git_config_tidy::lint::run_lint(git, directory, &NameFilter::default(), progress) {
         Ok(result) => {
             let c = &result.counts;
             let counts = counts_map(&[
@@ -324,6 +338,7 @@ fn scan_lfs(git: &dyn GitOps, directory: &Path, progress: &Progress) -> ToolResu
         directory,
         DEFAULT_LFS_SIZE_THRESHOLD,
         DEFAULT_LFS_DEPTH,
+        &NameFilter::default(),
         progress,
     ) {
         Ok(result) => {

--- a/crates/git-worktree-tidy/src/cli.rs
+++ b/crates/git-worktree-tidy/src/cli.rs
@@ -38,6 +38,14 @@ pub struct Cli {
     /// Exclude worktrees by name substring (takes precedence over --match)
     #[arg(long = "exclude", global = true)]
     pub exclude_patterns: Vec<String>,
+
+    /// Filter repos by name substring (can be repeated, OR semantics)
+    #[arg(long = "match-repo", global = true)]
+    pub match_repo_patterns: Vec<String>,
+
+    /// Exclude repos by name substring (takes precedence over --match-repo)
+    #[arg(long = "exclude-repo", global = true)]
+    pub exclude_repo_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -295,5 +303,19 @@ mod tests {
         assert_eq!(cli.noise_patterns, vec!["*.swp".to_string()]);
         assert!(cli.no_default_noise);
         assert!(matches!(cli.command, Some(Command::Scan { .. })));
+    }
+
+    #[test]
+    fn match_repo_and_exclude_repo_flags() {
+        let cli = Cli::parse_from([
+            "git-worktree-tidy",
+            "--match-repo",
+            "myproject",
+            "--exclude-repo",
+            "archive",
+            "scan",
+        ]);
+        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
+        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
     }
 }

--- a/crates/git-worktree-tidy/src/main.rs
+++ b/crates/git-worktree-tidy/src/main.rs
@@ -37,6 +37,7 @@ fn main() {
     let noise_patterns = noise_config.resolve();
 
     let entity_filter = NameFilter::new(&cli.match_patterns, &cli.exclude_patterns);
+    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
 
     let git = git::RealGit;
     let progress = Progress::new();
@@ -58,6 +59,7 @@ fn main() {
                 cli.verbose,
                 &noise_patterns,
                 &entity_filter,
+                &repo_filter,
                 &progress,
             ) {
                 Ok(result) => {
@@ -91,6 +93,7 @@ fn main() {
                 cli.verbose,
                 &noise_patterns,
                 &entity_filter,
+                &repo_filter,
                 &progress,
             ) {
                 Ok(scan_result) => {

--- a/crates/git-worktree-tidy/src/scan.rs
+++ b/crates/git-worktree-tidy/src/scan.rs
@@ -45,6 +45,7 @@ fn filter_worktrees(
 }
 
 /// Scan all worktrees under `directory` and classify them.
+#[allow(clippy::too_many_arguments)]
 pub fn run_scan(
     git: &dyn GitOps,
     directory: &Path,
@@ -52,10 +53,22 @@ pub fn run_scan(
     verbose: bool,
     noise_patterns: &[String],
     entity_filter: &NameFilter,
+    repo_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<ScanResult, Error> {
     let groups = discovery::discover_worktrees(directory)?;
     let groups = filter_worktrees(groups, entity_filter);
+    let groups = if repo_filter.is_empty() {
+        groups
+    } else {
+        groups
+            .into_iter()
+            .filter(|(repo_path, _)| {
+                let basename = repo_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                repo_filter.matches(basename)
+            })
+            .collect()
+    };
 
     let repo_paths: Vec<&std::path::Path> = groups.keys().map(|p| p.as_path()).collect();
     let mut warnings = git_tidy_core::fetch::parallel_fetch(git, &repo_paths, progress);


### PR DESCRIPTION
Closes #64

## Summary

- Add `--match-repo` and `--exclude-repo` global CLI args to all 8 tools
- Insert `filter_paths()` after `discover_repos()` in all scan/lint functions
- For worktree-tidy, filter `BTreeMap` keys from `discover_worktrees()` by basename
- In-process audit runner passes `NameFilter::default()` (no filtering)

## Test plan

- [x] 8 new CLI parse tests (one per tool)
- [x] All existing integration tests updated with new `repo_filter` parameter
- [x] `cargo test --workspace` passes
- [x] `cargo fmt --check` clean

Stacked on: #63