### PR TITLE
Add per-phase verbose logging with timing to LFS scan

### DIFF
--- a/crates/git-lfs-tidy/src/scan.rs
+++ b/crates/git-lfs-tidy/src/scan.rs
@@ -63,146 +63,159 @@ pub fn run_scan(
         warnings.push("git-lfs is not installed; skipping LFS-specific checks".to_string());
     }
 
-    let (repos, scan_warnings) = parallel_classify(&repo_paths, |repo_path| {
-        let repo_name = repo_display_name(repo_path);
-        let mut local_warnings = Vec::new();
-        let mut items = Vec::new();
-        let mut lfs_paths: HashSet<String> = HashSet::new();
-        let mut track_patterns = Vec::new();
+    let (repos, scan_warnings) = parallel_classify(
+        &repo_paths,
+        |repo_path| {
+            let repo_name = repo_display_name(repo_path);
+            let mut local_warnings = Vec::new();
+            let mut items = Vec::new();
+            let mut lfs_paths: HashSet<String> = HashSet::new();
+            let mut track_patterns = Vec::new();
 
-        if lfs_installed {
+            if lfs_installed {
+                let t = Instant::now();
+                track_patterns = git.lfs_track_patterns(repo_path).unwrap_or_default();
+
+                match git.lfs_ls_files(repo_path) {
+                    Ok(files) => {
+                        if verbose {
+                            eprintln!(
+                                "{repo_name}: lfs ls-files: {} tracked files ({:.1}s)",
+                                files.len(),
+                                t.elapsed().as_secs_f64(),
+                            );
+                        }
+                        for (oid, status, path) in files {
+                            lfs_paths.insert(path.clone());
+                            let classification = if status == '-' {
+                                LfsClassification::Missing
+                            } else {
+                                LfsClassification::Healthy
+                            };
+                            items.push(LfsInfo {
+                                repo_path: repo_path.to_path_buf(),
+                                path,
+                                classification,
+                                oid,
+                                size_bytes: None,
+                            });
+                        }
+                    }
+                    Err(e) => {
+                        local_warnings.push(format!(
+                            "could not list LFS files for {}: {e}",
+                            repo_path.display()
+                        ));
+                    }
+                }
+
+                let t = Instant::now();
+                match git.lfs_prune_dry_run(repo_path) {
+                    Ok((count, bytes)) if count > 0 => {
+                        if verbose {
+                            eprintln!(
+                                "{repo_name}: lfs prune --dry-run: {count} orphaned objects, {bytes} bytes ({:.1}s)",
+                                t.elapsed().as_secs_f64(),
+                            );
+                        }
+                        items.push(LfsInfo {
+                            repo_path: repo_path.to_path_buf(),
+                            path: format!("<{count} orphaned LFS objects>"),
+                            classification: LfsClassification::Orphaned,
+                            oid: String::new(),
+                            size_bytes: Some(bytes),
+                        });
+                    }
+                    Ok(_) => {
+                        if verbose {
+                            eprintln!(
+                                "{repo_name}: lfs prune --dry-run: nothing to prune ({:.1}s)",
+                                t.elapsed().as_secs_f64(),
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        local_warnings.push(format!(
+                            "could not check prunable LFS objects for {}: {e}",
+                            repo_path.display()
+                        ));
+                    }
+                }
+            }
+
             let t = Instant::now();
-            track_patterns = git.lfs_track_patterns(repo_path).unwrap_or_default();
-
-            match git.lfs_ls_files(repo_path) {
-                Ok(files) => {
+            match git.find_large_blobs(repo_path, size_threshold, depth) {
+                Ok(blobs) => {
+                    let untracked_count = blobs
+                        .iter()
+                        .filter(|(_, _, p)| !lfs_paths.contains(p))
+                        .count();
                     if verbose {
                         eprintln!(
-                            "{repo_name}: lfs ls-files: {} tracked files ({:.1}s)",
-                            files.len(),
+                            "{repo_name}: rev-list + cat-file: {} large blobs, {} untracked ({:.1}s)",
+                            blobs.len(),
+                            untracked_count,
                             t.elapsed().as_secs_f64(),
                         );
                     }
-                    for (oid, status, path) in files {
-                        lfs_paths.insert(path.clone());
-                        let classification = if status == '-' {
-                            LfsClassification::Missing
-                        } else {
-                            LfsClassification::Healthy
-                        };
+                    for (hash, size, path) in blobs {
+                        if lfs_paths.contains(&path) {
+                            continue;
+                        }
                         items.push(LfsInfo {
                             repo_path: repo_path.to_path_buf(),
                             path,
-                            classification,
-                            oid,
-                            size_bytes: None,
+                            classification: LfsClassification::Untracked,
+                            oid: hash,
+                            size_bytes: Some(size),
                         });
                     }
                 }
                 Err(e) => {
                     local_warnings.push(format!(
-                        "could not list LFS files for {}: {e}",
+                        "could not scan large blobs for {}: {e}",
                         repo_path.display()
                     ));
                 }
             }
 
-            let t = Instant::now();
-            match git.lfs_prune_dry_run(repo_path) {
-                Ok((count, bytes)) if count > 0 => {
-                    if verbose {
-                        eprintln!(
-                            "{repo_name}: lfs prune --dry-run: {count} orphaned objects, {bytes} bytes ({:.1}s)",
-                            t.elapsed().as_secs_f64(),
-                        );
-                    }
-                    items.push(LfsInfo {
-                        repo_path: repo_path.to_path_buf(),
-                        path: format!("<{count} orphaned LFS objects>"),
-                        classification: LfsClassification::Orphaned,
-                        oid: String::new(),
-                        size_bytes: Some(bytes),
-                    });
-                }
-                Ok(_) => {
-                    if verbose {
-                        eprintln!(
-                            "{repo_name}: lfs prune --dry-run: nothing to prune ({:.1}s)",
-                            t.elapsed().as_secs_f64(),
-                        );
-                    }
-                }
-                Err(e) => {
-                    local_warnings.push(format!(
-                        "could not check prunable LFS objects for {}: {e}",
-                        repo_path.display()
-                    ));
-                }
-            }
-        }
-
-        let t = Instant::now();
-        match git.find_large_blobs(repo_path, size_threshold, depth) {
-            Ok(blobs) => {
-                let untracked_count = blobs.iter().filter(|(_, _, p)| !lfs_paths.contains(p)).count();
-                if verbose {
+            if verbose && !items.is_empty() {
+                eprintln!("{repo_name}: {} LFS items total", items.len());
+                for item in &items {
                     eprintln!(
-                        "{repo_name}: rev-list + cat-file: {} large blobs, {} untracked ({:.1}s)",
-                        blobs.len(),
-                        untracked_count,
-                        t.elapsed().as_secs_f64(),
+                        "  {}: {} ({})",
+                        item.path,
+                        item.classification.label(),
+                        item.size_bytes
+                            .map_or("?".to_string(), |s| format!("{s} bytes"))
                     );
                 }
-                for (hash, size, path) in blobs {
-                    if lfs_paths.contains(&path) {
-                        continue;
-                    }
-                    items.push(LfsInfo {
-                        repo_path: repo_path.to_path_buf(),
-                        path,
-                        classification: LfsClassification::Untracked,
-                        oid: hash,
-                        size_bytes: Some(size),
-                    });
-                }
             }
-            Err(e) => {
-                local_warnings.push(format!(
-                    "could not scan large blobs for {}: {e}",
-                    repo_path.display()
-                ));
+
+            if items.is_empty() {
+                return (None, local_warnings);
             }
-        }
 
-        if verbose && !items.is_empty() {
-            eprintln!("{repo_name}: {} LFS items total", items.len());
-            for item in &items {
-                eprintln!("  {}: {} ({})", item.path, item.classification.label(),
-                    item.size_bytes.map_or("?".to_string(), |s| format!("{s} bytes")));
-            }
-        }
+            items.sort_by(|a, b| {
+                a.classification
+                    .priority()
+                    .cmp(&b.classification.priority())
+                    .then_with(|| a.path.cmp(&b.path))
+            });
 
-        if items.is_empty() {
-            return (None, local_warnings);
-        }
+            let group = LfsRepoGroup {
+                repo_path: repo_path.to_path_buf(),
+                name: repo_name,
+                items,
+                lfs_available: lfs_installed,
+                track_patterns,
+            };
 
-        items.sort_by(|a, b| {
-            a.classification
-                .priority()
-                .cmp(&b.classification.priority())
-                .then_with(|| a.path.cmp(&b.path))
-        });
-
-        let group = LfsRepoGroup {
-            repo_path: repo_path.to_path_buf(),
-            name: repo_name,
-            items,
-            lfs_available: lfs_installed,
-            track_patterns,
-        };
-
-        (Some(group), local_warnings)
-    }, "Scanning LFS", progress);
+            (Some(group), local_warnings)
+        },
+        "Scanning LFS",
+        progress,
+    );
     warnings.extend(scan_warnings);
 
     let mut counts = LfsCounts::default();


### PR DESCRIPTION
## Summary

- Add per-phase `eprintln!` logging with `Instant` timing to each step of the LFS scan closure (gated behind `-v`)
- Three phases now individually report: `lfs ls-files`, `lfs prune --dry-run`, `rev-list + cat-file`
- Follows the existing verbose logging pattern used by other tools (repo name prefix, `eprintln!` to stderr)

Closes #76

## Test plan

- [x] All 93 `git-lfs-tidy` tests pass (unit + integration)
- [ ] Manual: run `git tidy lfs -v` on a directory with repos and verify per-phase timing lines appear on stderr