### PR TITLE
Consolidate Classification naming: Merged -> Landed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ All tools follow a similar CLI shape:
 - All modules that call git take `&dyn GitOps` to enable mocking.
 - Tests use `tempfile::tempdir()` for isolation with real git repos.
 - Path canonicalization in discovery handles macOS `/var` -> `/private/var` symlinks.
-- Classification priority order: merged (0) > landed (1) > partial (2) > active (3) > local (4).
+- Classification priority order: landed (0) > landed-content (1) > partial (2) > active (3) > local (4).
 - Shared test utilities (MockGitBuilder, TestRepo, git helper) live in `git-tidy-core/src/testutil.rs`, gated behind the `testutil` feature. Binary crates depend on `git-tidy-core = { features = ["testutil"] }` in `[dev-dependencies]`.
 - `classify_branch` is the core classification function shared by both tools. `classify_worktree` is a thin wrapper that adds dirty detection.
 - Discovery is inverted between tools: worktree discovery finds `.git` files (linked worktrees), branch discovery finds `.git` directories (repos).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # git-tidy
 
-A Cargo workspace for Git housekeeping tools that share classification logic (merged/landed/active/local) and a common git abstraction layer.
+A Cargo workspace for Git housekeeping tools that share classification logic (landed/landed-content/active/local) and a common git abstraction layer.
 
 ## Usage
 
@@ -91,8 +91,7 @@ git-worktree-tidy scan ~/Developer --porcelain  # machine-readable
 
 # Clean stale worktrees
 git-worktree-tidy clean ~/Developer                    # interactive
-git-worktree-tidy clean ~/Developer --merged-only --yes  # non-interactive, merged only
-git-worktree-tidy clean ~/Developer --landed --yes       # merged + fully landed
+git-worktree-tidy clean ~/Developer --strict --yes         # non-interactive, landed (ancestor proof) only
 git-worktree-tidy clean ~/Developer --dry-run            # preview removals
 
 # Filter by worktree name (substring match, case-insensitive)
@@ -111,8 +110,8 @@ git-branch-tidy scan ~/Developer --json     # JSON output
 git-branch-tidy scan ~/Developer --porcelain  # machine-readable
 
 # Clean stale branches
-git-branch-tidy clean ~/Developer                         # delete merged + landed
-git-branch-tidy clean ~/Developer --merged-only --yes      # non-interactive, merged only
+git-branch-tidy clean ~/Developer                         # delete landed + landed-content
+git-branch-tidy clean ~/Developer --strict --yes           # non-interactive, landed (ancestor proof) only
 git-branch-tidy clean ~/Developer --all --force            # force-delete all classifications
 git-branch-tidy clean ~/Developer --dry-run                # preview deletions
 git-branch-tidy clean ~/Developer --include-remote --yes   # also delete remote branches
@@ -253,11 +252,11 @@ git-tidy ~/Developer --tools branch,tag  # run only specific tools
 
 | Classification | Meaning | Removal safety |
 |----------------|---------|----------------|
-| **merged** | Branch tip is an ancestor of the default branch | Safe |
-| **landed** | All branch commits matched on the default branch (rebase/squash/cherry-pick) | Safe |
+| **landed** | Branch tip is a structural ancestor of the default branch | Safe |
+| **landed-content** | All branch commits matched on the default branch by content (rebase/squash/cherry-pick) | Safe |
 | **partial** | Some branch commits matched (reports ratio like "4/6 landed") | Review required |
-| **active** | Has a remote tracking branch; not merged or landed | Keep |
-| **local** | No remote tracking branch; not merged or landed | Keep |
+| **active** | Has a remote tracking branch; not landed | Keep |
+| **local** | No remote tracking branch; not landed | Keep |
 
 ### Stash classifications
 

--- a/crates/git-branch-tidy/README.md
+++ b/crates/git-branch-tidy/README.md
@@ -22,8 +22,8 @@ git-branch-tidy scan ~/Developer --porcelain  # machine-readable tab-delimited
 ### Clean stale branches
 
 ```bash
-git-branch-tidy clean ~/Developer                         # delete merged + landed
-git-branch-tidy clean ~/Developer --merged-only --yes      # non-interactive, merged only
+git-branch-tidy clean ~/Developer                         # delete landed + landed-content
+git-branch-tidy clean ~/Developer --strict --yes           # non-interactive, landed (ancestor proof) only
 git-branch-tidy clean ~/Developer --all --force            # force-delete all classifications
 git-branch-tidy clean ~/Developer --dry-run                # preview deletions
 git-branch-tidy clean ~/Developer --include-remote --yes   # also delete remote tracking branches
@@ -33,7 +33,7 @@ git-branch-tidy clean ~/Developer --include-remote --yes   # also delete remote 
 
 - The default branch is never deleted (excluded during scan)
 - The currently checked-out branch is never deleted
-- Without `--force`: uses `git branch -d` which refuses to delete unmerged branches
+- Without `--force`: uses `git branch -d` which refuses to delete non-ancestor branches
 - With `--force`: uses `git branch -D` to force-delete
 - `--dry-run` prints what would be deleted without making any changes
 - Remote branch deletion failures are warned, not fatal
@@ -54,8 +54,7 @@ Clean:
   -n, --dry-run                Show what would be deleted without deleting
   -f, --force                  Force-delete branches (git branch -D)
   -y, --yes                    Skip confirmation prompts
-      --merged-only            Only target merged branches
-      --landed                 Target merged and fully landed branches
+      --strict                 Only target landed branches (structural ancestor proof)
       --all                    Include all classifications
       --include-remote         Also delete remote tracking branches
       --json                   Output results as JSON

--- a/crates/git-branch-tidy/src/clean.rs
+++ b/crates/git-branch-tidy/src/clean.rs
@@ -16,11 +16,8 @@ pub struct CleanOptions {
     /// Skip confirmation prompts.
     #[allow(dead_code)]
     pub yes: bool,
-    /// Only target merged branches.
-    pub merged_only: bool,
-    /// Target merged and fully landed branches (default behavior).
-    #[allow(dead_code)]
-    pub landed: bool,
+    /// Only target structurally-proven landed branches.
+    pub strict: bool,
     /// Include all classifications in the interactive flow.
     pub all: bool,
     /// Also delete remote tracking branches.
@@ -143,14 +140,14 @@ fn should_clean(classification: &Classification, options: &CleanOptions) -> bool
         return true;
     }
 
-    if options.merged_only {
-        return matches!(classification, Classification::Merged);
+    if options.strict {
+        return matches!(classification, Classification::Landed);
     }
 
-    // Default: merged + landed (--landed flag is redundant but kept for consistency)
+    // Default: landed (structural) + landed-by-content
     matches!(
         classification,
-        Classification::Merged | Classification::Landed { .. }
+        Classification::Landed | Classification::LandedByContent { .. }
     )
 }
 
@@ -198,7 +195,7 @@ mod tests {
             repo_path: repo(),
             name: name.to_string(),
             default_branch: "main".to_string(),
-            classification: Classification::Merged,
+            classification: Classification::Landed,
             remote_tracking: false,
             remote_deleted: true,
             ahead: 0,
@@ -228,8 +225,7 @@ mod tests {
             dry_run: false,
             force: false,
             yes: false,
-            merged_only: false,
-            landed: false,
+            strict: false,
             all: false,
             include_remote: false,
         }
@@ -331,24 +327,24 @@ mod tests {
     }
 
     #[test]
-    fn clean_merged_only_skips_landed() {
+    fn clean_strict_skips_landed_by_content() {
         let git = MockGitBuilder::new().build();
-        let mut landed = merged_branch("feature/landed");
-        landed.classification = Classification::Landed {
+        let mut content = merged_branch("feature/content");
+        content.classification = Classification::LandedByContent {
             matched: 3,
             total: 3,
         };
-        let scan = make_scan_result(vec![merged_branch("feature/merged"), landed]);
+        let scan = make_scan_result(vec![merged_branch("feature/landed"), content]);
         let mut buf = Vec::new();
         let options = CleanOptions {
-            merged_only: true,
+            strict: true,
             ..default_options()
         };
 
         let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
 
         assert_eq!(result.succeeded.len(), 1);
-        assert_eq!(result.succeeded[0].name, "feature/merged");
+        assert_eq!(result.succeeded[0].name, "feature/landed");
         assert_eq!(result.skipped, 1);
     }
 

--- a/crates/git-branch-tidy/src/cli.rs
+++ b/crates/git-branch-tidy/src/cli.rs
@@ -51,13 +51,9 @@ pub enum Command {
         #[arg(short = 'y', long)]
         yes: bool,
 
-        /// Only target merged branches
+        /// Only target structurally-proven landed branches
         #[arg(long)]
-        merged_only: bool,
-
-        /// Target merged and fully landed branches (not partial)
-        #[arg(long)]
-        landed: bool,
+        strict: bool,
 
         /// Include active and local branches in the interactive clean flow
         #[arg(long)]
@@ -111,7 +107,7 @@ mod tests {
             "--dry-run",
             "--force",
             "--yes",
-            "--merged-only",
+            "--strict",
             "--include-remote",
         ]);
         match cli.command {
@@ -119,14 +115,14 @@ mod tests {
                 dry_run,
                 force,
                 yes,
-                merged_only,
+                strict,
                 include_remote,
                 ..
             }) => {
                 assert!(dry_run);
                 assert!(force);
                 assert!(yes);
-                assert!(merged_only);
+                assert!(strict);
                 assert!(include_remote);
             }
             _ => panic!("expected Clean command"),
@@ -166,17 +162,6 @@ mod tests {
                 assert!(porcelain);
             }
             _ => panic!("expected Scan command"),
-        }
-    }
-
-    #[test]
-    fn clean_landed_flag() {
-        let cli = Cli::parse_from(["git-branch-tidy", "clean", "--landed"]);
-        match cli.command {
-            Some(Command::Clean { landed, .. }) => {
-                assert!(landed);
-            }
-            _ => panic!("expected Clean command"),
         }
     }
 

--- a/crates/git-branch-tidy/src/main.rs
+++ b/crates/git-branch-tidy/src/main.rs
@@ -60,8 +60,7 @@ fn main() {
             dry_run,
             force,
             yes,
-            merged_only,
-            landed,
+            strict,
             all,
             include_remote,
             ..
@@ -79,8 +78,7 @@ fn main() {
                         dry_run: *dry_run,
                         force: *force,
                         yes: *yes,
-                        merged_only: *merged_only,
-                        landed: *landed,
+                        strict: *strict,
                         all: *all,
                         include_remote: *include_remote,
                     };

--- a/crates/git-branch-tidy/src/output.rs
+++ b/crates/git-branch-tidy/src/output.rs
@@ -121,7 +121,7 @@ mod tests {
                         repo_path: PathBuf::from("/repos/Backend"),
                         name: "fix/skip-db-init".to_string(),
                         default_branch: "main".to_string(),
-                        classification: Classification::Merged,
+                        classification: Classification::Landed,
                         remote_tracking: true,
                         remote_deleted: true,
                         ahead: 0,
@@ -145,8 +145,8 @@ mod tests {
             }],
             total_scanned: 2,
             counts: ScanCounts {
-                merged: 1,
-                landed: 0,
+                landed: 1,
+                landed_content: 0,
                 partial: 0,
                 active: 1,
                 local: 0,
@@ -163,13 +163,14 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
 
         assert!(output.contains("Backend (2 branches)"));
-        assert!(output.contains("merged"));
+        assert!(output.contains("landed"));
         assert!(output.contains("active"));
         assert!(output.contains("fix/skip-db-init"));
         assert!(output.contains("* feature/caps"));
         assert!(output.contains("remote deleted"));
         assert!(
-            output.contains("2 branches scanned: 1 merged, 0 landed, 0 partial, 1 active, 0 local")
+            output
+                .contains("2 branches scanned: 1 landed, 0 content, 0 partial, 1 active, 0 local")
         );
     }
 
@@ -234,7 +235,7 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
         let arr = parsed.as_array().unwrap();
         assert_eq!(arr.len(), 2);
-        assert_eq!(arr[0]["classification"], "merged");
+        assert_eq!(arr[0]["classification"], "landed");
         assert_eq!(arr[0]["remote_deleted"], true);
         assert_eq!(arr[1]["classification"], "active");
         assert_eq!(arr[1]["is_current"], true);
@@ -254,7 +255,7 @@ mod tests {
         assert_eq!(fields.len(), 8);
         assert_eq!(fields[0], "/repos/Backend");
         assert_eq!(fields[1], "fix/skip-db-init");
-        assert_eq!(fields[2], "merged");
+        assert_eq!(fields[2], "landed");
         assert_eq!(fields[7], "remote_deleted");
 
         let fields2: Vec<&str> = lines[1].split('\t').collect();

--- a/crates/git-branch-tidy/src/scan.rs
+++ b/crates/git-branch-tidy/src/scan.rs
@@ -191,7 +191,7 @@ mod tests {
         let bc1 =
             classification::classify_branch(&git, &repo(), "feature/done", "main", 100, false)
                 .unwrap();
-        assert_eq!(bc1.classification, Classification::Merged);
+        assert_eq!(bc1.classification, Classification::Landed);
 
         let bc2 = classification::classify_branch(&git, &repo(), "feature/wip", "main", 100, false)
             .unwrap();

--- a/crates/git-branch-tidy/tests/integration_clean.rs
+++ b/crates/git-branch-tidy/tests/integration_clean.rs
@@ -58,8 +58,7 @@ fn clean_deletes_merged_branch_in_real_repo() {
         dry_run: false,
         force: false,
         yes: true,
-        merged_only: false,
-        landed: false,
+        strict: false,
         all: false,
         include_remote: false,
     };
@@ -97,8 +96,7 @@ fn clean_dry_run_does_not_delete() {
         dry_run: true,
         force: false,
         yes: true,
-        merged_only: false,
-        landed: false,
+        strict: false,
         all: false,
         include_remote: false,
     };
@@ -145,8 +143,7 @@ fn clean_safe_refuses_unmerged_branch() {
         dry_run: false,
         force: false,
         yes: true,
-        merged_only: false,
-        landed: false,
+        strict: false,
         all: true,
         include_remote: false,
     };

--- a/crates/git-branch-tidy/tests/integration_scan.rs
+++ b/crates/git-branch-tidy/tests/integration_scan.rs
@@ -78,7 +78,7 @@ fn scan_real_repo_with_mixed_branches() {
         .iter()
         .find(|b| b.name == "feature/done")
         .expect("should find feature/done");
-    assert_eq!(done.classification, Classification::Merged);
+    assert_eq!(done.classification, Classification::Landed);
 
     // feature/wip should be local (no remote tracking, has unique commits)
     let wip = repo_group
@@ -94,7 +94,7 @@ fn scan_real_repo_with_mixed_branches() {
 
     // Counts
     assert_eq!(result.total_scanned, 2);
-    assert_eq!(result.counts.merged, 1);
+    assert_eq!(result.counts.landed, 1);
     assert_eq!(result.counts.local, 1);
 }
 

--- a/crates/git-tidy-core/src/classification.rs
+++ b/crates/git-tidy-core/src/classification.rs
@@ -52,32 +52,34 @@ pub fn classify_branch(
     // Ahead/behind counts
     let (behind, ahead) = git.rev_list_left_right_count(repo, &origin_default, branch_name)?;
 
-    // Check if merged — skip the subprocess call when ahead == 0 (already fully merged)
+    // Check if structurally landed — skip the subprocess call when ahead == 0
     let is_merged = ahead == 0 || git.is_ancestor(repo, branch_name, &origin_default)?;
 
     let classification = if is_merged {
-        Classification::Merged
+        Classification::Landed
     } else {
-        // Try landed detection
+        // Try content-based landed detection
         let landed_result =
             landed::detect_landed(git, repo, &origin_default, branch_name, verbose)?;
 
         enum Action {
-            UseLanded,
-            Merged,
+            UseContentResult,
+            Landed,
             Active,
             Local,
         }
         let action = match &landed_result.classification {
-            Classification::Landed { .. } if landed_result.total > 0 => Action::UseLanded,
-            Classification::Landed { .. } => Action::Merged,
-            Classification::LandedPartial { .. } => Action::UseLanded,
+            Classification::LandedByContent { .. } if landed_result.total > 0 => {
+                Action::UseContentResult
+            }
+            Classification::LandedByContent { .. } => Action::Landed,
+            Classification::LandedPartial { .. } => Action::UseContentResult,
             _ if has_remote => Action::Active,
             _ => Action::Local,
         };
         match action {
-            Action::UseLanded => landed_result.classification,
-            Action::Merged => Classification::Merged,
+            Action::UseContentResult => landed_result.classification,
+            Action::Landed => Classification::Landed,
             Action::Active => Classification::Active,
             Action::Local => Classification::Local,
         }
@@ -235,7 +237,7 @@ mod tests {
 
         let info =
             classify_worktree(&git, &wt(), &repo(), "main", 100, false, &default_noise()).unwrap();
-        assert_eq!(info.classification, Classification::Merged);
+        assert_eq!(info.classification, Classification::Landed);
         assert!(!info.annotations.dirty);
         assert!(!info.annotations.remote_deleted);
     }
@@ -344,7 +346,7 @@ mod tests {
 
         let info =
             classify_worktree(&git, &wt(), &repo(), "main", 100, false, &default_noise()).unwrap();
-        assert_eq!(info.classification, Classification::Merged);
+        assert_eq!(info.classification, Classification::Landed);
         assert!(info.annotations.remote_deleted);
     }
 
@@ -360,7 +362,7 @@ mod tests {
 
         let info =
             classify_worktree(&git, &wt(), &repo(), "main", 100, false, &default_noise()).unwrap();
-        assert_eq!(info.classification, Classification::Merged);
+        assert_eq!(info.classification, Classification::Landed);
         assert!(info.branch.is_none());
     }
 
@@ -375,7 +377,7 @@ mod tests {
             .build();
 
         let result = classify_branch(&git, &repo(), "feature/done", "main", 100, false).unwrap();
-        assert_eq!(result.classification, Classification::Merged);
+        assert_eq!(result.classification, Classification::Landed);
         assert!(result.remote_tracking);
         assert!(!result.remote_deleted);
         assert!(!result.diverged);
@@ -430,7 +432,7 @@ mod tests {
             .build();
 
         let result = classify_branch(&git, &repo(), "feature/gone", "main", 100, false).unwrap();
-        assert_eq!(result.classification, Classification::Merged);
+        assert_eq!(result.classification, Classification::Landed);
         assert!(result.remote_deleted);
     }
 
@@ -464,7 +466,7 @@ mod tests {
             .build();
 
         let result = classify_branch(&git, &repo(), "feature/behind", "main", 100, false).unwrap();
-        assert_eq!(result.classification, Classification::Merged);
+        assert_eq!(result.classification, Classification::Landed);
         assert_eq!(result.behind, 50);
         assert_eq!(result.ahead, 0);
     }

--- a/crates/git-tidy-core/src/landed.rs
+++ b/crates/git-tidy-core/src/landed.rs
@@ -33,7 +33,7 @@ pub fn detect_landed(
 
     if total == 0 {
         return Ok(LandedResult {
-            classification: Classification::Landed {
+            classification: Classification::LandedByContent {
                 matched: 0,
                 total: 0,
             },
@@ -70,7 +70,7 @@ pub fn detect_landed(
     }
 
     let classification = if matched == total {
-        Classification::Landed { matched, total }
+        Classification::LandedByContent { matched, total }
     } else if matched > 0 {
         Classification::LandedPartial {
             matched,
@@ -435,7 +435,7 @@ mod tests {
         assert_eq!(result.total, 2);
         assert!(matches!(
             result.classification,
-            Classification::Landed {
+            Classification::LandedByContent {
                 matched: 2,
                 total: 2
             }
@@ -506,7 +506,7 @@ mod tests {
         assert_eq!(result.total, 0);
         assert!(matches!(
             result.classification,
-            Classification::Landed {
+            Classification::LandedByContent {
                 matched: 0,
                 total: 0
             }

--- a/crates/git-tidy-core/src/output.rs
+++ b/crates/git-tidy-core/src/output.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 
 use crate::types::{Classification, ScanCounts};
 
-/// Write the summary line: "N {item_noun} scanned: X merged, Y landed, ..."
+/// Write the summary line: "N {item_noun} scanned: X landed, Y content, ..."
 pub fn write_summary_line(
     out: &mut dyn Write,
     total: usize,
@@ -16,8 +16,8 @@ pub fn write_summary_line(
 ) -> std::io::Result<()> {
     writeln!(
         out,
-        "\n{total} {item_noun} scanned: {} merged, {} landed, {} partial, {} active, {} local",
-        counts.merged, counts.landed, counts.partial, counts.active, counts.local,
+        "\n{total} {item_noun} scanned: {} landed, {} content, {} partial, {} active, {} local",
+        counts.landed, counts.landed_content, counts.partial, counts.active, counts.local,
     )
 }
 
@@ -75,7 +75,7 @@ pub fn write_json_pretty(out: &mut dyn Write, value: &impl Serialize) -> std::io
 /// Format the landed ratio for display. Returns empty string for non-landed classifications.
 pub fn format_landed_ratio(classification: &Classification) -> String {
     match classification {
-        Classification::Landed { matched, total } => format!("{matched}/{total}"),
+        Classification::LandedByContent { matched, total } => format!("{matched}/{total}"),
         Classification::LandedPartial { matched, total, .. } => format!("{matched}/{total}"),
         _ => String::new(),
     }
@@ -88,8 +88,8 @@ mod tests {
     #[test]
     fn summary_line_format() {
         let counts = ScanCounts {
-            merged: 3,
-            landed: 1,
+            landed: 3,
+            landed_content: 1,
             partial: 0,
             active: 2,
             local: 1,
@@ -99,14 +99,14 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
         assert_eq!(
             output,
-            "\n7 branches scanned: 3 merged, 1 landed, 0 partial, 2 active, 1 local\n"
+            "\n7 branches scanned: 3 landed, 1 content, 0 partial, 2 active, 1 local\n"
         );
     }
 
     #[test]
     fn summary_line_worktrees() {
         let counts = ScanCounts {
-            merged: 1,
+            landed: 1,
             ..Default::default()
         };
         let mut buf = Vec::new();
@@ -155,9 +155,9 @@ mod tests {
     }
 
     #[test]
-    fn landed_ratio_landed() {
+    fn landed_ratio_by_content() {
         assert_eq!(
-            format_landed_ratio(&Classification::Landed {
+            format_landed_ratio(&Classification::LandedByContent {
                 matched: 3,
                 total: 3
             }),

--- a/crates/git-tidy-core/src/types.rs
+++ b/crates/git-tidy-core/src/types.rs
@@ -55,31 +55,32 @@ pub struct CleanResult<S> {
     pub skipped: usize,
 }
 
-/// Primary staleness classification for a worktree.
+/// Primary staleness classification for a worktree or branch.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Classification {
-    /// Branch tip is an ancestor of the default branch.
-    Merged,
-    /// All branch commits have matching commits on the default branch.
-    Landed { matched: usize, total: usize },
-    /// Some but not all branch commits matched.
+    /// Branch tip is a structural ancestor of the default branch (git merge-base proof).
+    Landed,
+    /// All branch commits have matching commits on the default branch (heuristic content matching).
+    #[serde(rename = "landed-content")]
+    LandedByContent { matched: usize, total: usize },
+    /// Some but not all branch commits matched (heuristic, partial).
     LandedPartial {
         matched: usize,
         total: usize,
         unmatched: Vec<UnmatchedCommit>,
     },
-    /// Has a remote tracking branch; not merged or landed.
+    /// Has a remote tracking branch; not landed.
     Active,
-    /// No remote tracking branch; not merged or landed.
+    /// No remote tracking branch; not landed.
     Local,
 }
 
 impl ClassificationLabel for Classification {
     fn priority(&self) -> u8 {
         match self {
-            Classification::Merged => 0,
-            Classification::Landed { .. } => 1,
+            Classification::Landed => 0,
+            Classification::LandedByContent { .. } => 1,
             Classification::LandedPartial { .. } => 2,
             Classification::Active => 3,
             Classification::Local => 4,
@@ -88,8 +89,8 @@ impl ClassificationLabel for Classification {
 
     fn label(&self) -> &'static str {
         match self {
-            Classification::Merged => "merged",
-            Classification::Landed { .. } => "landed",
+            Classification::Landed => "landed",
+            Classification::LandedByContent { .. } => "landed-content",
             Classification::LandedPartial { .. } => "partial",
             Classification::Active => "active",
             Classification::Local => "local",
@@ -108,7 +109,7 @@ pub struct LandedFields {
 /// Extract landed ratio, total, and unmatched commits from a classification.
 pub fn extract_landed_fields(classification: &Classification) -> LandedFields {
     match classification {
-        Classification::Landed { matched, total } => LandedFields {
+        Classification::LandedByContent { matched, total } => LandedFields {
             ratio: Some(format!("{matched}/{total}")),
             total: Some(*total),
             unmatched: vec![],
@@ -206,8 +207,8 @@ pub struct RepoGroup {
 }
 
 define_counts!(ScanCounts, Classification, {
-    Classification::Merged => merged,
-    Classification::Landed { .. } => landed,
+    Classification::Landed => landed,
+    Classification::LandedByContent { .. } => landed_content,
     Classification::LandedPartial { .. } => partial,
     Classification::Active => active,
     Classification::Local => local,
@@ -290,14 +291,14 @@ mod tests {
 
     #[test]
     fn classification_label_trait() {
-        assert_eq!(Classification::Merged.label(), "merged");
+        assert_eq!(Classification::Landed.label(), "landed");
         assert_eq!(
-            Classification::Landed {
+            Classification::LandedByContent {
                 matched: 1,
                 total: 1
             }
             .label(),
-            "landed"
+            "landed-content"
         );
         assert_eq!(
             Classification::LandedPartial {
@@ -310,12 +311,12 @@ mod tests {
         );
         assert_eq!(Classification::Active.label(), "active");
         assert_eq!(Classification::Local.label(), "local");
-        assert!(Classification::Merged.priority() < Classification::Active.priority());
+        assert!(Classification::Landed.priority() < Classification::Active.priority());
     }
 
     #[test]
-    fn extract_landed_merged() {
-        let c = Classification::Merged;
+    fn extract_landed_structural() {
+        let c = Classification::Landed;
         let f = extract_landed_fields(&c);
         assert!(f.ratio.is_none());
         assert!(f.total.is_none());
@@ -323,8 +324,8 @@ mod tests {
     }
 
     #[test]
-    fn extract_landed_landed() {
-        let c = Classification::Landed {
+    fn extract_landed_by_content() {
+        let c = Classification::LandedByContent {
             matched: 3,
             total: 3,
         };

--- a/crates/git-tidy/README.md
+++ b/crates/git-tidy/README.md
@@ -78,8 +78,8 @@ In subprocess mode (`--subprocess`), only installed tools are run. Missing tools
 ```
 git-tidy audit: ~/Developer
 
-  worktrees:       8 scanned (1 merged, 2 landed, 5 active)
-  branches:       22 scanned (3 merged, 5 landed, 2 partial, 12 active)
+  worktrees:       8 scanned (1 landed, 2 content, 5 active)
+  branches:       22 scanned (3 landed, 5 content, 2 partial, 12 active)
   stashes:         6 scanned (2 committed, 1 orphaned, 3 active)
   remotes:         4 scanned (1 unreachable, 3 active)
   tags:           15 scanned (2 stale, 3 local_only, 10 synced)
@@ -103,7 +103,7 @@ Run individual tools for details.
       "name": "git-worktree-tidy",
       "item_noun": "worktrees",
       "total": 8,
-      "counts": { "active": 5, "landed": 2, "merged": 1 },
+      "counts": { "active": 5, "landed_content": 2, "landed": 1 },
       "error": null
     }
   ]

--- a/crates/git-tidy/src/inprocess.rs
+++ b/crates/git-tidy/src/inprocess.rs
@@ -150,8 +150,8 @@ fn scan_worktrees(
         Ok(result) => {
             let c = &result.counts;
             let counts = counts_map(&[
-                ("merged", c.merged),
                 ("landed", c.landed),
+                ("landed-content", c.landed_content),
                 ("partial", c.partial),
                 ("active", c.active),
                 ("local", c.local),
@@ -175,8 +175,8 @@ fn scan_branches(git: &dyn GitOps, directory: &Path, progress: &Progress) -> Too
         Ok(result) => {
             let c = &result.counts;
             let counts = counts_map(&[
-                ("merged", c.merged),
                 ("landed", c.landed),
+                ("landed-content", c.landed_content),
                 ("partial", c.partial),
                 ("active", c.active),
                 ("local", c.local),
@@ -370,11 +370,11 @@ mod tests {
 
     #[test]
     fn counts_map_omits_zeros() {
-        let m = counts_map(&[("active", 5), ("merged", 0), ("landed", 2)]);
+        let m = counts_map(&[("active", 5), ("landed", 0), ("landed-content", 2)]);
         assert_eq!(m.len(), 2);
         assert_eq!(m["active"], 5);
-        assert_eq!(m["landed"], 2);
-        assert!(!m.contains_key("merged"));
+        assert_eq!(m["landed-content"], 2);
+        assert!(!m.contains_key("landed"));
     }
 
     #[test]

--- a/crates/git-tidy/src/output.rs
+++ b/crates/git-tidy/src/output.rs
@@ -121,8 +121,8 @@ mod tests {
                     total: 8,
                     counts: BTreeMap::from([
                         ("active".to_string(), 5),
-                        ("landed".to_string(), 2),
-                        ("merged".to_string(), 1),
+                        ("landed".to_string(), 1),
+                        ("landed-content".to_string(), 2),
                     ]),
                     error: None,
                 },
@@ -130,7 +130,7 @@ mod tests {
                     name: "git-branch-tidy".to_string(),
                     item_noun: "branches".to_string(),
                     total: 3,
-                    counts: BTreeMap::from([("active".to_string(), 2), ("merged".to_string(), 1)]),
+                    counts: BTreeMap::from([("active".to_string(), 2), ("landed".to_string(), 1)]),
                     error: None,
                 },
             ],
@@ -145,8 +145,10 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
 
         assert!(output.contains("git-tidy audit: /tmp/dev"));
-        assert!(output.contains("worktrees:       8 scanned (5 active, 2 landed, 1 merged)"));
-        assert!(output.contains("branches:        3 scanned (2 active, 1 merged)"));
+        assert!(
+            output.contains("worktrees:       8 scanned (5 active, 1 landed, 2 landed-content)")
+        );
+        assert!(output.contains("branches:        3 scanned (2 active, 1 landed)"));
         assert!(output.contains("not installed: git-repo-tidy"));
         assert!(output.contains("Run individual tools for details."));
     }
@@ -235,11 +237,11 @@ mod tests {
         assert_eq!(fields[0], "git-worktree-tidy");
         assert_eq!(fields[1], "worktrees");
         assert_eq!(fields[2], "8");
-        // Counts are sorted (BTreeMap): active, landed, merged
+        // Counts are sorted (BTreeMap): active, landed, landed-content
         let counts: serde_json::Value = serde_json::from_str(fields[3]).unwrap();
         assert_eq!(counts["active"], 5);
-        assert_eq!(counts["landed"], 2);
-        assert_eq!(counts["merged"], 1);
+        assert_eq!(counts["landed"], 1);
+        assert_eq!(counts["landed-content"], 2);
         assert_eq!(fields[4], ""); // no error
     }
 

--- a/crates/git-tidy/src/runner.rs
+++ b/crates/git-tidy/src/runner.rs
@@ -169,17 +169,17 @@ mod tests {
     #[test]
     fn parse_classification_field() {
         let json = r#"[
-            {"name": "a", "classification": "merged"},
+            {"name": "a", "classification": "landed"},
             {"name": "b", "classification": "active"},
-            {"name": "c", "classification": "merged"},
-            {"name": "d", "classification": "landed"}
+            {"name": "c", "classification": "landed"},
+            {"name": "d", "classification": "landed-content"}
         ]"#;
 
         let (total, counts) = parse_tool_output(json, "classification").unwrap();
         assert_eq!(total, 4);
-        assert_eq!(counts["merged"], 2);
+        assert_eq!(counts["landed"], 2);
         assert_eq!(counts["active"], 1);
-        assert_eq!(counts["landed"], 1);
+        assert_eq!(counts["landed-content"], 1);
     }
 
     #[test]
@@ -304,9 +304,12 @@ mod tests {
         let runner = MockToolRunner::new(vec![
             (
                 "git-worktree-tidy",
-                Ok(r#"[{"classification":"active"},{"classification":"merged"}]"#),
+                Ok(r#"[{"classification":"active"},{"classification":"landed"}]"#),
             ),
-            ("git-branch-tidy", Ok(r#"[{"classification":"landed"}]"#)),
+            (
+                "git-branch-tidy",
+                Ok(r#"[{"classification":"landed-content"}]"#),
+            ),
             ("git-stash-tidy", Ok("[]")),
             ("git-remote-tidy", Ok("[]")),
             ("git-tag-tidy", Ok("[]")),
@@ -327,7 +330,7 @@ mod tests {
         assert_eq!(wt.name, "git-worktree-tidy");
         assert_eq!(wt.total, 2);
         assert_eq!(wt.counts["active"], 1);
-        assert_eq!(wt.counts["merged"], 1);
+        assert_eq!(wt.counts["landed"], 1);
         assert!(wt.error.is_none());
 
         let config = &result.results[6];

--- a/crates/git-tidy/src/types.rs
+++ b/crates/git-tidy/src/types.rs
@@ -204,7 +204,7 @@ mod tests {
             name: "git-branch-tidy".to_string(),
             item_noun: "branches".to_string(),
             total: 5,
-            counts: BTreeMap::from([("active".to_string(), 3), ("merged".to_string(), 2)]),
+            counts: BTreeMap::from([("active".to_string(), 3), ("landed".to_string(), 2)]),
             error: None,
         };
         let json = serde_json::to_value(&result).unwrap();

--- a/crates/git-tidy/tests/integration.rs
+++ b/crates/git-tidy/tests/integration.rs
@@ -44,14 +44,14 @@ fn full_audit_multiple_tools() {
             "git-worktree-tidy",
             r#"[
                 {"classification":"active","name":"a"},
-                {"classification":"merged","name":"b"},
+                {"classification":"landed","name":"b"},
                 {"classification":"active","name":"c"}
             ]"#,
         ),
         (
             "git-branch-tidy",
             r#"[
-                {"classification":"landed","name":"feature"},
+                {"classification":"landed-content","name":"feature"},
                 {"classification":"active","name":"main"}
             ]"#,
         ),
@@ -85,7 +85,7 @@ fn full_audit_multiple_tools() {
         .unwrap();
     assert_eq!(wt.total, 3);
     assert_eq!(wt.counts["active"], 2);
-    assert_eq!(wt.counts["merged"], 1);
+    assert_eq!(wt.counts["landed"], 1);
     assert!(wt.error.is_none());
 
     // Config results (uses "kind" field)
@@ -122,7 +122,7 @@ fn full_audit_json_roundtrip() {
 fn full_audit_porcelain_roundtrip() {
     let runner = FakeToolRunner::new(vec![(
         "git-branch-tidy",
-        r#"[{"classification":"active"},{"classification":"merged"}]"#,
+        r#"[{"classification":"active"},{"classification":"landed"}]"#,
     )]);
 
     let result = run_audit(&runner, Path::new("/tmp"), None, &Progress::disabled());
@@ -145,7 +145,7 @@ fn full_audit_porcelain_roundtrip() {
 fn full_audit_human_output_end_to_end() {
     let runner = FakeToolRunner::new(vec![(
         "git-worktree-tidy",
-        r#"[{"classification":"active"},{"classification":"active"},{"classification":"merged"}]"#,
+        r#"[{"classification":"active"},{"classification":"active"},{"classification":"landed"}]"#,
     )]);
 
     let result = run_audit(&runner, Path::new("/tmp/dev"), None, &Progress::disabled());
@@ -158,7 +158,7 @@ fn full_audit_human_output_end_to_end() {
     assert!(output.contains("worktrees:"));
     assert!(output.contains("3 scanned"));
     assert!(output.contains("2 active"));
-    assert!(output.contains("1 merged"));
+    assert!(output.contains("1 landed"));
     assert!(output.contains("not installed:"));
     assert!(output.contains("Run individual tools for details."));
 }

--- a/crates/git-worktree-tidy/src/clean.rs
+++ b/crates/git-worktree-tidy/src/clean.rs
@@ -14,11 +14,8 @@ pub struct CleanOptions {
     /// Skip confirmation prompts.
     #[allow(dead_code)]
     pub yes: bool,
-    /// Only target merged worktrees.
-    pub merged_only: bool,
-    /// Target merged and fully landed worktrees (default behavior).
-    #[allow(dead_code)]
-    pub landed: bool,
+    /// Only target structurally-proven landed worktrees.
+    pub strict: bool,
     /// Include active and local worktrees in the clean flow.
     pub all: bool,
     /// Delete local branches after removing their worktrees.
@@ -119,14 +116,14 @@ fn should_clean(classification: &Classification, options: &CleanOptions) -> bool
         return true;
     }
 
-    if options.merged_only {
-        return matches!(classification, Classification::Merged);
+    if options.strict {
+        return matches!(classification, Classification::Landed);
     }
 
-    // Default: merged + landed (--landed flag is redundant but kept for consistency)
+    // Default: landed (structural) + landed-by-content
     matches!(
         classification,
-        Classification::Merged | Classification::Landed { .. }
+        Classification::Landed | Classification::LandedByContent { .. }
     )
 }
 
@@ -257,8 +254,7 @@ mod tests {
             dry_run: false,
             force: false,
             yes: false,
-            merged_only: false,
-            landed: false,
+            strict: false,
             all: false,
             delete_branches: false,
         }
@@ -267,7 +263,7 @@ mod tests {
     #[test]
     fn clean_removes_merged_worktrees() {
         let git = MockGitBuilder::new().build();
-        let wt = make_worktree("wt-done", "feature/done", Classification::Merged);
+        let wt = make_worktree("wt-done", "feature/done", Classification::Landed);
         let scan = make_scan(vec![wt]);
         let mut buf = Vec::new();
 
@@ -282,12 +278,12 @@ mod tests {
     }
 
     #[test]
-    fn clean_removes_landed_worktrees() {
+    fn clean_removes_landed_by_content_worktrees() {
         let git = MockGitBuilder::new().build();
         let wt = make_worktree(
             "wt-landed",
             "feature/landed",
-            Classification::Landed {
+            Classification::LandedByContent {
                 matched: 3,
                 total: 3,
             },
@@ -347,14 +343,14 @@ mod tests {
     }
 
     #[test]
-    fn clean_merged_only_skips_landed() {
+    fn clean_strict_skips_landed_by_content() {
         let git = MockGitBuilder::new().build();
         let scan = make_scan(vec![
-            make_worktree("wt-merged", "fix/done", Classification::Merged),
+            make_worktree("wt-landed", "fix/done", Classification::Landed),
             make_worktree(
-                "wt-landed",
-                "fix/landed",
-                Classification::Landed {
+                "wt-content",
+                "fix/content",
+                Classification::LandedByContent {
                     matched: 3,
                     total: 3,
                 },
@@ -362,14 +358,14 @@ mod tests {
         ]);
         let mut buf = Vec::new();
         let options = CleanOptions {
-            merged_only: true,
+            strict: true,
             ..default_options()
         };
 
         let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
 
         assert_eq!(result.succeeded.len(), 1);
-        assert_eq!(result.succeeded[0].path, PathBuf::from("/dev/wt-merged"));
+        assert_eq!(result.succeeded[0].path, PathBuf::from("/dev/wt-landed"));
         assert_eq!(result.skipped, 1);
     }
 
@@ -377,8 +373,8 @@ mod tests {
     fn clean_dry_run_makes_zero_remove_calls() {
         let git = MockGitBuilder::new().build();
         let scan = make_scan(vec![
-            make_worktree("wt-a", "feature/a", Classification::Merged),
-            make_worktree("wt-b", "feature/b", Classification::Merged),
+            make_worktree("wt-a", "feature/a", Classification::Landed),
+            make_worktree("wt-b", "feature/b", Classification::Landed),
         ]);
         let mut buf = Vec::new();
         let options = CleanOptions {
@@ -400,7 +396,7 @@ mod tests {
     #[test]
     fn clean_dirty_blocked_without_force() {
         let git = MockGitBuilder::new().build();
-        let mut wt = make_worktree("wt-dirty", "fix/dirty", Classification::Merged);
+        let mut wt = make_worktree("wt-dirty", "fix/dirty", Classification::Landed);
         wt.annotations.dirty = true;
         wt.annotations.dirty_file_count = 3;
         let scan = make_scan(vec![wt]);
@@ -420,7 +416,7 @@ mod tests {
     #[test]
     fn clean_force_removes_dirty() {
         let git = MockGitBuilder::new().build();
-        let mut wt = make_worktree("wt-dirty", "fix/dirty", Classification::Merged);
+        let mut wt = make_worktree("wt-dirty", "fix/dirty", Classification::Landed);
         wt.annotations.dirty = true;
         wt.annotations.dirty_file_count = 2;
         let scan = make_scan(vec![wt]);
@@ -445,7 +441,7 @@ mod tests {
             .build();
         // The worktree path doesn't actually exist on disk, so rm -rf is a no-op,
         // but worktree_prune should be called.
-        let wt = make_worktree("wt-stubborn", "feature/stuck", Classification::Merged);
+        let wt = make_worktree("wt-stubborn", "feature/stuck", Classification::Landed);
         let scan = make_scan(vec![wt]);
         let mut buf = Vec::new();
 
@@ -460,7 +456,7 @@ mod tests {
     #[test]
     fn clean_delete_branches_after_removal() {
         let git = MockGitBuilder::new().build();
-        let wt = make_worktree("wt-done", "feature/done", Classification::Merged);
+        let wt = make_worktree("wt-done", "feature/done", Classification::Landed);
         let scan = make_scan(vec![wt]);
         let mut buf = Vec::new();
         let options = CleanOptions {
@@ -486,7 +482,7 @@ mod tests {
         let git = MockGitBuilder::new()
             .with_is_branch_checked_out(&repo(), "feature/done", true)
             .build();
-        let wt = make_worktree("wt-done", "feature/done", Classification::Merged);
+        let wt = make_worktree("wt-done", "feature/done", Classification::Landed);
         let scan = make_scan(vec![wt]);
         let mut buf = Vec::new();
         let options = CleanOptions {
@@ -507,7 +503,7 @@ mod tests {
     #[test]
     fn clean_dry_run_mentions_branch_deletion() {
         let git = MockGitBuilder::new().build();
-        let wt = make_worktree("wt-done", "feature/done", Classification::Merged);
+        let wt = make_worktree("wt-done", "feature/done", Classification::Landed);
         let scan = make_scan(vec![wt]);
         let mut buf = Vec::new();
         let options = CleanOptions {
@@ -534,7 +530,7 @@ mod tests {
         let git = MockGitBuilder::new()
             .with_worktree_remove_error(&wt_path, "tier 1 failed")
             .build();
-        let wt = make_worktree("wt-fail", "feature/fail", Classification::Merged);
+        let wt = make_worktree("wt-fail", "feature/fail", Classification::Landed);
         let scan = make_scan(vec![wt]);
         let mut buf = Vec::new();
 
@@ -545,12 +541,12 @@ mod tests {
     }
 
     #[test]
-    fn should_clean_default_includes_merged_and_landed() {
+    fn should_clean_default_includes_landed_and_by_content() {
         let options = default_options();
 
-        assert!(should_clean(&Classification::Merged, &options));
+        assert!(should_clean(&Classification::Landed, &options));
         assert!(should_clean(
-            &Classification::Landed {
+            &Classification::LandedByContent {
                 matched: 1,
                 total: 1
             },
@@ -575,21 +571,21 @@ mod tests {
             ..default_options()
         };
 
-        assert!(should_clean(&Classification::Merged, &options));
+        assert!(should_clean(&Classification::Landed, &options));
         assert!(should_clean(&Classification::Active, &options));
         assert!(should_clean(&Classification::Local, &options));
     }
 
     #[test]
-    fn should_clean_merged_only() {
+    fn should_clean_strict_only_structural() {
         let options = CleanOptions {
-            merged_only: true,
+            strict: true,
             ..default_options()
         };
 
-        assert!(should_clean(&Classification::Merged, &options));
+        assert!(should_clean(&Classification::Landed, &options));
         assert!(!should_clean(
-            &Classification::Landed {
+            &Classification::LandedByContent {
                 matched: 1,
                 total: 1
             },

--- a/crates/git-worktree-tidy/src/cli.rs
+++ b/crates/git-worktree-tidy/src/cli.rs
@@ -63,13 +63,9 @@ pub enum Command {
         #[arg(short = 'y', long)]
         yes: bool,
 
-        /// Only target merged worktrees
+        /// Only target structurally-proven landed worktrees
         #[arg(long)]
-        merged_only: bool,
-
-        /// Target merged and fully landed worktrees (not partial)
-        #[arg(long)]
-        landed: bool,
+        strict: bool,
 
         /// Include active and local worktrees in the interactive clean flow
         #[arg(long)]
@@ -123,7 +119,7 @@ mod tests {
             "--dry-run",
             "--force",
             "--yes",
-            "--merged-only",
+            "--strict",
             "--delete-branches",
         ]);
         match cli.command {
@@ -131,14 +127,14 @@ mod tests {
                 dry_run,
                 force,
                 yes,
-                merged_only,
+                strict,
                 delete_branches,
                 ..
             }) => {
                 assert!(dry_run);
                 assert!(force);
                 assert!(yes);
-                assert!(merged_only);
+                assert!(strict);
                 assert!(delete_branches);
             }
             _ => panic!("expected Clean command"),
@@ -178,17 +174,6 @@ mod tests {
                 assert!(porcelain);
             }
             _ => panic!("expected Scan command"),
-        }
-    }
-
-    #[test]
-    fn clean_landed_flag() {
-        let cli = Cli::parse_from(["git-worktree-tidy", "clean", "--landed"]);
-        match cli.command {
-            Some(Command::Clean { landed, .. }) => {
-                assert!(landed);
-            }
-            _ => panic!("expected Clean command"),
         }
     }
 

--- a/crates/git-worktree-tidy/src/main.rs
+++ b/crates/git-worktree-tidy/src/main.rs
@@ -75,8 +75,7 @@ fn main() {
             dry_run,
             force,
             yes,
-            merged_only,
-            landed,
+            strict,
             all,
             delete_branches,
             ..
@@ -96,8 +95,7 @@ fn main() {
                         dry_run: *dry_run,
                         force: *force,
                         yes: *yes,
-                        merged_only: *merged_only,
-                        landed: *landed,
+                        strict: *strict,
                         all: *all,
                         delete_branches: *delete_branches,
                     };

--- a/crates/git-worktree-tidy/src/output.rs
+++ b/crates/git-worktree-tidy/src/output.rs
@@ -131,7 +131,7 @@ mod tests {
                         parent_repo: PathBuf::from("/repos/Backend"),
                         branch: Some("fix/skip-db-init".to_string()),
                         default_branch: "main".to_string(),
-                        classification: Classification::Merged,
+                        classification: Classification::Landed,
                         annotations: Annotations::default(),
                         remote_tracking: true,
                         ahead: 0,
@@ -156,8 +156,8 @@ mod tests {
             }],
             total_scanned: 2,
             counts: ScanCounts {
-                merged: 1,
-                landed: 0,
+                landed: 1,
+                landed_content: 0,
                 partial: 0,
                 active: 1,
                 local: 0,
@@ -174,13 +174,13 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
 
         assert!(output.contains("Backend (2 worktrees)"));
-        assert!(output.contains("merged"));
+        assert!(output.contains("landed"));
         assert!(output.contains("active"));
         assert!(output.contains("Backend-parallel"));
         assert!(output.contains("Backend-caps"));
         assert!(
             output
-                .contains("2 worktrees scanned: 1 merged, 0 landed, 0 partial, 1 active, 0 local")
+                .contains("2 worktrees scanned: 1 landed, 0 content, 0 partial, 1 active, 0 local")
         );
     }
 
@@ -252,7 +252,7 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
         let arr = parsed.as_array().unwrap();
         assert_eq!(arr.len(), 2);
-        assert_eq!(arr[0]["classification"], "merged");
+        assert_eq!(arr[0]["classification"], "landed");
         assert_eq!(arr[1]["classification"], "active");
     }
 
@@ -268,7 +268,7 @@ mod tests {
 
         let fields: Vec<&str> = lines[0].split('\t').collect();
         assert_eq!(fields.len(), 9);
-        assert_eq!(fields[3], "merged");
+        assert_eq!(fields[3], "landed");
 
         let fields2: Vec<&str> = lines[1].split('\t').collect();
         assert_eq!(fields2[3], "active");


### PR DESCRIPTION
## Summary

- Rename `Classification::Merged` to `Classification::Landed` (structural git ancestor proof)
- Rename `Classification::Landed { matched, total }` to `Classification::LandedByContent { matched, total }` (heuristic content matching)
- Replace `--merged-only` CLI flag with `--strict` (only clean structurally-proven items)
- Remove redundant `--landed` CLI flag from both worktree-tidy and branch-tidy
- Update JSON/porcelain labels: `"merged"` -> `"landed"`, `"landed"` -> `"landed-content"`
- Update human summary format: `"X landed, Y content, Z partial, W active, V local"`

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes (all unit + integration tests)
- [x] `cargo clippy --workspace --all-targets -- -D clippy::all` clean
- [x] Pre-commit `cargo fmt --check` passes

Closes #70