### PR TITLE
Cache per-commit landed detection results across branches

### DIFF
--- a/crates/git-branch-tidy/src/scan.rs
+++ b/crates/git-branch-tidy/src/scan.rs
@@ -4,6 +4,7 @@ use git_tidy_core::classification;
 use git_tidy_core::error::Error;
 use git_tidy_core::filter::{NameFilter, filter_paths};
 use git_tidy_core::git::GitOps;
+use git_tidy_core::landed::LandedCache;
 use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
 use git_tidy_core::scan::parallel_classify;
@@ -91,6 +92,7 @@ pub fn run_scan_repos(
             }
 
             let mut classified = Vec::with_capacity(branches.len());
+            let mut landed_cache = LandedCache::new();
 
             for branch_name in &branches {
                 if branch_name == &default_branch {
@@ -103,13 +105,14 @@ pub fn run_scan_repos(
 
                 let is_current = current.as_deref() == Some(branch_name.as_str());
 
-                match classification::classify_branch(
+                match classification::classify_branch_cached(
                     git,
                     repo_path,
                     branch_name,
                     &default_branch,
                     behind_threshold,
                     verbose,
+                    &mut landed_cache,
                 ) {
                     Ok(bc) => {
                         if verbose {

--- a/crates/git-tidy-core/src/classification.rs
+++ b/crates/git-tidy-core/src/classification.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use crate::dirty;
 use crate::error::Error;
 use crate::git::GitOps;
-use crate::landed;
+use crate::landed::{self, LandedCache};
 use crate::types::{
     Annotations, BranchClassification, Classification, ClassificationLabel, WorktreeInfo,
 };
@@ -87,6 +87,100 @@ pub fn classify_branch(
         // Try content-based landed detection
         let landed_result =
             landed::detect_landed(git, repo, &comparison_target, branch_name, verbose)?;
+
+        enum Action {
+            UseContentResult,
+            Landed,
+            Active,
+            Local,
+        }
+        let action = match &landed_result.classification {
+            Classification::LandedByContent { .. } if landed_result.total > 0 => {
+                Action::UseContentResult
+            }
+            Classification::LandedByContent { .. } => Action::Landed,
+            Classification::LandedPartial { .. } => Action::UseContentResult,
+            _ if has_remote => Action::Active,
+            _ => Action::Local,
+        };
+        let cls = match action {
+            Action::UseContentResult => landed_result.classification,
+            Action::Landed => Classification::Landed,
+            Action::Active => Classification::Active,
+            Action::Local => Classification::Local,
+        };
+        if verbose {
+            eprintln!(
+                "  {branch_name}: content detection ({}/{}) → {}",
+                landed_result.matched,
+                landed_result.total,
+                cls.label(),
+            );
+        }
+        cls
+    };
+
+    Ok(BranchClassification {
+        classification,
+        remote_tracking: has_remote,
+        remote_deleted,
+        ahead,
+        behind,
+        diverged: behind > behind_threshold,
+    })
+}
+
+/// Classify a branch, reusing cached landed detection results from previous
+/// branches in the same repo. Use this when classifying multiple branches
+/// within a single repo to avoid redundant git subprocess calls for shared commits.
+pub fn classify_branch_cached(
+    git: &dyn GitOps,
+    repo: &Path,
+    branch_name: &str,
+    default_branch: &str,
+    behind_threshold: usize,
+    verbose: bool,
+    landed_cache: &mut LandedCache,
+) -> Result<BranchClassification, Error> {
+    // Determine whether origin has the default branch
+    let origin_ref = format!("refs/remotes/origin/{default_branch}");
+    let has_origin = git.rev_parse_verify(repo, &origin_ref)?;
+    let comparison_target = if has_origin {
+        format!("origin/{default_branch}")
+    } else {
+        default_branch.to_string()
+    };
+
+    // Check remote tracking branch
+    let remote_ref = format!("refs/remotes/origin/{branch_name}");
+    let has_remote = git.rev_parse_verify(repo, &remote_ref)?;
+    let remote_deleted = has_origin && !has_remote;
+
+    // Ahead/behind counts
+    let (behind, ahead) = git.rev_list_left_right_count(repo, &comparison_target, branch_name)?;
+
+    if verbose {
+        eprintln!("  {branch_name}: remote={has_remote}, ahead={ahead}, behind={behind}",);
+    }
+
+    // Check if structurally landed — skip the subprocess call when ahead == 0
+    let is_merged = ahead == 0 || git.is_ancestor(repo, branch_name, &comparison_target)?;
+
+    let classification = if is_merged {
+        if verbose {
+            eprintln!("  {branch_name}: structurally merged → landed");
+        }
+        Classification::Landed
+    } else {
+        // Try content-based landed detection with cache
+        let landed_result = landed::detect_landed_cached(
+            git,
+            repo,
+            &comparison_target,
+            branch_name,
+            verbose,
+            landed_cache,
+        )?;
 
         enum Action {
             UseContentResult,

--- a/crates/git-tidy-core/src/landed.rs
+++ b/crates/git-tidy-core/src/landed.rs
@@ -1,9 +1,28 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use crate::error::Error;
 use crate::git::GitOps;
 use crate::types::{Classification, UnmatchedCommit};
+
+/// Cache for per-commit landed detection results within a repo.
+///
+/// When multiple branches share the same commits, this cache avoids redundant
+/// git subprocess calls by remembering whether each commit was already matched
+/// against the default branch. Create one per repo and pass it to
+/// [`detect_landed_cached`] for each branch.
+#[derive(Default)]
+pub struct LandedCache {
+    /// Maps commit hash to whether it was matched on the default branch.
+    results: HashMap<String, bool>,
+}
+
+impl LandedCache {
+    /// Create an empty cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 
 /// Threshold for fuzzy subject matching (combined Jaccard + Levenshtein).
 const FUZZY_THRESHOLD: f64 = 0.6;
@@ -27,6 +46,30 @@ pub fn detect_landed(
     default_branch_ref: &str,
     branch_ref: &str,
     verbose: bool,
+) -> Result<LandedResult, Error> {
+    detect_landed_cached(
+        git,
+        repo,
+        default_branch_ref,
+        branch_ref,
+        verbose,
+        &mut LandedCache::new(),
+    )
+}
+
+/// Check if branch commits have "landed" on the default branch, reusing
+/// cached per-commit results from previous branches in the same repo.
+///
+/// When a repo has many branches that share commits (e.g., branches forked
+/// from the same point), this avoids re-running the full detection pipeline
+/// (exact match, fuzzy match, patch similarity) for commits already seen.
+pub fn detect_landed_cached(
+    git: &dyn GitOps,
+    repo: &Path,
+    default_branch_ref: &str,
+    branch_ref: &str,
+    verbose: bool,
+    cache: &mut LandedCache,
 ) -> Result<LandedResult, Error> {
     let unique_commits = git.log_exclusive(repo, default_branch_ref, branch_ref)?;
     let total = unique_commits.len();
@@ -52,8 +95,28 @@ pub fn detect_landed(
     for (hash, subject) in &unique_commits {
         let short_hash = &hash[..hash.len().min(7)];
 
+        // Check the cache for a previous result on this commit.
+        if let Some(&was_matched) = cache.results.get(hash) {
+            if was_matched {
+                matched += 1;
+                if verbose {
+                    eprintln!("    {short_hash}: cached match \"{subject}\"");
+                }
+            } else {
+                if verbose {
+                    eprintln!("    {short_hash}: cached no-match \"{subject}\"");
+                }
+                unmatched.push(UnmatchedCommit {
+                    short_hash: short_hash.to_string(),
+                    subject: subject.clone(),
+                });
+            }
+            continue;
+        }
+
         if try_exact_subject_match(git, repo, default_branch_ref, subject)? {
             matched += 1;
+            cache.results.insert(hash.clone(), true);
             if verbose {
                 eprintln!("    {short_hash}: exact subject match \"{subject}\"");
             }
@@ -62,6 +125,7 @@ pub fn detect_landed(
 
         if try_fuzzy_subject_match(git, repo, default_branch_ref, subject)? {
             matched += 1;
+            cache.results.insert(hash.clone(), true);
             if verbose {
                 eprintln!("    {short_hash}: fuzzy subject match \"{subject}\"");
             }
@@ -70,12 +134,14 @@ pub fn detect_landed(
 
         if try_patch_similarity(git, repo, default_branch_ref, hash)? {
             matched += 1;
+            cache.results.insert(hash.clone(), true);
             if verbose {
                 eprintln!("    {short_hash}: patch similarity match \"{subject}\"");
             }
             continue;
         }
 
+        cache.results.insert(hash.clone(), false);
         if verbose {
             eprintln!("    {short_hash}: no match \"{subject}\"");
         }
@@ -526,6 +592,142 @@ mod tests {
             Classification::LandedByContent {
                 matched: 0,
                 total: 0
+            }
+        ));
+    }
+
+    #[test]
+    fn detect_landed_cached_skips_redundant_commits() {
+        // Two branches share commit "aaa1111" which doesn't match.
+        // The second branch should use the cached result.
+        let git = MockGitBuilder::new()
+            // Branch 1: has aaa1111 (unmatched) and bbb2222 (matched)
+            .with_log_exclusive(
+                &repo(),
+                "origin/main",
+                "feature/branch1",
+                vec![
+                    ("aaa1111".into(), "Unique unmatched work".into()),
+                    ("bbb2222".into(), "feat: add widget".into()),
+                ],
+            )
+            .with_log_grep(
+                &repo(),
+                "origin/main",
+                "add widget",
+                vec![("ccc".into(), "feat: add widget".into())],
+            )
+            // Branch 2: shares aaa1111 with branch1, plus has ddd4444 (matched)
+            .with_log_exclusive(
+                &repo(),
+                "origin/main",
+                "feature/branch2",
+                vec![
+                    ("aaa1111".into(), "Unique unmatched work".into()),
+                    ("ddd4444".into(), "fix: widget alignment".into()),
+                ],
+            )
+            .with_log_grep(
+                &repo(),
+                "origin/main",
+                "widget alignment",
+                vec![("eee".into(), "fix: widget alignment".into())],
+            )
+            .build();
+
+        let mut cache = LandedCache::new();
+
+        // First branch: aaa1111 runs full pipeline (no exact, no fuzzy, no patch → unmatched)
+        let r1 = detect_landed_cached(
+            &git,
+            &repo(),
+            "origin/main",
+            "feature/branch1",
+            false,
+            &mut cache,
+        )
+        .unwrap();
+        assert_eq!(r1.matched, 1); // bbb2222 matched
+        assert_eq!(r1.total, 2);
+        assert_eq!(cache.results.len(), 2); // both commits cached
+
+        // Second branch: aaa1111 should be served from cache (no git calls),
+        // ddd4444 runs the pipeline fresh
+        let r2 = detect_landed_cached(
+            &git,
+            &repo(),
+            "origin/main",
+            "feature/branch2",
+            false,
+            &mut cache,
+        )
+        .unwrap();
+        assert_eq!(r2.matched, 1); // ddd4444 matched
+        assert_eq!(r2.total, 2);
+        assert_eq!(cache.results.len(), 3); // aaa1111, bbb2222, ddd4444
+    }
+
+    #[test]
+    fn detect_landed_cached_reuses_matched_commits() {
+        // Both branches have the same matched commit — second should hit cache
+        let git = MockGitBuilder::new()
+            .with_log_exclusive(
+                &repo(),
+                "origin/main",
+                "feature/branch1",
+                vec![("aaa1111".into(), "feat: add widget".into())],
+            )
+            .with_log_grep(
+                &repo(),
+                "origin/main",
+                "add widget",
+                vec![("ccc".into(), "feat: add widget".into())],
+            )
+            .with_log_exclusive(
+                &repo(),
+                "origin/main",
+                "feature/branch2",
+                vec![("aaa1111".into(), "feat: add widget".into())],
+            )
+            // No log_grep needed for branch2 — cache should handle it
+            .build();
+
+        let mut cache = LandedCache::new();
+
+        let r1 = detect_landed_cached(
+            &git,
+            &repo(),
+            "origin/main",
+            "feature/branch1",
+            false,
+            &mut cache,
+        )
+        .unwrap();
+        assert_eq!(r1.matched, 1);
+        assert!(matches!(
+            r1.classification,
+            Classification::LandedByContent {
+                matched: 1,
+                total: 1,
+            }
+        ));
+
+        // Second branch: aaa1111 is in cache as matched — no git calls needed
+        let r2 = detect_landed_cached(
+            &git,
+            &repo(),
+            "origin/main",
+            "feature/branch2",
+            false,
+            &mut cache,
+        )
+        .unwrap();
+        assert_eq!(r2.matched, 1);
+        assert!(matches!(
+            r2.classification,
+            Classification::LandedByContent {
+                matched: 1,
+                total: 1,
             }
         ));
     }


### PR DESCRIPTION
## Summary

- Add `LandedCache` struct that memoizes per-commit match/no-match results during landed detection
- Add `detect_landed_cached` and `classify_branch_cached` variants that accept a cache parameter
- Wire branch-tidy's scan closure to create one `LandedCache` per repo, shared across all branches in that repo
- Original `detect_landed` and `classify_branch` are unchanged (backward compatible)

Closes #92

## Results

**66% wall-clock reduction** on a real workload (183 branches, 90 repos): 3:05 → 1:03.

The biggest beneficiary is repos where many branches share the same unmatched commits. Previously each branch re-ran the full detection pipeline (exact → fuzzy → patch similarity, 5-10 git subprocesses each) for every shared commit.

## Test plan

- [x] `cargo test --workspace` — all existing + 2 new cache tests pass
- [x] `cargo build --workspace` — no compilation errors
- [x] Manual: timed `git tidy branch` before and after, confirmed 66% speedup with identical output