### PR TITLE
Add 'git tidy explain' subcommand and hint footer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ This is a Cargo workspace with a shared core library and seven binary crates.
 
 - **`GitOps` trait** (`git-tidy-core/src/git.rs`): All git operations go through this trait (`Send + Sync` for thread safety). `RealGit` shells out to `git`; `MockGit` (in `testutil.rs`) returns canned data. `MockGit` uses `Mutex` for call-tracking fields.
 - **Output to `&mut dyn Write`**: Enables unit testing output formatters without process capture.
-- **Shared output helpers** (`git-tidy-core/src/output.rs`): `write_summary_line`, `write_warnings`, `format_ahead_behind`, `format_annotations`, `format_landed_ratio`, `repo_display_name`, `write_json_pretty`. All tools call these to avoid duplicating formatting logic.
+- **Shared output helpers** (`git-tidy-core/src/output.rs`): `write_summary_line`, `write_warnings`, `write_explain_hint`, `format_ahead_behind`, `format_annotations`, `format_landed_ratio`, `repo_display_name`, `write_json_pretty`. All tools call these to avoid duplicating formatting logic.
 - **Shared CLI utilities** (`git-tidy-core/src/cli.rs`): `resolve_directory` for resolving optional directory arguments, `SharedCommands` enum (hidden `completions` subcommand flattened into all tools via `#[command(flatten)]`), used by all tools.
 - **Shared error handling** (`git-tidy-core/src/error.rs`): `exit_with_error` for consistent error-exit behavior across all tools.
 - **Shared type helpers** (`git-tidy-core/src/types.rs`): `extract_landed_fields` for extracting landed ratio/total/unmatched from `Classification` for JSON serialization.
@@ -57,7 +57,7 @@ All tools follow a similar CLI shape:
 - Tag-tidy global arg: `--offline` instead of `--behind-threshold`/`--verbose`
 - Repo-tidy global args: `--stale-months` (default 6), `--offline`
 - Tool-specific flags: worktree-tidy has `--delete-branches`, branch-tidy has `--include-remote`/`--force`, remote-tidy has `--force` (allow removing origin)/`--all` (include orphaned), tag-tidy has `--stale-only`/`--local-only`/`--include-remote`/`--force` (bypass release protection)/`--all`, repo-tidy has `--force` (allow deleting dirty repos)/`--stale-only`/`--orphaned-only`/`--all`, lfs-tidy has `--prune` (enable orphaned LFS object removal)
-- git-tidy (audit runner + dispatch): Pre-clap alias dispatch in `main.rs` checks `args[1]` against `ToolSpec::aliases` and execs the binary. Falls through to `Audit` subcommand (default) with `--json`/`--porcelain`/`--verbose`/`--tools`/`--subprocess`. Default mode calls tool scan/lint functions in-process with `CachingGitOps`; `--subprocess` shells out via `ToolRunner` trait.
+- git-tidy (audit runner + dispatch): Pre-clap alias dispatch in `main.rs` checks `args[1]` against `ToolSpec::aliases` and execs the binary. Falls through to `Audit` subcommand (default) with `--json`/`--porcelain`/`--verbose`/`--tools`/`--subprocess`. `Explain` subcommand prints a terminology glossary. Default mode calls tool scan/lint functions in-process with `CachingGitOps`; `--subprocess` shells out via `ToolRunner` trait.
 - Config-tidy uses **lint/fix** subcommands instead of scan/clean (config issues are "lint findings")
 - LFS-tidy scan args: `--size-threshold` (default "1MB"), `--depth` (default 1000)
 
@@ -82,9 +82,10 @@ crates/
     src/
       main.rs                                 # Pre-clap dispatch, then CLI audit
       lib.rs                                  # Public module exports
-      cli.rs                                  # clap definitions (Audit subcommand, after_help aliases)
+      cli.rs                                  # clap definitions (Audit, Explain subcommands, after_help aliases)
       completions.rs                          # Custom zsh dispatcher completion generator
       dispatch.rs                             # Alias resolution + Unix exec dispatch
+      explain.rs                              # Terminology glossary (GlossaryEntry, write_full, write_term)
       types.rs                                # ToolSpec (with aliases), TOOL_SPECS, ToolResult, AuditResult
       runner.rs                               # ToolRunner trait, RealToolRunner, run_audit (subprocess mode)
       inprocess.rs                            # In-process audit: calls tool scan/lint with CachingGitOps

--- a/crates/git-branch-tidy/src/output.rs
+++ b/crates/git-branch-tidy/src/output.rs
@@ -29,6 +29,7 @@ pub fn write_human(out: &mut dyn Write, result: &BranchScanResult) -> std::io::R
     }
 
     shared::write_summary_line(out, result.total_scanned, &result.counts, "branches")?;
+    shared::write_explain_hint(out)?;
 
     Ok(())
 }

--- a/crates/git-config-tidy/src/output.rs
+++ b/crates/git-config-tidy/src/output.rs
@@ -30,6 +30,7 @@ pub fn write_human(out: &mut dyn Write, result: &ConfigLintResult) -> std::io::R
     }
 
     write_lint_summary(out, result)?;
+    shared::write_explain_hint(out)?;
 
     Ok(())
 }

--- a/crates/git-lfs-tidy/src/output.rs
+++ b/crates/git-lfs-tidy/src/output.rs
@@ -70,6 +70,7 @@ pub fn write_human(out: &mut dyn Write, result: &LfsScanResult) -> std::io::Resu
     }
 
     write_lfs_summary(out, result)?;
+    shared::write_explain_hint(out)?;
 
     Ok(())
 }

--- a/crates/git-remote-tidy/src/output.rs
+++ b/crates/git-remote-tidy/src/output.rs
@@ -36,6 +36,7 @@ pub fn write_human(out: &mut dyn Write, result: &RemoteScanResult) -> std::io::R
     }
 
     write_remote_summary(out, result)?;
+    shared::write_explain_hint(out)?;
 
     Ok(())
 }

--- a/crates/git-repo-tidy/src/output.rs
+++ b/crates/git-repo-tidy/src/output.rs
@@ -36,6 +36,7 @@ pub fn write_human(out: &mut dyn Write, result: &RepoScanResult) -> std::io::Res
     }
 
     write_summary(out, result)?;
+    shared::write_explain_hint(out)?;
 
     Ok(())
 }

--- a/crates/git-stash-tidy/src/output.rs
+++ b/crates/git-stash-tidy/src/output.rs
@@ -30,6 +30,7 @@ pub fn write_human(out: &mut dyn Write, result: &StashScanResult) -> std::io::Re
     }
 
     write_stash_summary(out, result)?;
+    shared::write_explain_hint(out)?;
 
     Ok(())
 }

--- a/crates/git-tag-tidy/src/output.rs
+++ b/crates/git-tag-tidy/src/output.rs
@@ -36,6 +36,7 @@ pub fn write_human(out: &mut dyn Write, result: &TagScanResult) -> std::io::Resu
     }
 
     write_tag_summary(out, result)?;
+    shared::write_explain_hint(out)?;
 
     Ok(())
 }

--- a/crates/git-tidy-core/src/output.rs
+++ b/crates/git-tidy-core/src/output.rs
@@ -72,6 +72,11 @@ pub fn write_json_pretty(out: &mut dyn Write, value: &impl Serialize) -> std::io
     writeln!(out, "{json}")
 }
 
+/// Write a hint pointing users to `git tidy explain` for terminology.
+pub fn write_explain_hint(out: &mut dyn Write) -> std::io::Result<()> {
+    writeln!(out, "hint: run 'git tidy explain' for a glossary of terms")
+}
+
 /// Format the landed ratio for display. Returns empty string for non-landed classifications.
 pub fn format_landed_ratio(classification: &Classification) -> String {
     match classification {
@@ -207,5 +212,16 @@ mod tests {
         let path = PathBuf::from("/");
         // Root path has no file_name, should fall back to display
         assert_eq!(repo_display_name(&path), "/");
+    }
+
+    #[test]
+    fn explain_hint_output() {
+        let mut buf = Vec::new();
+        write_explain_hint(&mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert_eq!(
+            output,
+            "hint: run 'git tidy explain' for a glossary of terms\n"
+        );
     }
 }

--- a/crates/git-tidy/src/cli.rs
+++ b/crates/git-tidy/src/cli.rs
@@ -17,12 +17,16 @@ Tool commands (dispatch to individual tools):
   config       git-config-tidy
   lfs          git-lfs-tidy
 
+Other commands:
+  explain      Show terminology glossary
+
 Singular forms also accepted (worktree, branch, stash, etc.).
 
 Examples:
   git tidy worktrees scan --json ~/Developer
   git tidy branches clean --yes
-  git tidy config lint"
+  git tidy config lint
+  git tidy explain partial"
 )]
 pub struct Cli {
     /// Directory to scan (default: current directory)
@@ -37,6 +41,12 @@ pub struct Cli {
 pub enum Command {
     #[command(flatten)]
     Shared(git_tidy_core::cli::SharedCommands),
+
+    /// Explain git-tidy terminology and classifications
+    Explain {
+        /// Look up a specific term (shows full glossary if omitted)
+        term: Option<String>,
+    },
 
     /// Run audit across all installed git-tidy tools (default)
     Audit {
@@ -145,6 +155,21 @@ mod tests {
                 assert_eq!(tools, vec!["branch", "tag"]);
             }
             _ => panic!("expected Audit command"),
+        }
+    }
+
+    #[test]
+    fn explain_subcommand_no_term() {
+        let cli = Cli::parse_from(["git-tidy", "explain"]);
+        assert!(matches!(cli.command, Some(Command::Explain { term: None })));
+    }
+
+    #[test]
+    fn explain_subcommand_with_term() {
+        let cli = Cli::parse_from(["git-tidy", "explain", "partial"]);
+        match cli.command {
+            Some(Command::Explain { term: Some(t) }) => assert_eq!(t, "partial"),
+            _ => panic!("expected Explain command with term"),
         }
     }
 

--- a/crates/git-tidy/src/completions.rs
+++ b/crates/git-tidy/src/completions.rs
@@ -27,6 +27,7 @@ pub fn generate_zsh(out: &mut dyn Write) -> io::Result<()> {
         }
     }
     aliases.push("audit");
+    aliases.push("explain");
 
     // Introspect audit flags from clap
     let audit_flags = introspect_audit_flags();
@@ -68,6 +69,10 @@ pub fn generate_zsh(out: &mut dyn Write) -> io::Result<()> {
         writeln!(out, "          _{bin}")?;
         writeln!(out, "          ;;")?;
     }
+
+    // explain subcommand (no flags, just pass-through)
+    writeln!(out, "        explain)")?;
+    writeln!(out, "          ;;")?;
 
     // audit subcommand
     writeln!(out, "        audit)")?;
@@ -147,6 +152,12 @@ mod tests {
     fn output_contains_audit() {
         let output = generated_output();
         assert!(output.contains("'audit'"));
+    }
+
+    #[test]
+    fn output_contains_explain() {
+        let output = generated_output();
+        assert!(output.contains("'explain'"));
     }
 
     #[test]

--- a/crates/git-tidy/src/dispatch.rs
+++ b/crates/git-tidy/src/dispatch.rs
@@ -37,8 +37,8 @@ pub fn try_dispatch(args: &[OsString], find_binary: impl Fn(&str) -> Option<Path
         return;
     };
 
-    // Don't intercept flags or the explicit "audit" subcommand
-    if alias_str.starts_with('-') || alias_str == "audit" {
+    // Don't intercept flags or built-in subcommands
+    if alias_str.starts_with('-') || alias_str == "audit" || alias_str == "explain" {
         return;
     }
 
@@ -112,6 +112,11 @@ mod tests {
         assert_eq!(resolve_alias("audit"), None);
     }
 
+    #[test]
+    fn resolve_alias_explain_not_intercepted() {
+        assert_eq!(resolve_alias("explain"), None);
+    }
+
     // -- try_dispatch fall-through tests --
 
     fn os(s: &str) -> OsString {
@@ -145,6 +150,12 @@ mod tests {
     #[test]
     fn try_dispatch_audit_not_intercepted() {
         let args = [os("git-tidy"), os("audit")];
+        try_dispatch(&args, never_find);
+    }
+
+    #[test]
+    fn try_dispatch_explain_not_intercepted() {
+        let args = [os("git-tidy"), os("explain")];
         try_dispatch(&args, never_find);
     }
 

--- a/crates/git-tidy/src/explain.rs
+++ b/crates/git-tidy/src/explain.rs
@@ -1,0 +1,338 @@
+//! Glossary of git-tidy terminology and classifications.
+
+use std::io::Write;
+
+/// A single glossary entry.
+struct GlossaryEntry {
+    term: &'static str,
+    section: &'static str,
+    description: &'static str,
+    used_by: &'static [&'static str],
+}
+
+/// All glossary entries grouped by section.
+static GLOSSARY: &[GlossaryEntry] = &[
+    // Branches & Worktrees
+    GlossaryEntry {
+        term: "landed",
+        section: "Branches & Worktrees",
+        description: "Branch tip is an ancestor of the default branch (structurally merged).",
+        used_by: &["branches", "worktrees"],
+    },
+    GlossaryEntry {
+        term: "landed-content",
+        section: "Branches & Worktrees",
+        description: "All branch commits matched on the default branch by content (patch heuristic).",
+        used_by: &["branches", "worktrees"],
+    },
+    GlossaryEntry {
+        term: "partial",
+        section: "Branches & Worktrees",
+        description: "Some but not all branch commits matched on the default branch.",
+        used_by: &["branches", "worktrees"],
+    },
+    GlossaryEntry {
+        term: "active",
+        section: "Branches & Worktrees",
+        description: "Branch has unique work that has not landed on the default branch. Still in use.",
+        used_by: &["branches", "worktrees"],
+    },
+    GlossaryEntry {
+        term: "local",
+        section: "Branches & Worktrees",
+        description: "Branch has no remote tracking branch configured.",
+        used_by: &["branches", "worktrees"],
+    },
+    // Stashes
+    GlossaryEntry {
+        term: "committed",
+        section: "Stashes",
+        description: "Stash contents have been committed to the branch (safe to drop).",
+        used_by: &["stashes"],
+    },
+    GlossaryEntry {
+        term: "orphaned",
+        section: "Stashes",
+        description: "Stash references a branch that no longer exists.",
+        used_by: &["stashes"],
+    },
+    GlossaryEntry {
+        term: "aged",
+        section: "Stashes",
+        description: "Stash is older than the configured age threshold.",
+        used_by: &["stashes"],
+    },
+    GlossaryEntry {
+        term: "active",
+        section: "Stashes",
+        description: "Stash is recent and its branch still exists.",
+        used_by: &["stashes"],
+    },
+    // Remotes
+    GlossaryEntry {
+        term: "unreachable",
+        section: "Remotes",
+        description: "Remote URL cannot be contacted (DNS failure, deleted repo, etc.).",
+        used_by: &["remotes"],
+    },
+    GlossaryEntry {
+        term: "orphaned",
+        section: "Remotes",
+        description: "Remote has no configured URL (leftover tracking refs only).",
+        used_by: &["remotes"],
+    },
+    GlossaryEntry {
+        term: "active",
+        section: "Remotes",
+        description: "Remote is reachable and in use.",
+        used_by: &["remotes"],
+    },
+    // Tags
+    GlossaryEntry {
+        term: "stale",
+        section: "Tags",
+        description: "Tag points to a commit unreachable from any branch tip.",
+        used_by: &["tags"],
+    },
+    GlossaryEntry {
+        term: "local_only",
+        section: "Tags",
+        description: "Tag exists locally but not on any remote.",
+        used_by: &["tags"],
+    },
+    GlossaryEntry {
+        term: "remote_only",
+        section: "Tags",
+        description: "Tag exists on a remote but not locally.",
+        used_by: &["tags"],
+    },
+    GlossaryEntry {
+        term: "synced",
+        section: "Tags",
+        description: "Tag exists both locally and on at least one remote.",
+        used_by: &["tags"],
+    },
+    // Repos
+    GlossaryEntry {
+        term: "stale",
+        section: "Repos",
+        description: "Repo has not been committed to within the configured stale-months threshold.",
+        used_by: &["repos"],
+    },
+    GlossaryEntry {
+        term: "orphaned",
+        section: "Repos",
+        description: "Repo has no configured remote (local-only, no upstream).",
+        used_by: &["repos"],
+    },
+    GlossaryEntry {
+        term: "active",
+        section: "Repos",
+        description: "Repo has a remote and recent commits.",
+        used_by: &["repos"],
+    },
+    // LFS
+    GlossaryEntry {
+        term: "untracked",
+        section: "LFS",
+        description: "Large file stored directly in git instead of LFS.",
+        used_by: &["lfs"],
+    },
+    GlossaryEntry {
+        term: "missing",
+        section: "LFS",
+        description: "LFS pointer exists but the object is not downloaded locally.",
+        used_by: &["lfs"],
+    },
+    GlossaryEntry {
+        term: "orphaned",
+        section: "LFS",
+        description: "LFS object exists locally but is no longer referenced by any pointer.",
+        used_by: &["lfs"],
+    },
+    GlossaryEntry {
+        term: "healthy",
+        section: "LFS",
+        description: "LFS pointer and object are both present and consistent.",
+        used_by: &["lfs"],
+    },
+    // Config
+    GlossaryEntry {
+        term: "orphaned_branch_config",
+        section: "Config",
+        description: "Git config section for a branch that no longer exists locally.",
+        used_by: &["config"],
+    },
+    GlossaryEntry {
+        term: "alias_shadows_builtin",
+        section: "Config",
+        description: "Git alias has the same name as a built-in git command.",
+        used_by: &["config"],
+    },
+    // Annotations
+    GlossaryEntry {
+        term: "dirty",
+        section: "Annotations",
+        description: "Working tree has meaningful uncommitted changes.",
+        used_by: &["branches", "worktrees", "repos"],
+    },
+    GlossaryEntry {
+        term: "diverged",
+        section: "Annotations",
+        description: "Branch has commits both ahead of and behind the remote tracking branch.",
+        used_by: &["branches", "worktrees"],
+    },
+    GlossaryEntry {
+        term: "remote deleted",
+        section: "Annotations",
+        description: "The remote tracking branch has been deleted upstream.",
+        used_by: &["branches", "worktrees"],
+    },
+    // Metrics
+    GlossaryEntry {
+        term: "+N/-M",
+        section: "Metrics",
+        description: "Commits ahead of / behind the default branch.",
+        used_by: &["branches", "worktrees"],
+    },
+    GlossaryEntry {
+        term: "N/M",
+        section: "Metrics",
+        description: "Landed ratio: N commits matched out of M total branch commits.",
+        used_by: &["branches", "worktrees"],
+    },
+    GlossaryEntry {
+        term: "unmatched",
+        section: "Metrics",
+        description: "Branch commits that could not be matched on the default branch (listed under partial).",
+        used_by: &["branches", "worktrees"],
+    },
+];
+
+/// Section ordering for grouped output.
+static SECTIONS: &[&str] = &[
+    "Branches & Worktrees",
+    "Stashes",
+    "Remotes",
+    "Tags",
+    "Repos",
+    "LFS",
+    "Config",
+    "Annotations",
+    "Metrics",
+];
+
+/// Write the full glossary grouped by section headers.
+pub fn write_full(out: &mut dyn Write) -> std::io::Result<()> {
+    writeln!(out, "git-tidy terminology")?;
+
+    for section in SECTIONS {
+        writeln!(out)?;
+        writeln!(out, "{}", section.to_uppercase())?;
+
+        for entry in GLOSSARY.iter().filter(|e| e.section == *section) {
+            writeln!(out, "  {:<24} {}", entry.term, entry.description)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Write a single-term lookup. Case-insensitive.
+pub fn write_term(out: &mut dyn Write, term: &str) -> std::io::Result<()> {
+    let lower = term.to_lowercase();
+    let found = GLOSSARY.iter().find(|e| e.term.to_lowercase() == lower);
+
+    match found {
+        Some(entry) => {
+            writeln!(out, "{}: {}", entry.term, entry.description)?;
+            writeln!(
+                out,
+                "{}  Used by: {}",
+                " ".repeat(entry.term.len() + 2),
+                entry.used_by.join(", ")
+            )?;
+        }
+        None => {
+            writeln!(
+                out,
+                "Unknown term: \"{term}\". Run 'git tidy explain' to see all terms."
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_output_contains_all_sections() {
+        let mut buf = Vec::new();
+        write_full(&mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        for section in SECTIONS {
+            assert!(
+                output.contains(&section.to_uppercase()),
+                "missing section header: {section}"
+            );
+        }
+    }
+
+    #[test]
+    fn full_output_contains_every_term() {
+        let mut buf = Vec::new();
+        write_full(&mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        for entry in GLOSSARY {
+            assert!(output.contains(entry.term), "missing term: {}", entry.term);
+        }
+    }
+
+    #[test]
+    fn single_term_found() {
+        let mut buf = Vec::new();
+        write_term(&mut buf, "partial").unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("partial:"));
+        assert!(output.contains("Some but not all"));
+        assert!(output.contains("Used by:"));
+        assert!(output.contains("branches"));
+    }
+
+    #[test]
+    fn single_term_case_insensitive() {
+        let mut buf = Vec::new();
+        write_term(&mut buf, "PARTIAL").unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("partial:"));
+        assert!(output.contains("Used by:"));
+    }
+
+    #[test]
+    fn single_term_not_found() {
+        let mut buf = Vec::new();
+        write_term(&mut buf, "nonexistent").unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("Unknown term: \"nonexistent\""));
+        assert!(output.contains("git tidy explain"));
+    }
+
+    #[test]
+    fn single_term_hyphenated() {
+        let mut buf = Vec::new();
+        write_term(&mut buf, "landed-content").unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("landed-content:"));
+        assert!(output.contains("patch heuristic"));
+        assert!(output.contains("Used by:"));
+    }
+}

--- a/crates/git-tidy/src/lib.rs
+++ b/crates/git-tidy/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cli;
 pub mod completions;
 pub mod dispatch;
+pub mod explain;
 pub mod inprocess;
 pub mod output;
 pub mod runner;

--- a/crates/git-tidy/src/main.rs
+++ b/crates/git-tidy/src/main.rs
@@ -9,6 +9,7 @@ use git_tidy_core::progress::Progress;
 mod cli;
 mod completions;
 mod dispatch;
+mod explain;
 mod inprocess;
 mod output;
 mod runner;
@@ -30,6 +31,16 @@ fn main() {
         return;
     }
 
+    if let Some(cli::Command::Explain { term }) = &cli.command {
+        let mut stdout = io::stdout().lock();
+        if let Some(t) = term {
+            explain::write_term(&mut stdout, t).unwrap();
+        } else {
+            explain::write_full(&mut stdout).unwrap();
+        }
+        return;
+    }
+
     let directory = cli.target_directory();
 
     if !directory.is_dir() {
@@ -46,7 +57,9 @@ fn main() {
             subprocess,
         }) => (*json, *porcelain, *verbose, tools.clone(), *subprocess),
         None => (false, false, false, vec![], false),
-        Some(cli::Command::Shared(_)) => unreachable!("handled above"),
+        Some(cli::Command::Shared(_)) | Some(cli::Command::Explain { .. }) => {
+            unreachable!("handled above")
+        }
     };
 
     let tool_filter = if tools.is_empty() {

--- a/crates/git-tidy/src/output.rs
+++ b/crates/git-tidy/src/output.rs
@@ -69,7 +69,10 @@ pub fn write_human(
         }
     }
 
-    writeln!(out, "\nRun individual tools for details.")?;
+    writeln!(
+        out,
+        "\nRun individual tools for details. See 'git tidy explain' for terminology."
+    )?;
 
     Ok(())
 }
@@ -150,7 +153,11 @@ mod tests {
         );
         assert!(output.contains("branches:        3 scanned (2 active, 1 landed)"));
         assert!(output.contains("not installed: git-repo-tidy"));
-        assert!(output.contains("Run individual tools for details."));
+        assert!(
+            output.contains(
+                "Run individual tools for details. See 'git tidy explain' for terminology."
+            )
+        );
     }
 
     #[test]

--- a/crates/git-tidy/src/types.rs
+++ b/crates/git-tidy/src/types.rs
@@ -155,7 +155,7 @@ mod tests {
 
     #[test]
     fn tool_specs_aliases_dont_collide_with_commands() {
-        let reserved = ["audit", "completions", "help"];
+        let reserved = ["audit", "completions", "explain", "help"];
         for spec in TOOL_SPECS {
             for alias in spec.aliases {
                 assert!(

--- a/crates/git-worktree-tidy/src/output.rs
+++ b/crates/git-worktree-tidy/src/output.rs
@@ -88,6 +88,7 @@ pub fn write_human(out: &mut dyn Write, result: &ScanResult) -> std::io::Result<
     }
 
     shared::write_summary_line(out, result.total_scanned, &result.counts, "worktrees")?;
+    shared::write_explain_hint(out)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Adds `git tidy explain` subcommand that prints a glossary of all user-facing terminology (classifications, annotations, metrics) grouped by section
- Supports single-term lookup: `git tidy explain partial` with case-insensitive matching
- Adds `hint: run 'git tidy explain' for a glossary of terms` footer to all 8 tool scan outputs
- Updates audit footer to reference the explain command

Closes #82

## Test plan

- [x] `cargo test --workspace` -- all existing + new tests pass
- [x] `cargo clippy --workspace` -- clean
- [x] `cargo fmt --check` -- clean
- [x] Manual: `git tidy explain` shows full glossary
- [x] Manual: `git tidy explain partial` shows single term
- [x] Manual: `git tidy explain nonexistent` shows unknown term message