### PR TITLE
Add entity --match/--exclude for branch, tag, stash, remote

### DIFF
--- a/crates/git-branch-tidy/src/cli.rs
+++ b/crates/git-branch-tidy/src/cli.rs
@@ -30,6 +30,14 @@ pub struct Cli {
     /// Exclude repos by name substring (takes precedence over --match-repo)
     #[arg(long = "exclude-repo", global = true)]
     pub exclude_repo_patterns: Vec<String>,
+
+    /// Filter branches by name substring (can be repeated, OR semantics)
+    #[arg(long = "match", global = true)]
+    pub match_patterns: Vec<String>,
+
+    /// Exclude branches by name substring (takes precedence over --match)
+    #[arg(long = "exclude", global = true)]
+    pub exclude_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -197,6 +205,20 @@ mod tests {
             }
             _ => panic!("expected Clean command"),
         }
+    }
+
+    #[test]
+    fn match_and_exclude_flags() {
+        let cli = Cli::parse_from([
+            "git-branch-tidy",
+            "--match",
+            "feature",
+            "--exclude",
+            "wip",
+            "scan",
+        ]);
+        assert_eq!(cli.match_patterns, vec!["feature".to_string()]);
+        assert_eq!(cli.exclude_patterns, vec!["wip".to_string()]);
     }
 
     #[test]

--- a/crates/git-branch-tidy/src/main.rs
+++ b/crates/git-branch-tidy/src/main.rs
@@ -26,6 +26,7 @@ fn main() {
     let git = git::RealGit;
     let progress = Progress::new();
     let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let entity_filter = NameFilter::new(&cli.match_patterns, &cli.exclude_patterns);
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -43,6 +44,7 @@ fn main() {
                 cli.behind_threshold,
                 cli.verbose,
                 &repo_filter,
+                &entity_filter,
                 &progress,
             ) {
                 Ok(result) => {
@@ -76,6 +78,7 @@ fn main() {
                 cli.behind_threshold,
                 cli.verbose,
                 &repo_filter,
+                &entity_filter,
                 &progress,
             ) {
                 Ok(scan_result) => {

--- a/crates/git-branch-tidy/src/scan.rs
+++ b/crates/git-branch-tidy/src/scan.rs
@@ -18,6 +18,7 @@ pub fn run_scan(
     behind_threshold: usize,
     verbose: bool,
     repo_filter: &NameFilter,
+    entity_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<BranchScanResult, Error> {
     let repo_paths = discovery::discover_repos(directory)?;
@@ -66,6 +67,10 @@ pub fn run_scan(
         for branch_name in &branches {
             // Skip the default branch
             if branch_name == &default_branch {
+                continue;
+            }
+
+            if !entity_filter.matches(branch_name) {
                 continue;
             }
 

--- a/crates/git-branch-tidy/tests/integration_clean.rs
+++ b/crates/git-branch-tidy/tests/integration_clean.rs
@@ -51,6 +51,7 @@ fn clean_deletes_merged_branch_in_real_repo() {
         100,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -90,6 +91,7 @@ fn clean_dry_run_does_not_delete() {
         &scan_dir,
         100,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
@@ -138,6 +140,7 @@ fn clean_safe_refuses_unmerged_branch() {
         &scan_dir,
         100,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-branch-tidy/tests/integration_scan.rs
+++ b/crates/git-branch-tidy/tests/integration_scan.rs
@@ -62,6 +62,7 @@ fn scan_real_repo_with_mixed_branches() {
         100,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -118,6 +119,7 @@ fn scan_marks_current_branch_in_real_repo() {
         100,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -149,6 +151,7 @@ fn scan_skips_repo_without_default_branch() {
         &base,
         100,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-remote-tidy/src/cli.rs
+++ b/crates/git-remote-tidy/src/cli.rs
@@ -26,6 +26,14 @@ pub struct Cli {
     /// Exclude repos by name substring (takes precedence over --match-repo)
     #[arg(long = "exclude-repo", global = true)]
     pub exclude_repo_patterns: Vec<String>,
+
+    /// Filter remotes by name substring (can be repeated, OR semantics)
+    #[arg(long = "match", global = true)]
+    pub match_patterns: Vec<String>,
+
+    /// Exclude remotes by name substring (takes precedence over --match)
+    #[arg(long = "exclude", global = true)]
+    pub exclude_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -151,6 +159,20 @@ mod tests {
             Some(Command::Clean { dry_run, .. }) => assert!(dry_run),
             _ => panic!("expected Clean command"),
         }
+    }
+
+    #[test]
+    fn match_and_exclude_flags() {
+        let cli = Cli::parse_from([
+            "git-remote-tidy",
+            "--match",
+            "origin",
+            "--exclude",
+            "stale",
+            "scan",
+        ]);
+        assert_eq!(cli.match_patterns, vec!["origin".to_string()]);
+        assert_eq!(cli.exclude_patterns, vec!["stale".to_string()]);
     }
 
     #[test]

--- a/crates/git-remote-tidy/src/main.rs
+++ b/crates/git-remote-tidy/src/main.rs
@@ -25,6 +25,7 @@ fn main() {
     let git = git::RealGit;
     let progress = Progress::new();
     let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let entity_filter = NameFilter::new(&cli.match_patterns, &cli.exclude_patterns);
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -36,7 +37,14 @@ fn main() {
                 _ => OutputFormat::Human,
             };
 
-            match scan::run_scan(&git, &directory, cli.offline, &repo_filter, &progress) {
+            match scan::run_scan(
+                &git,
+                &directory,
+                cli.offline,
+                &repo_filter,
+                &entity_filter,
+                &progress,
+            ) {
                 Ok(result) => {
                     let write_result = match format {
                         OutputFormat::Json => output::write_json(&mut stdout, &result),
@@ -57,7 +65,14 @@ fn main() {
             force,
             all,
             ..
-        }) => match scan::run_scan(&git, &directory, cli.offline, &repo_filter, &progress) {
+        }) => match scan::run_scan(
+            &git,
+            &directory,
+            cli.offline,
+            &repo_filter,
+            &entity_filter,
+            &progress,
+        ) {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,

--- a/crates/git-remote-tidy/src/scan.rs
+++ b/crates/git-remote-tidy/src/scan.rs
@@ -45,6 +45,7 @@ pub fn run_scan(
     directory: &Path,
     offline: bool,
     repo_filter: &NameFilter,
+    entity_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<RemoteScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
@@ -110,6 +111,10 @@ pub fn run_scan(
         let mut classified = Vec::new();
 
         for (idx, remote_name) in all_remote_names.iter().enumerate() {
+            if !entity_filter.matches(remote_name) {
+                continue;
+            }
+
             let is_configured = idx < configured_count;
             let classification =
                 classify_remote(git, repo_path, remote_name, is_configured, offline);

--- a/crates/git-remote-tidy/tests/integration_clean.rs
+++ b/crates/git-remote-tidy/tests/integration_clean.rs
@@ -46,6 +46,7 @@ fn clean_removes_remote_in_real_repo() {
         &scan_dir,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -83,6 +84,7 @@ fn clean_dry_run_does_not_remove() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
@@ -140,6 +142,7 @@ fn clean_prunes_orphaned_refs() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-remote-tidy/tests/integration_scan.rs
+++ b/crates/git-remote-tidy/tests/integration_scan.rs
@@ -44,6 +44,7 @@ fn scan_real_repo_with_reachable_remote() {
         &scan_dir,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -75,6 +76,7 @@ fn scan_repo_with_unreachable_remote() {
         &scan_dir,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -105,6 +107,7 @@ fn scan_repo_with_orphaned_refs() {
         &scan_dir,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -134,6 +137,7 @@ fn scan_empty_repo_no_remotes() {
         &scan_dir,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -159,6 +163,7 @@ fn scan_offline_mode() {
         &git_ops,
         &scan_dir,
         true,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-stash-tidy/src/cli.rs
+++ b/crates/git-stash-tidy/src/cli.rs
@@ -26,6 +26,14 @@ pub struct Cli {
     /// Exclude repos by name substring (takes precedence over --match-repo)
     #[arg(long = "exclude-repo", global = true)]
     pub exclude_repo_patterns: Vec<String>,
+
+    /// Filter stashes by branch name substring (can be repeated, OR semantics)
+    #[arg(long = "match", global = true)]
+    pub match_patterns: Vec<String>,
+
+    /// Exclude stashes by branch name substring (takes precedence over --match)
+    #[arg(long = "exclude", global = true)]
+    pub exclude_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -179,6 +187,20 @@ mod tests {
             }
             _ => panic!("expected Clean command"),
         }
+    }
+
+    #[test]
+    fn match_and_exclude_flags() {
+        let cli = Cli::parse_from([
+            "git-stash-tidy",
+            "--match",
+            "feature",
+            "--exclude",
+            "temp",
+            "scan",
+        ]);
+        assert_eq!(cli.match_patterns, vec!["feature".to_string()]);
+        assert_eq!(cli.exclude_patterns, vec!["temp".to_string()]);
     }
 
     #[test]

--- a/crates/git-stash-tidy/src/main.rs
+++ b/crates/git-stash-tidy/src/main.rs
@@ -25,6 +25,7 @@ fn main() {
     let git = git::RealGit;
     let progress = Progress::new();
     let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let entity_filter = NameFilter::new(&cli.match_patterns, &cli.exclude_patterns);
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -36,7 +37,14 @@ fn main() {
                 _ => OutputFormat::Human,
             };
 
-            match scan::run_scan(&git, &directory, cli.age_threshold, &repo_filter, &progress) {
+            match scan::run_scan(
+                &git,
+                &directory,
+                cli.age_threshold,
+                &repo_filter,
+                &entity_filter,
+                &progress,
+            ) {
                 Ok(result) => {
                     let write_result = match format {
                         OutputFormat::Json => output::write_json(&mut stdout, &result),
@@ -58,7 +66,14 @@ fn main() {
             aged_only,
             all,
             ..
-        }) => match scan::run_scan(&git, &directory, cli.age_threshold, &repo_filter, &progress) {
+        }) => match scan::run_scan(
+            &git,
+            &directory,
+            cli.age_threshold,
+            &repo_filter,
+            &entity_filter,
+            &progress,
+        ) {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,

--- a/crates/git-stash-tidy/src/scan.rs
+++ b/crates/git-stash-tidy/src/scan.rs
@@ -71,6 +71,7 @@ pub fn run_scan(
     directory: &Path,
     age_threshold: u64,
     repo_filter: &NameFilter,
+    entity_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<StashScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
@@ -104,6 +105,12 @@ pub fn run_scan(
         let mut classified = Vec::with_capacity(stashes.len());
 
         for (stash_ref, message, iso_date) in &stashes {
+            // Filter on parsed branch name, or full message if unparseable
+            let filter_name = parse_stash_branch(message);
+            if !entity_filter.matches(filter_name.as_deref().unwrap_or(message)) {
+                continue;
+            }
+
             let (classification, age_days, branch) = classify_stash(
                 git,
                 repo_path,

--- a/crates/git-stash-tidy/tests/integration_clean.rs
+++ b/crates/git-stash-tidy/tests/integration_clean.rs
@@ -48,6 +48,7 @@ fn clean_drops_stash_in_real_repo() {
         &scan_dir,
         90,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -89,6 +90,7 @@ fn clean_dry_run_does_not_drop() {
         &git_ops,
         &scan_dir,
         90,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-stash-tidy/tests/integration_scan.rs
+++ b/crates/git-stash-tidy/tests/integration_scan.rs
@@ -42,6 +42,7 @@ fn scan_real_repo_with_stashes() {
         &scan_dir,
         90,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -76,6 +77,7 @@ fn scan_repo_with_orphaned_stash() {
         &scan_dir,
         90,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -98,6 +100,7 @@ fn scan_empty_repo_no_stashes() {
         &git_ops,
         &scan_dir,
         90,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-tag-tidy/src/cli.rs
+++ b/crates/git-tag-tidy/src/cli.rs
@@ -26,6 +26,14 @@ pub struct Cli {
     /// Exclude repos by name substring (takes precedence over --match-repo)
     #[arg(long = "exclude-repo", global = true)]
     pub exclude_repo_patterns: Vec<String>,
+
+    /// Filter tags by name substring (can be repeated, OR semantics)
+    #[arg(long = "match", global = true)]
+    pub match_patterns: Vec<String>,
+
+    /// Exclude tags by name substring (takes precedence over --match)
+    #[arg(long = "exclude", global = true)]
+    pub exclude_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -196,6 +204,13 @@ mod tests {
             Some(Command::Clean { dry_run, .. }) => assert!(dry_run),
             _ => panic!("expected Clean command"),
         }
+    }
+
+    #[test]
+    fn match_and_exclude_flags() {
+        let cli = Cli::parse_from(["git-tag-tidy", "--match", "v1", "--exclude", "beta", "scan"]);
+        assert_eq!(cli.match_patterns, vec!["v1".to_string()]);
+        assert_eq!(cli.exclude_patterns, vec!["beta".to_string()]);
     }
 
     #[test]

--- a/crates/git-tag-tidy/src/main.rs
+++ b/crates/git-tag-tidy/src/main.rs
@@ -25,6 +25,7 @@ fn main() {
     let git = git::RealGit;
     let progress = Progress::new();
     let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let entity_filter = NameFilter::new(&cli.match_patterns, &cli.exclude_patterns);
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -36,7 +37,14 @@ fn main() {
                 _ => OutputFormat::Human,
             };
 
-            match scan::run_scan(&git, &directory, cli.offline, &repo_filter, &progress) {
+            match scan::run_scan(
+                &git,
+                &directory,
+                cli.offline,
+                &repo_filter,
+                &entity_filter,
+                &progress,
+            ) {
                 Ok(result) => {
                     let write_result = match format {
                         OutputFormat::Json => output::write_json(&mut stdout, &result),
@@ -60,7 +68,14 @@ fn main() {
             include_remote,
             all,
             ..
-        }) => match scan::run_scan(&git, &directory, cli.offline, &repo_filter, &progress) {
+        }) => match scan::run_scan(
+            &git,
+            &directory,
+            cli.offline,
+            &repo_filter,
+            &entity_filter,
+            &progress,
+        ) {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,

--- a/crates/git-tag-tidy/src/scan.rs
+++ b/crates/git-tag-tidy/src/scan.rs
@@ -41,6 +41,7 @@ pub fn run_scan(
     directory: &Path,
     offline: bool,
     repo_filter: &NameFilter,
+    entity_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<TagScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
@@ -107,6 +108,10 @@ pub fn run_scan(
         let mut classified = Vec::with_capacity(all_tag_names.len());
 
         for tag_name in &all_tag_names {
+            if !entity_filter.matches(tag_name) {
+                continue;
+            }
+
             let is_local = local_tags.contains(tag_name);
 
             let (local_commit, is_reachable, is_annotated, tagger_date) = if is_local {

--- a/crates/git-tag-tidy/tests/integration_clean.rs
+++ b/crates/git-tag-tidy/tests/integration_clean.rs
@@ -50,6 +50,7 @@ fn clean_removes_local_only_tag() {
         &scan_dir,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -94,6 +95,7 @@ fn clean_dry_run_preserves_tags() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
@@ -149,6 +151,7 @@ fn clean_removes_stale_tag() {
         &scan_dir,
         true,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -202,6 +205,7 @@ fn clean_include_remote_deletes_from_remote() {
         &git_ops,
         &scan_dir,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-tag-tidy/tests/integration_scan.rs
+++ b/crates/git-tag-tidy/tests/integration_scan.rs
@@ -48,6 +48,7 @@ fn scan_synced_tag() {
         &scan_dir,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -87,6 +88,7 @@ fn scan_local_only_tag() {
         &scan_dir,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -123,6 +125,7 @@ fn scan_stale_tag() {
         &scan_dir,
         true,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -152,6 +155,7 @@ fn scan_annotated_tag() {
         &scan_dir,
         true,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -179,6 +183,7 @@ fn scan_empty_repo_no_tags() {
         &git_ops,
         &scan_dir,
         true,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-tidy/src/inprocess.rs
+++ b/crates/git-tidy/src/inprocess.rs
@@ -178,6 +178,7 @@ fn scan_branches(git: &dyn GitOps, directory: &Path, progress: &Progress) -> Too
         DEFAULT_BEHIND_THRESHOLD,
         false,
         &NameFilter::default(),
+        &NameFilter::default(),
         progress,
     ) {
         Ok(result) => {
@@ -208,6 +209,7 @@ fn scan_stashes(git: &dyn GitOps, directory: &Path, progress: &Progress) -> Tool
         directory,
         DEFAULT_AGE_THRESHOLD,
         &NameFilter::default(),
+        &NameFilter::default(),
         progress,
     ) {
         Ok(result) => {
@@ -232,7 +234,14 @@ fn scan_stashes(git: &dyn GitOps, directory: &Path, progress: &Progress) -> Tool
 }
 
 fn scan_remotes(git: &dyn GitOps, directory: &Path, progress: &Progress) -> ToolResult {
-    match git_remote_tidy::scan::run_scan(git, directory, false, &NameFilter::default(), progress) {
+    match git_remote_tidy::scan::run_scan(
+        git,
+        directory,
+        false,
+        &NameFilter::default(),
+        &NameFilter::default(),
+        progress,
+    ) {
         Ok(result) => {
             let c = &result.counts;
             let counts = counts_map(&[
@@ -254,7 +263,14 @@ fn scan_remotes(git: &dyn GitOps, directory: &Path, progress: &Progress) -> Tool
 }
 
 fn scan_tags(git: &dyn GitOps, directory: &Path, progress: &Progress) -> ToolResult {
-    match git_tag_tidy::scan::run_scan(git, directory, false, &NameFilter::default(), progress) {
+    match git_tag_tidy::scan::run_scan(
+        git,
+        directory,
+        false,
+        &NameFilter::default(),
+        &NameFilter::default(),
+        progress,
+    ) {
         Ok(result) => {
             let c = &result.counts;
             let counts = counts_map(&[


### PR DESCRIPTION
Closes #66

## Summary

- Add `--match`/`--exclude` CLI flags to branch-tidy, tag-tidy, stash-tidy, and remote-tidy
- Filter individual entities before classification to skip unnecessary git operations
- Uses the shared `NameFilter` type (case-insensitive substring, OR semantics, exclude takes precedence)

## Entity filter targets

| Tool | Filter target |
|------|--------------|
| branch-tidy | branch name |
| tag-tidy | tag name |
| stash-tidy | parsed branch name from stash message |
| remote-tidy | remote name |

## Test plan

- [x] All existing unit tests pass with `&NameFilter::default()`
- [x] All existing integration tests pass with `&NameFilter::default()`
- [x] New CLI tests verify `--match`/`--exclude` flag parsing for all 4 tools
- [x] `cargo clippy --workspace -- -D clippy::all` clean
- [x] `cargo fmt --check` clean