### PR TITLE
Fix zsh sub-tool completion delegation

### DIFF
--- a/crates/git-tidy/src/completions.rs
+++ b/crates/git-tidy/src/completions.rs
@@ -54,16 +54,18 @@ pub fn generate_zsh(out: &mut dyn Write) -> io::Result<()> {
     writeln!(out, "    args)")?;
     writeln!(out, "      case ${{line[1]}} in")?;
 
-    // For each tool spec, map all its aliases to the tool's completer
+    // For each tool spec, map all its aliases to the tool's completer.
+    // Prepend the binary name to words (since '*::arg:->args' already
+    // stripped the alias) so the sub-tool's completion function sees the
+    // expected command context.
     for spec in TOOL_SPECS {
         let patterns: Vec<&str> = spec.aliases.to_vec();
         let pattern = patterns.join("|");
+        let bin = spec.binary;
         writeln!(out, "        {pattern})")?;
-        writeln!(
-            out,
-            "          _dispatch {} {} \"$@\"",
-            spec.binary, spec.binary
-        )?;
+        writeln!(out, "          words=({bin} \"${{words[@]}}\")")?;
+        writeln!(out, "          (( CURRENT++ ))")?;
+        writeln!(out, "          _{bin}")?;
         writeln!(out, "          ;;")?;
     }
 
@@ -167,10 +169,14 @@ mod tests {
     fn output_contains_tool_delegation() {
         let output = generated_output();
         for spec in TOOL_SPECS {
+            let bin = spec.binary;
             assert!(
-                output.contains(spec.binary),
-                "missing delegation for {}",
-                spec.binary
+                output.contains(&format!("_{bin}")),
+                "missing delegation call for {bin}"
+            );
+            assert!(
+                output.contains(&format!("words=({bin}")),
+                "missing words prepend for {bin}"
             );
         }
     }


### PR DESCRIPTION
## Summary

- Replace `_dispatch` with direct `_git-<tool>-tidy` function calls in the zsh dispatcher completion generator
- Prepend the binary name to `words` and bump `CURRENT` so the sub-tool completion function sees the expected command context

This fixes tab completion for sub-tool flags (e.g., `git tidy worktree clean --f<TAB>` now correctly completes to `--force`).

The `'*::arg:->args'` pattern in `_arguments` already strips the alias from `words`, but the sub-tool's clap-generated completion function expects `words[1]` to be the binary name. Without this fix, the function received an unexpected context and couldn't match subcommands or flags.

## Test plan

- [x] `cargo test --workspace` passes
- [ ] `git tidy worktree clean --f<TAB>` completes to `--force`
- [ ] `git tidy worktree <TAB>` lists `scan`, `clean`, `completions`
- [ ] `git tidy <TAB>` lists all aliases + `audit`