### PR TITLE
Add real-time per-repo progress beneath audit spinners

### DIFF
--- a/crates/git-tidy-core/src/progress.rs
+++ b/crates/git-tidy-core/src/progress.rs
@@ -7,8 +7,15 @@ use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 /// When `enabled` is true, creates visible progress bars on stderr.
 /// When `enabled` is false (non-TTY, tests, nested contexts), creates
 /// hidden no-op bars so callers never need conditionals.
+///
+/// In forwarding mode, `bar()` inserts sub-bars into an existing
+/// `MultiProgress` beneath a parent spinner, providing real-time
+/// per-repo progress during parallel audits.
 pub struct Progress {
     enabled: bool,
+    /// When set, `bar()` inserts bars into this `MultiProgress` after the
+    /// given spinner instead of creating standalone bars.
+    multi: Option<(MultiProgress, ProgressBar)>,
 }
 
 impl Default for Progress {
@@ -22,13 +29,30 @@ impl Progress {
     pub fn new() -> Self {
         Self {
             enabled: std::io::stderr().is_terminal(),
+            multi: None,
         }
     }
 
     /// Create a disabled `Progress` that always returns hidden bars.
     /// Use in tests and nested contexts (e.g., audit runner calling sub-tools).
     pub fn disabled() -> Self {
-        Self { enabled: false }
+        Self {
+            enabled: false,
+            multi: None,
+        }
+    }
+
+    /// Create a `Progress` whose `bar()` calls insert sub-bars into an
+    /// existing `MultiProgress`, positioned after the given spinner.
+    ///
+    /// Used by the audit runner so sub-tool repo-level progress appears
+    /// beneath each tool's spinner. The sub-bar is cleared automatically
+    /// when the sub-tool calls `finish_and_clear()`.
+    pub fn forwarding(mp: &MultiProgress, after: &ProgressBar) -> Self {
+        Self {
+            enabled: true,
+            multi: Some((mp.clone(), after.clone())),
+        }
     }
 
     /// Returns whether progress display is enabled.
@@ -38,8 +62,21 @@ impl Progress {
 
     /// Create a progress bar with a known length (e.g., repo count).
     ///
-    /// Displays: `⠋ Fetching  ████████░░░░░░  3/5`
+    /// In forwarding mode, the bar is inserted into the parent `MultiProgress`
+    /// beneath the tool's spinner with a compact indented style.
+    ///
+    /// Standalone display: `⠋ Fetching  ████████░░░░░░  3/5`
+    /// Forwarding display: `    ──────────····  3/12`
     pub fn bar(&self, len: u64, msg: &str) -> ProgressBar {
+        if let Some((ref mp, ref after)) = self.multi {
+            let pb = mp.insert_after(after, ProgressBar::new(len));
+            pb.set_style(
+                ProgressStyle::with_template("    {wide_bar:.dim} {pos}/{len}")
+                    .unwrap()
+                    .progress_chars("──·"),
+            );
+            return pb;
+        }
         if !self.enabled {
             return ProgressBar::hidden();
         }
@@ -105,7 +142,10 @@ mod tests {
         // Force-enable even in test (non-TTY) context.
         // Note: indicatif may still hide the bar if stderr is not a TTY,
         // so we only verify length/message, not visibility.
-        let p = Progress { enabled: true };
+        let p = Progress {
+            enabled: true,
+            multi: None,
+        };
 
         let bar = p.bar(5, "Fetching");
         assert_eq!(bar.length(), Some(5));
@@ -115,7 +155,10 @@ mod tests {
 
     #[test]
     fn spinner_sets_message() {
-        let p = Progress { enabled: true };
+        let p = Progress {
+            enabled: true,
+            multi: None,
+        };
 
         let spinner = p.spinner("Scanning...");
         assert_eq!(spinner.message(), "Scanning...");
@@ -130,8 +173,36 @@ mod tests {
 
     #[test]
     fn enabled_returns_some_for_multi() {
-        let p = Progress { enabled: true };
+        let p = Progress {
+            enabled: true,
+            multi: None,
+        };
         assert!(p.multi().is_some());
+    }
+
+    #[test]
+    fn forwarding_bar_inserts_into_multi() {
+        let mp = MultiProgress::new();
+        let spinner = mp.add(ProgressBar::new_spinner());
+        let p = Progress::forwarding(&mp, &spinner);
+
+        assert!(p.is_enabled());
+        let bar = p.bar(10, "Scanning");
+        assert_eq!(bar.length(), Some(10));
+        assert_eq!(bar.position(), 0);
+        bar.inc(1);
+        assert_eq!(bar.position(), 1);
+        bar.finish_and_clear();
+        spinner.finish_and_clear();
+    }
+
+    #[test]
+    fn forwarding_is_enabled() {
+        let mp = MultiProgress::new();
+        let spinner = mp.add(ProgressBar::new_spinner());
+        let p = Progress::forwarding(&mp, &spinner);
+        assert!(p.is_enabled());
+        spinner.finish_and_clear();
     }
 
     #[test]

--- a/crates/git-tidy/src/inprocess.rs
+++ b/crates/git-tidy/src/inprocess.rs
@@ -100,8 +100,15 @@ pub fn run_audit_inprocess(
         })
         .collect();
 
-    // Sub-tool scans get disabled progress to avoid visual conflicts.
-    let sub_progress = Progress::disabled();
+    // Per-tool forwarding progress: sub-tool bars appear beneath each spinner.
+    // When progress is disabled, falls back to hidden bars.
+    let sub_progresses: Vec<Progress> = spinners
+        .iter()
+        .map(|spinner| match mp.as_ref() {
+            Some(mp) => Progress::forwarding(mp, spinner),
+            None => Progress::disabled(),
+        })
+        .collect();
 
     // Run all tool scans concurrently, each returning (index, result).
     let mut indexed_results: Vec<(usize, ToolResult)> = thread::scope(|s| {
@@ -113,7 +120,7 @@ pub fn run_audit_inprocess(
                 let caching = &caching;
                 let repo_paths = &repo_paths;
                 let noise_patterns = &noise_patterns;
-                let sub_progress = &sub_progress;
+                let sub_progresses = &sub_progresses;
                 s.spawn(move || {
                     let result = run_tool_scan(
                         spec,
@@ -122,7 +129,7 @@ pub fn run_audit_inprocess(
                         repo_paths,
                         noise_patterns,
                         verbose,
-                        sub_progress,
+                        &sub_progresses[idx],
                     );
                     spinners[idx].finish_with_message(format_spinner_done(&result));
                     (idx, result)


### PR DESCRIPTION
## Summary

- Add `Progress::forwarding(mp, spinner)` mode so sub-tool scan bars appear beneath each tool's spinner in the `MultiProgress`
- The shared `parallel_classify()` already calls `progress.bar()` and increments per-repo; this makes those bars visible instead of hidden
- No sub-tool code changes needed

Closes #102

## Test plan

- [x] `Progress::forwarding()` creates bars inserted into the MultiProgress (new unit test)
- [x] `forwarding_is_enabled` confirms the progress reports as enabled
- [x] All existing tests pass unchanged
- [ ] Manual: run `git tidy` and confirm per-repo progress bars appear below each spinner
- [ ] Manual: `git tidy --json` / `--porcelain` — no spinner artifacts on stdout