### PR TITLE
Add entity --match/--exclude filtering for branch, tag, stash, remote

### DIFF
--- a/crates/git-branch-tidy/src/cli.rs
+++ b/crates/git-branch-tidy/src/cli.rs
@@ -30,6 +30,14 @@ pub struct Cli {
     /// Exclude repos by name substring (takes precedence over --match-repo)
     #[arg(long = "exclude-repo", global = true)]
     pub exclude_repo_patterns: Vec<String>,
+
+    /// Filter branches by name substring (can be repeated, OR semantics)
+    #[arg(long = "match", global = true)]
+    pub match_patterns: Vec<String>,
+
+    /// Exclude branches by name substring (takes precedence over --match)
+    #[arg(long = "exclude", global = true)]
+    pub exclude_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -196,6 +204,20 @@ mod tests {
                 git_tidy_core::cli::SharedCommands::Completions { .. }
             ))
         ));
+    }
+
+    #[test]
+    fn match_and_exclude_flags() {
+        let cli = Cli::parse_from([
+            "git-branch-tidy",
+            "--match",
+            "feature",
+            "--exclude",
+            "wip",
+            "scan",
+        ]);
+        assert_eq!(cli.match_patterns, vec!["feature".to_string()]);
+        assert_eq!(cli.exclude_patterns, vec!["wip".to_string()]);
     }
 
     #[test]

--- a/crates/git-branch-tidy/src/main.rs
+++ b/crates/git-branch-tidy/src/main.rs
@@ -32,6 +32,7 @@ fn main() {
     let git = gix_ops::GixGitOps;
     let progress = Progress::new();
     let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let entity_filter = NameFilter::new(&cli.match_patterns, &cli.exclude_patterns);
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -49,6 +50,7 @@ fn main() {
                 cli.behind_threshold,
                 cli.verbose,
                 &repo_filter,
+                &entity_filter,
                 &progress,
             ) {
                 Ok(result) => {
@@ -81,6 +83,7 @@ fn main() {
                 cli.behind_threshold,
                 cli.verbose,
                 &repo_filter,
+                &entity_filter,
                 &progress,
             ) {
                 Ok(scan_result) => {

--- a/crates/git-branch-tidy/src/scan.rs
+++ b/crates/git-branch-tidy/src/scan.rs
@@ -19,6 +19,7 @@ pub fn run_scan(
     behind_threshold: usize,
     verbose: bool,
     repo_filter: &NameFilter,
+    entity_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<BranchScanResult, Error> {
     let repo_paths = discovery::discover_repos(directory)?;
@@ -68,6 +69,10 @@ pub fn run_scan(
 
             for branch_name in &branches {
                 if branch_name == &default_branch {
+                    continue;
+                }
+
+                if !entity_filter.matches(branch_name) {
                     continue;
                 }
 

--- a/crates/git-branch-tidy/tests/integration_clean.rs
+++ b/crates/git-branch-tidy/tests/integration_clean.rs
@@ -51,6 +51,7 @@ fn clean_deletes_merged_branch_in_real_repo() {
         100,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -89,6 +90,7 @@ fn clean_dry_run_does_not_delete() {
         &scan_dir,
         100,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
@@ -136,6 +138,7 @@ fn clean_safe_refuses_unmerged_branch() {
         &scan_dir,
         100,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-branch-tidy/tests/integration_scan.rs
+++ b/crates/git-branch-tidy/tests/integration_scan.rs
@@ -62,6 +62,7 @@ fn scan_real_repo_with_mixed_branches() {
         100,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -118,6 +119,7 @@ fn scan_marks_current_branch_in_real_repo() {
         100,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -126,6 +128,80 @@ fn scan_marks_current_branch_in_real_repo() {
     let branch = &result.repos[0].branches[0];
     assert_eq!(branch.name, "my-feature");
     assert!(branch.is_current);
+}
+
+#[test]
+fn scan_entity_filter_includes_matching_branches() {
+    let (dir, repo) = set_up_repo_with_remote();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Create several branches
+    git(&repo, &["branch", "feature/login"]);
+    git(&repo, &["branch", "feature/signup"]);
+    git(&repo, &["branch", "bugfix/crash"]);
+
+    // Filter to only feature branches
+    let entity_filter = git_tidy_core::filter::NameFilter::new(&["feature".to_string()], &[]);
+
+    let result = git_branch_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        100,
+        false,
+        &git_tidy_core::filter::NameFilter::default(),
+        &entity_filter,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+    let names: Vec<&str> = result.repos[0]
+        .branches
+        .iter()
+        .map(|b| b.name.as_str())
+        .collect();
+    assert!(names.contains(&"feature/login"));
+    assert!(names.contains(&"feature/signup"));
+    assert!(!names.contains(&"bugfix/crash"));
+    assert_eq!(result.total_scanned, 2);
+}
+
+#[test]
+fn scan_entity_filter_exclude_takes_precedence() {
+    let (dir, repo) = set_up_repo_with_remote();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    git(&repo, &["branch", "feature/login"]);
+    git(&repo, &["branch", "feature/login-wip"]);
+    git(&repo, &["branch", "bugfix/crash"]);
+
+    // Include "feature" but exclude "wip"
+    let entity_filter =
+        git_tidy_core::filter::NameFilter::new(&["feature".to_string()], &["wip".to_string()]);
+
+    let result = git_branch_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        100,
+        false,
+        &git_tidy_core::filter::NameFilter::default(),
+        &entity_filter,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+    let names: Vec<&str> = result.repos[0]
+        .branches
+        .iter()
+        .map(|b| b.name.as_str())
+        .collect();
+    assert!(names.contains(&"feature/login"));
+    assert!(!names.contains(&"feature/login-wip"));
+    assert!(!names.contains(&"bugfix/crash"));
+    assert_eq!(result.total_scanned, 1);
 }
 
 #[test]
@@ -149,6 +225,7 @@ fn scan_skips_repo_without_default_branch() {
         &base,
         100,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-remote-tidy/src/cli.rs
+++ b/crates/git-remote-tidy/src/cli.rs
@@ -30,6 +30,14 @@ pub struct Cli {
     /// Exclude repos by name substring (takes precedence over --match-repo)
     #[arg(long = "exclude-repo", global = true)]
     pub exclude_repo_patterns: Vec<String>,
+
+    /// Filter remotes by name substring (can be repeated, OR semantics)
+    #[arg(long = "match", global = true)]
+    pub match_patterns: Vec<String>,
+
+    /// Exclude remotes by name substring (takes precedence over --match)
+    #[arg(long = "exclude", global = true)]
+    pub exclude_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -169,6 +177,20 @@ mod tests {
                 git_tidy_core::cli::SharedCommands::Completions { .. }
             ))
         ));
+    }
+
+    #[test]
+    fn match_and_exclude_flags() {
+        let cli = Cli::parse_from([
+            "git-remote-tidy",
+            "--match",
+            "upstream",
+            "--exclude",
+            "stale",
+            "scan",
+        ]);
+        assert_eq!(cli.match_patterns, vec!["upstream".to_string()]);
+        assert_eq!(cli.exclude_patterns, vec!["stale".to_string()]);
     }
 
     #[test]

--- a/crates/git-remote-tidy/src/main.rs
+++ b/crates/git-remote-tidy/src/main.rs
@@ -31,6 +31,7 @@ fn main() {
     let git = gix_ops::GixGitOps;
     let progress = Progress::new();
     let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let entity_filter = NameFilter::new(&cli.match_patterns, &cli.exclude_patterns);
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -48,6 +49,7 @@ fn main() {
                 cli.offline,
                 cli.verbose,
                 &repo_filter,
+                &entity_filter,
                 &progress,
             ) {
                 Ok(result) => {
@@ -76,6 +78,7 @@ fn main() {
             cli.offline,
             cli.verbose,
             &repo_filter,
+            &entity_filter,
             &progress,
         ) {
             Ok(scan_result) => {

--- a/crates/git-remote-tidy/src/scan.rs
+++ b/crates/git-remote-tidy/src/scan.rs
@@ -47,6 +47,7 @@ pub fn run_scan(
     offline: bool,
     verbose: bool,
     repo_filter: &NameFilter,
+    entity_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<RemoteScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
@@ -113,6 +114,10 @@ pub fn run_scan(
             let mut classified = Vec::new();
 
             for (idx, remote_name) in all_remote_names.iter().enumerate() {
+                if !entity_filter.matches(remote_name) {
+                    continue;
+                }
+
                 let is_configured = idx < configured_count;
                 let classification =
                     classify_remote(git, repo_path, remote_name, is_configured, offline);

--- a/crates/git-remote-tidy/tests/integration_clean.rs
+++ b/crates/git-remote-tidy/tests/integration_clean.rs
@@ -47,6 +47,7 @@ fn clean_removes_remote_in_real_repo() {
         false,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -85,6 +86,7 @@ fn clean_dry_run_does_not_remove() {
         &scan_dir,
         false,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
@@ -143,6 +145,7 @@ fn clean_prunes_orphaned_refs() {
         &scan_dir,
         false,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-remote-tidy/tests/integration_scan.rs
+++ b/crates/git-remote-tidy/tests/integration_scan.rs
@@ -45,6 +45,7 @@ fn scan_real_repo_with_reachable_remote() {
         false,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -77,6 +78,7 @@ fn scan_repo_with_unreachable_remote() {
         false,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -108,6 +110,7 @@ fn scan_repo_with_orphaned_refs() {
         false,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -127,6 +130,92 @@ fn scan_repo_with_orphaned_refs() {
 }
 
 #[test]
+fn scan_entity_filter_includes_matching_remotes() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Add multiple remotes (all offline/unreachable for simplicity)
+    git(
+        &repo,
+        &["remote", "add", "origin", "/nonexistent/origin.git"],
+    );
+    git(
+        &repo,
+        &["remote", "add", "upstream", "/nonexistent/upstream.git"],
+    );
+    git(&repo, &["remote", "add", "fork", "/nonexistent/fork.git"]);
+
+    // Filter to only "origin"
+    let entity_filter = git_tidy_core::filter::NameFilter::new(&["origin".to_string()], &[]);
+
+    let result = git_remote_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        true, // offline to avoid network
+        false,
+        &git_tidy_core::filter::NameFilter::default(),
+        &entity_filter,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+    let names: Vec<&str> = result.repos[0]
+        .remotes
+        .iter()
+        .map(|r| r.name.as_str())
+        .collect();
+    assert!(names.contains(&"origin"));
+    assert!(!names.contains(&"upstream"));
+    assert!(!names.contains(&"fork"));
+    assert_eq!(result.total_scanned, 1);
+}
+
+#[test]
+fn scan_entity_filter_exclude_takes_precedence() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    git(
+        &repo,
+        &["remote", "add", "origin", "/nonexistent/origin.git"],
+    );
+    git(
+        &repo,
+        &["remote", "add", "origin-backup", "/nonexistent/backup.git"],
+    );
+    git(&repo, &["remote", "add", "fork", "/nonexistent/fork.git"]);
+
+    // Include "origin" but exclude "backup"
+    let entity_filter =
+        git_tidy_core::filter::NameFilter::new(&["origin".to_string()], &["backup".to_string()]);
+
+    let result = git_remote_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        true,
+        false,
+        &git_tidy_core::filter::NameFilter::default(),
+        &entity_filter,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+    let names: Vec<&str> = result.repos[0]
+        .remotes
+        .iter()
+        .map(|r| r.name.as_str())
+        .collect();
+    assert!(names.contains(&"origin"));
+    assert!(!names.contains(&"origin-backup"));
+    assert!(!names.contains(&"fork"));
+    assert_eq!(result.total_scanned, 1);
+}
+
+#[test]
 fn scan_empty_repo_no_remotes() {
     let (dir, _repo) = set_up_repo();
     let scan_dir = dir.path().canonicalize().unwrap().join("projects");
@@ -137,6 +226,7 @@ fn scan_empty_repo_no_remotes() {
         &scan_dir,
         false,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
@@ -164,6 +254,7 @@ fn scan_offline_mode() {
         &scan_dir,
         true,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-stash-tidy/src/cli.rs
+++ b/crates/git-stash-tidy/src/cli.rs
@@ -30,6 +30,14 @@ pub struct Cli {
     /// Exclude repos by name substring (takes precedence over --match-repo)
     #[arg(long = "exclude-repo", global = true)]
     pub exclude_repo_patterns: Vec<String>,
+
+    /// Filter stashes by branch name substring (can be repeated, OR semantics)
+    #[arg(long = "match", global = true)]
+    pub match_patterns: Vec<String>,
+
+    /// Exclude stashes by branch name substring (takes precedence over --match)
+    #[arg(long = "exclude", global = true)]
+    pub exclude_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -197,6 +205,20 @@ mod tests {
                 git_tidy_core::cli::SharedCommands::Completions { .. }
             ))
         ));
+    }
+
+    #[test]
+    fn match_and_exclude_flags() {
+        let cli = Cli::parse_from([
+            "git-stash-tidy",
+            "--match",
+            "feature",
+            "--exclude",
+            "wip",
+            "scan",
+        ]);
+        assert_eq!(cli.match_patterns, vec!["feature".to_string()]);
+        assert_eq!(cli.exclude_patterns, vec!["wip".to_string()]);
     }
 
     #[test]

--- a/crates/git-stash-tidy/src/main.rs
+++ b/crates/git-stash-tidy/src/main.rs
@@ -31,6 +31,7 @@ fn main() {
     let git = gix_ops::GixGitOps;
     let progress = Progress::new();
     let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let entity_filter = NameFilter::new(&cli.match_patterns, &cli.exclude_patterns);
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -48,6 +49,7 @@ fn main() {
                 cli.age_threshold,
                 cli.verbose,
                 &repo_filter,
+                &entity_filter,
                 &progress,
             ) {
                 Ok(result) => {
@@ -77,6 +79,7 @@ fn main() {
             cli.age_threshold,
             cli.verbose,
             &repo_filter,
+            &entity_filter,
             &progress,
         ) {
             Ok(scan_result) => {

--- a/crates/git-stash-tidy/src/scan.rs
+++ b/crates/git-stash-tidy/src/scan.rs
@@ -73,6 +73,7 @@ pub fn run_scan(
     age_threshold: u64,
     verbose: bool,
     repo_filter: &NameFilter,
+    entity_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<StashScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
@@ -110,6 +111,11 @@ pub fn run_scan(
             let mut classified = Vec::with_capacity(stashes.len());
 
             for (stash_ref, message, iso_date) in &stashes {
+                let filter_name = parse_stash_branch(message);
+                if !entity_filter.matches(filter_name.as_deref().unwrap_or(message)) {
+                    continue;
+                }
+
                 let (classification, age_days, branch) = classify_stash(
                     git,
                     repo_path,

--- a/crates/git-stash-tidy/tests/integration_clean.rs
+++ b/crates/git-stash-tidy/tests/integration_clean.rs
@@ -49,6 +49,7 @@ fn clean_drops_stash_in_real_repo() {
         90,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -91,6 +92,7 @@ fn clean_dry_run_does_not_drop() {
         &scan_dir,
         90,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-stash-tidy/tests/integration_scan.rs
+++ b/crates/git-stash-tidy/tests/integration_scan.rs
@@ -43,6 +43,7 @@ fn scan_real_repo_with_stashes() {
         90,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -78,6 +79,7 @@ fn scan_repo_with_orphaned_stash() {
         90,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -91,6 +93,91 @@ fn scan_repo_with_orphaned_stash() {
 }
 
 #[test]
+fn scan_entity_filter_includes_matching_stashes() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Create stashes on different branches
+    git(&repo, &["checkout", "-b", "feature-alpha"]);
+    std::fs::write(repo.join("alpha.txt"), "alpha content").unwrap();
+    git(&repo, &["add", "alpha.txt"]);
+    git(&repo, &["stash"]);
+
+    git(&repo, &["checkout", "main"]);
+    git(&repo, &["checkout", "-b", "bugfix-beta"]);
+    std::fs::write(repo.join("beta.txt"), "beta content").unwrap();
+    git(&repo, &["add", "beta.txt"]);
+    git(&repo, &["stash"]);
+
+    git(&repo, &["checkout", "main"]);
+
+    // Filter to only stashes on branches matching "feature"
+    let entity_filter = git_tidy_core::filter::NameFilter::new(&["feature".to_string()], &[]);
+
+    let result = git_stash_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        90,
+        false,
+        &git_tidy_core::filter::NameFilter::default(),
+        &entity_filter,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+    assert_eq!(result.total_scanned, 1);
+    assert_eq!(
+        result.repos[0].stashes[0].branch.as_deref(),
+        Some("feature-alpha")
+    );
+}
+
+#[test]
+fn scan_entity_filter_exclude_takes_precedence() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Create stashes on different branches
+    git(&repo, &["checkout", "-b", "feature-login"]);
+    std::fs::write(repo.join("login.txt"), "login content").unwrap();
+    git(&repo, &["add", "login.txt"]);
+    git(&repo, &["stash"]);
+
+    git(&repo, &["checkout", "main"]);
+    git(&repo, &["checkout", "-b", "feature-wip"]);
+    std::fs::write(repo.join("wip.txt"), "wip content").unwrap();
+    git(&repo, &["add", "wip.txt"]);
+    git(&repo, &["stash"]);
+
+    git(&repo, &["checkout", "main"]);
+
+    // Include "feature" but exclude "wip"
+    let entity_filter =
+        git_tidy_core::filter::NameFilter::new(&["feature".to_string()], &["wip".to_string()]);
+
+    let result = git_stash_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        90,
+        false,
+        &git_tidy_core::filter::NameFilter::default(),
+        &entity_filter,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+    assert_eq!(result.total_scanned, 1);
+    assert_eq!(
+        result.repos[0].stashes[0].branch.as_deref(),
+        Some("feature-login")
+    );
+}
+
+#[test]
 fn scan_empty_repo_no_stashes() {
     let (dir, _repo) = set_up_repo();
     let scan_dir = dir.path().canonicalize().unwrap().join("projects");
@@ -101,6 +188,7 @@ fn scan_empty_repo_no_stashes() {
         &scan_dir,
         90,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-tag-tidy/src/cli.rs
+++ b/crates/git-tag-tidy/src/cli.rs
@@ -30,6 +30,14 @@ pub struct Cli {
     /// Exclude repos by name substring (takes precedence over --match-repo)
     #[arg(long = "exclude-repo", global = true)]
     pub exclude_repo_patterns: Vec<String>,
+
+    /// Filter tags by name substring (can be repeated, OR semantics)
+    #[arg(long = "match", global = true)]
+    pub match_patterns: Vec<String>,
+
+    /// Exclude tags by name substring (takes precedence over --match)
+    #[arg(long = "exclude", global = true)]
+    pub exclude_patterns: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -214,6 +222,13 @@ mod tests {
                 git_tidy_core::cli::SharedCommands::Completions { .. }
             ))
         ));
+    }
+
+    #[test]
+    fn match_and_exclude_flags() {
+        let cli = Cli::parse_from(["git-tag-tidy", "--match", "v1", "--exclude", "rc", "scan"]);
+        assert_eq!(cli.match_patterns, vec!["v1".to_string()]);
+        assert_eq!(cli.exclude_patterns, vec!["rc".to_string()]);
     }
 
     #[test]

--- a/crates/git-tag-tidy/src/main.rs
+++ b/crates/git-tag-tidy/src/main.rs
@@ -31,6 +31,7 @@ fn main() {
     let git = gix_ops::GixGitOps;
     let progress = Progress::new();
     let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let entity_filter = NameFilter::new(&cli.match_patterns, &cli.exclude_patterns);
     let mut stdout = io::stdout().lock();
 
     match &cli.command {
@@ -48,6 +49,7 @@ fn main() {
                 cli.offline,
                 cli.verbose,
                 &repo_filter,
+                &entity_filter,
                 &progress,
             ) {
                 Ok(result) => {
@@ -79,6 +81,7 @@ fn main() {
             cli.offline,
             cli.verbose,
             &repo_filter,
+            &entity_filter,
             &progress,
         ) {
             Ok(scan_result) => {

--- a/crates/git-tag-tidy/src/scan.rs
+++ b/crates/git-tag-tidy/src/scan.rs
@@ -43,6 +43,7 @@ pub fn run_scan(
     offline: bool,
     verbose: bool,
     repo_filter: &NameFilter,
+    entity_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<TagScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
@@ -115,6 +116,10 @@ pub fn run_scan(
             let mut classified = Vec::with_capacity(all_tag_names.len());
 
             for tag_name in &all_tag_names {
+                if !entity_filter.matches(tag_name) {
+                    continue;
+                }
+
                 let is_local = local_tags.contains(tag_name);
 
                 let (local_commit, is_reachable, is_annotated, tagger_date) = if is_local {

--- a/crates/git-tag-tidy/tests/integration_clean.rs
+++ b/crates/git-tag-tidy/tests/integration_clean.rs
@@ -51,6 +51,7 @@ fn clean_removes_local_only_tag() {
         false,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -96,6 +97,7 @@ fn clean_dry_run_preserves_tags() {
         &scan_dir,
         false,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
@@ -152,6 +154,7 @@ fn clean_removes_stale_tag() {
         true,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -206,6 +209,7 @@ fn clean_include_remote_deletes_from_remote() {
         &scan_dir,
         false,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-tag-tidy/tests/integration_scan.rs
+++ b/crates/git-tag-tidy/tests/integration_scan.rs
@@ -49,6 +49,7 @@ fn scan_synced_tag() {
         false,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -89,6 +90,7 @@ fn scan_local_only_tag() {
         false,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -126,6 +128,7 @@ fn scan_stale_tag() {
         true,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -156,6 +159,7 @@ fn scan_annotated_tag() {
         true,
         false,
         &git_tidy_core::filter::NameFilter::default(),
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -174,6 +178,80 @@ fn scan_annotated_tag() {
 }
 
 #[test]
+fn scan_entity_filter_includes_matching_tags() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    // Create multiple tags
+    git(&repo, &["tag", "v1.0.0"]);
+    git(&repo, &["tag", "v2.0.0"]);
+    git(&repo, &["tag", "experiment-alpha"]);
+
+    // Filter to only v1 tags
+    let entity_filter = git_tidy_core::filter::NameFilter::new(&["v1".to_string()], &[]);
+
+    let result = git_tag_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        true,
+        false,
+        &git_tidy_core::filter::NameFilter::default(),
+        &entity_filter,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+    let names: Vec<&str> = result.repos[0]
+        .tags
+        .iter()
+        .map(|t| t.name.as_str())
+        .collect();
+    assert!(names.contains(&"v1.0.0"));
+    assert!(!names.contains(&"v2.0.0"));
+    assert!(!names.contains(&"experiment-alpha"));
+    assert_eq!(result.total_scanned, 1);
+}
+
+#[test]
+fn scan_entity_filter_exclude_takes_precedence() {
+    let (dir, repo) = set_up_repo();
+    let scan_dir = dir.path().canonicalize().unwrap().join("projects");
+    let git_ops = RealGit;
+
+    git(&repo, &["tag", "v1.0.0"]);
+    git(&repo, &["tag", "v1.0.0-rc1"]);
+    git(&repo, &["tag", "experiment"]);
+
+    // Include "v1" but exclude "rc"
+    let entity_filter =
+        git_tidy_core::filter::NameFilter::new(&["v1".to_string()], &["rc".to_string()]);
+
+    let result = git_tag_tidy::scan::run_scan(
+        &git_ops,
+        &scan_dir,
+        true,
+        false,
+        &git_tidy_core::filter::NameFilter::default(),
+        &entity_filter,
+        &git_tidy_core::progress::Progress::disabled(),
+    )
+    .unwrap();
+
+    assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
+    let names: Vec<&str> = result.repos[0]
+        .tags
+        .iter()
+        .map(|t| t.name.as_str())
+        .collect();
+    assert!(names.contains(&"v1.0.0"));
+    assert!(!names.contains(&"v1.0.0-rc1"));
+    assert!(!names.contains(&"experiment"));
+    assert_eq!(result.total_scanned, 1);
+}
+
+#[test]
 fn scan_empty_repo_no_tags() {
     let (dir, _repo) = set_up_repo();
     let scan_dir = dir.path().canonicalize().unwrap().join("projects");
@@ -184,6 +262,7 @@ fn scan_empty_repo_no_tags() {
         &scan_dir,
         true,
         false,
+        &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::progress::Progress::disabled(),
     )

--- a/crates/git-tidy/src/inprocess.rs
+++ b/crates/git-tidy/src/inprocess.rs
@@ -174,6 +174,7 @@ fn run_tool_scan(
                 DEFAULT_BEHIND_THRESHOLD,
                 verbose,
                 &filter,
+                &filter,
                 progress,
             ),
             spec,
@@ -194,6 +195,7 @@ fn run_tool_scan(
                 DEFAULT_AGE_THRESHOLD,
                 verbose,
                 &filter,
+                &filter,
                 progress,
             ),
             spec,
@@ -207,7 +209,9 @@ fn run_tool_scan(
             },
         ),
         "git-remote-tidy" => scan_to_result(
-            git_remote_tidy::scan::run_scan(git, directory, false, verbose, &filter, progress),
+            git_remote_tidy::scan::run_scan(
+                git, directory, false, verbose, &filter, &filter, progress,
+            ),
             spec,
             |r| {
                 vec![
@@ -218,7 +222,9 @@ fn run_tool_scan(
             },
         ),
         "git-tag-tidy" => scan_to_result(
-            git_tag_tidy::scan::run_scan(git, directory, false, verbose, &filter, progress),
+            git_tag_tidy::scan::run_scan(
+                git, directory, false, verbose, &filter, &filter, progress,
+            ),
             spec,
             |r| {
                 vec![


### PR DESCRIPTION
## Summary

- Extend entity-level `--match`/`--exclude` filtering to branch-tidy, tag-tidy, stash-tidy, and remote-tidy (worktree-tidy already had this)
- Skip classification for non-matching entities, avoiding unnecessary git operations
- Each tool filters on its natural entity name (branch names, tag names, stash branch, remote names)
- Audit runner passes default (no-op) entity filter

Closes #80

## Test plan

- [x] 4 CLI parsing tests verify `--match`/`--exclude` args parse correctly
- [x] 8 new integration tests (2 per tool) with real git repos verify include filtering and exclude-takes-precedence behavior
- [x] All existing integration tests updated for the new parameter and still pass
- [x] `cargo build --workspace` and `cargo test --workspace` pass with 0 failures