### PR TITLE
Use force-delete for content-matched landed branches

### DIFF
--- a/crates/git-branch-tidy/src/clean.rs
+++ b/crates/git-branch-tidy/src/clean.rs
@@ -71,8 +71,15 @@ pub fn run_clean(
                 continue;
             }
 
-            // Delete the local branch
-            let delete_result = if options.force {
+            // Delete the local branch.
+            // Use force-delete for branches our analysis has confirmed as landed,
+            // since git's built-in merge check doesn't understand squash merges.
+            let force_delete = options.force
+                || matches!(
+                    branch.classification,
+                    Classification::Landed | Classification::LandedByContent { .. }
+                );
+            let delete_result = if force_delete {
                 git.branch_delete(&branch.repo_path, &branch.name)
             } else {
                 git.branch_delete_safe(&branch.repo_path, &branch.name)
@@ -241,7 +248,8 @@ mod tests {
 
         assert_eq!(result.succeeded.len(), 1);
         assert_eq!(result.succeeded[0].name, "feature/done");
-        assert_eq!(git.branch_delete_safe_calls().len(), 1);
+        // Landed branches use force-delete since git's merge check is redundant
+        assert_eq!(git.branch_delete_calls().len(), 1);
     }
 
     #[test]
@@ -349,6 +357,26 @@ mod tests {
     }
 
     #[test]
+    fn clean_landed_by_content_uses_force_delete() {
+        let git = MockGitBuilder::new().build();
+        let mut branch = merged_branch("feature/squashed");
+        branch.classification = Classification::LandedByContent {
+            matched: 2,
+            total: 2,
+        };
+        let scan = make_scan_result(vec![branch]);
+        let mut buf = Vec::new();
+
+        let result = run_clean(&git, &scan, &default_options(), &mut buf).unwrap();
+
+        assert_eq!(result.succeeded.len(), 1);
+        // LandedByContent uses force-delete since git's merge check
+        // doesn't understand squash merges
+        assert_eq!(git.branch_delete_calls().len(), 1);
+        assert_eq!(git.branch_delete_safe_calls().len(), 0);
+    }
+
+    #[test]
     fn clean_include_remote_deletes_remote_branch() {
         let git = MockGitBuilder::new()
             .with_upstream_branch(&repo(), "feature/done", Some("origin/feature/done"))
@@ -408,7 +436,7 @@ mod tests {
     #[test]
     fn clean_handles_delete_failure() {
         let git = MockGitBuilder::new()
-            .with_branch_delete_safe_error(&repo(), "feature/unmerged", "not fully merged")
+            .with_branch_delete_error(&repo(), "feature/unmerged", "not fully merged")
             .build();
         let scan = make_scan_result(vec![merged_branch("feature/unmerged")]);
         let mut buf = Vec::new();

--- a/crates/git-tidy-core/src/testutil.rs
+++ b/crates/git-tidy-core/src/testutil.rs
@@ -29,6 +29,7 @@ pub struct MockGitBuilder {
     remove_force_calls: std::sync::Mutex<Vec<(PathBuf, PathBuf)>>,
     prune_calls: std::sync::Mutex<Vec<PathBuf>>,
     branch_delete_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
+    branch_delete_errors: HashMap<(PathBuf, String), String>,
     worktree_remove_errors: HashMap<PathBuf, String>,
     worktree_remove_force_errors: HashMap<PathBuf, String>,
     worktree_list: HashMap<PathBuf, Vec<(PathBuf, Option<String>)>>,
@@ -246,6 +247,12 @@ impl MockGitBuilder {
             (repo.to_path_buf(), branch.to_string()),
             upstream.map(|s| s.to_string()),
         );
+        self
+    }
+
+    pub fn with_branch_delete_error(mut self, repo: &Path, branch: &str, error: &str) -> Self {
+        self.branch_delete_errors
+            .insert((repo.to_path_buf(), branch.to_string()), error.to_string());
         self
     }
 
@@ -504,6 +511,7 @@ impl MockGitBuilder {
             remove_force_calls: self.remove_force_calls,
             prune_calls: self.prune_calls,
             branch_delete_calls: self.branch_delete_calls,
+            branch_delete_errors: self.branch_delete_errors,
             worktree_remove_errors: self.worktree_remove_errors,
             worktree_remove_force_errors: self.worktree_remove_force_errors,
             worktree_list: self.worktree_list,
@@ -574,6 +582,7 @@ pub struct MockGit {
     remove_force_calls: std::sync::Mutex<Vec<(PathBuf, PathBuf)>>,
     prune_calls: std::sync::Mutex<Vec<PathBuf>>,
     branch_delete_calls: std::sync::Mutex<Vec<(PathBuf, String)>>,
+    branch_delete_errors: HashMap<(PathBuf, String), String>,
     worktree_remove_errors: HashMap<PathBuf, String>,
     worktree_remove_force_errors: HashMap<PathBuf, String>,
     worktree_list: HashMap<PathBuf, Vec<(PathBuf, Option<String>)>>,
@@ -864,6 +873,15 @@ impl GitOps for MockGit {
     }
 
     fn branch_delete(&self, repo: &Path, branch: &str) -> GitResult<()> {
+        if let Some(err) = self
+            .branch_delete_errors
+            .get(&(repo.to_path_buf(), branch.to_string()))
+        {
+            return Err(Error::GitCommand {
+                command: format!("branch -D {branch}"),
+                message: err.clone(),
+            });
+        }
         self.branch_delete_calls
             .lock()
             .unwrap()


### PR DESCRIPTION
## Summary

- Use `git branch -D` for branches classified as `Landed` or `LandedByContent`, since our content analysis has already confirmed the work landed and git's built-in merge check doesn't understand squash merges
- Reserve `git branch -d` only for unanalyzed branches (e.g. `Active`/`Local` in `--all` mode)
- Add `with_branch_delete_error` to `MockGitBuilder` for testing force-delete error paths

Closes #88

## Test plan

- [x] `cargo test -p git-branch-tidy` — all 70 tests pass
- [x] `cargo test --workspace` — all tests pass
- [x] New test `clean_landed_by_content_uses_force_delete` verifies `LandedByContent` branches use `-D` without `--force`
- [x] Existing test `clean_all_includes_active` confirms `Active` branches still use `-d`