### PR TITLE
Add LandedStale classification for worktrees with deleted branch refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ All tools follow a similar CLI shape:
 - All modules that call git take `&dyn GitOps` to enable mocking.
 - Tests use `tempfile::tempdir()` for isolation with real git repos.
 - Path canonicalization in discovery handles macOS `/var` -> `/private/var` symlinks.
-- Classification priority order: landed (0) > landed-content (1) > partial (2) > active (3) > local (4).
+- Classification priority order: landed (0) = landed-stale (0) > landed-content (1) > partial (2) > active (3) > local (4). `LandedStale` is for worktrees whose branch ref was deleted (typically after a PR merge).
 - Shared test utilities (MockGitBuilder, TestRepo, git helper) live in `git-tidy-core/src/testutil.rs`, gated behind the `testutil` feature. Binary crates depend on `git-tidy-core = { features = ["testutil"] }` in `[dev-dependencies]`.
 - `classify_branch` is the core classification function shared by both tools. `classify_worktree` is a thin wrapper that adds dirty detection.
 - Discovery is inverted between tools: worktree discovery finds `.git` files (linked worktrees), branch discovery finds `.git` directories (repos).

--- a/crates/git-branch-tidy/src/clean.rs
+++ b/crates/git-branch-tidy/src/clean.rs
@@ -77,7 +77,9 @@ pub fn run_clean(
             let force_delete = options.force
                 || matches!(
                     branch.classification,
-                    Classification::Landed | Classification::LandedByContent { .. }
+                    Classification::Landed
+                        | Classification::LandedStale
+                        | Classification::LandedByContent { .. }
                 );
             let delete_result = if force_delete {
                 git.branch_delete(&branch.repo_path, &branch.name)
@@ -151,10 +153,12 @@ fn should_clean(classification: &Classification, options: &CleanOptions) -> bool
         return matches!(classification, Classification::Landed);
     }
 
-    // Default: landed (structural) + landed-by-content
+    // Default: landed (structural) + landed-stale + landed-by-content
     matches!(
         classification,
-        Classification::Landed | Classification::LandedByContent { .. }
+        Classification::Landed
+            | Classification::LandedStale
+            | Classification::LandedByContent { .. }
     )
 }
 

--- a/crates/git-branch-tidy/src/output.rs
+++ b/crates/git-branch-tidy/src/output.rs
@@ -147,10 +147,8 @@ mod tests {
             total_scanned: 2,
             counts: ScanCounts {
                 landed: 1,
-                landed_content: 0,
-                partial: 0,
                 active: 1,
-                local: 0,
+                ..Default::default()
             },
             warnings: vec![],
         }
@@ -169,10 +167,9 @@ mod tests {
         assert!(output.contains("fix/skip-db-init"));
         assert!(output.contains("* feature/caps"));
         assert!(output.contains("remote deleted"));
-        assert!(
-            output
-                .contains("2 branches scanned: 1 landed, 0 content, 0 partial, 1 active, 0 local")
-        );
+        assert!(output.contains(
+            "2 branches scanned: 1 landed, 0 stale, 0 content, 0 partial, 1 active, 0 local"
+        ));
     }
 
     #[test]

--- a/crates/git-tidy-core/src/classification.rs
+++ b/crates/git-tidy-core/src/classification.rs
@@ -249,6 +249,32 @@ pub fn classify_worktree(
 ) -> Result<WorktreeInfo, Error> {
     let branch = git.worktree_branch(worktree_path)?;
 
+    // Detect dangling branch ref: branch name is known but ref doesn't resolve.
+    // This happens when a PR is merged and the branch is deleted while the worktree remains.
+    if let Some(ref branch_name) = branch {
+        let ref_path = format!("refs/heads/{branch_name}");
+        if !git.rev_parse_verify(parent_repo, &ref_path)? {
+            let dirty_result = dirty::check_dirty(git, worktree_path, noise_patterns)?;
+            return Ok(WorktreeInfo {
+                path: worktree_path.to_path_buf(),
+                parent_repo: parent_repo.to_path_buf(),
+                branch,
+                default_branch: default_branch.to_string(),
+                classification: Classification::LandedStale,
+                annotations: Annotations {
+                    dirty: !dirty_result.meaningful_files.is_empty(),
+                    dirty_file_count: dirty_result.meaningful_files.len(),
+                    ..Default::default()
+                },
+                remote_tracking: false,
+                ahead: 0,
+                behind: 0,
+                dirty_files: dirty_result.all_files,
+                meaningful_dirty_files: dirty_result.meaningful_files,
+            });
+        }
+    }
+
     // Determine the ref to compare against
     let detached_head;
     let branch_ref: &str = match &branch {
@@ -380,6 +406,7 @@ mod tests {
     fn classify_merged_branch() {
         let git = MockGitBuilder::new()
             .with_worktree_branch(&wt(), Some("feature/done"))
+            .with_rev_parse_verify(&repo(), "refs/heads/feature/done", true)
             .with_rev_parse_verify(&repo(), "refs/remotes/origin/feature/done", true)
             .with_rev_list_counts(&repo(), "origin/main", "feature/done", (0, 0))
             .with_is_ancestor(&repo(), "feature/done", "origin/main", true)
@@ -397,6 +424,7 @@ mod tests {
     fn classify_active_branch() {
         let git = MockGitBuilder::new()
             .with_worktree_branch(&wt(), Some("feature/wip"))
+            .with_rev_parse_verify(&repo(), "refs/heads/feature/wip", true)
             .with_rev_parse_verify(&repo(), "refs/remotes/origin/main", true)
             .with_rev_parse_verify(&repo(), "refs/remotes/origin/feature/wip", true)
             .with_rev_list_counts(&repo(), "origin/main", "feature/wip", (5, 3))
@@ -421,6 +449,7 @@ mod tests {
     fn classify_local_branch() {
         let git = MockGitBuilder::new()
             .with_worktree_branch(&wt(), Some("feature/local"))
+            .with_rev_parse_verify(&repo(), "refs/heads/feature/local", true)
             .with_rev_parse_verify(&repo(), "refs/remotes/origin/main", true)
             .with_rev_parse_verify(&repo(), "refs/remotes/origin/feature/local", false)
             .with_rev_list_counts(&repo(), "origin/main", "feature/local", (10, 2))
@@ -444,6 +473,7 @@ mod tests {
     fn classify_dirty_branch() {
         let git = MockGitBuilder::new()
             .with_worktree_branch(&wt(), Some("feature/dirty"))
+            .with_rev_parse_verify(&repo(), "refs/heads/feature/dirty", true)
             .with_rev_parse_verify(&repo(), "refs/remotes/origin/feature/dirty", true)
             .with_rev_list_counts(&repo(), "origin/main", "feature/dirty", (0, 1))
             .with_is_ancestor(&repo(), "feature/dirty", "origin/main", false)
@@ -469,6 +499,7 @@ mod tests {
     fn classify_diverged_branch() {
         let git = MockGitBuilder::new()
             .with_worktree_branch(&wt(), Some("feature/old"))
+            .with_rev_parse_verify(&repo(), "refs/heads/feature/old", true)
             .with_rev_parse_verify(&repo(), "refs/remotes/origin/main", true)
             .with_rev_parse_verify(&repo(), "refs/remotes/origin/feature/old", true)
             .with_rev_list_counts(&repo(), "origin/main", "feature/old", (150, 5))
@@ -492,6 +523,7 @@ mod tests {
     fn classify_remote_deleted() {
         let git = MockGitBuilder::new()
             .with_worktree_branch(&wt(), Some("feature/gone"))
+            .with_rev_parse_verify(&repo(), "refs/heads/feature/gone", true)
             .with_rev_parse_verify(&repo(), "refs/remotes/origin/main", true)
             .with_rev_parse_verify(&repo(), "refs/remotes/origin/feature/gone", false)
             .with_rev_list_counts(&repo(), "origin/main", "feature/gone", (0, 0))
@@ -802,5 +834,39 @@ mod tests {
         let info =
             classify_worktree(&git, &wt(), &repo(), "main", 100, false, &default_noise()).unwrap();
         assert_eq!(info.classification, Classification::Local);
+    }
+
+    #[test]
+    fn classify_dangling_ref_returns_landed_stale() {
+        // Branch name is known but the ref doesn't exist (deleted after merge)
+        let git = MockGitBuilder::new()
+            .with_worktree_branch(&wt(), Some("feature/merged"))
+            .with_rev_parse_verify(&repo(), "refs/heads/feature/merged", false)
+            .with_status_porcelain(&wt(), vec![])
+            .build();
+
+        let info =
+            classify_worktree(&git, &wt(), &repo(), "main", 100, false, &default_noise()).unwrap();
+        assert_eq!(info.classification, Classification::LandedStale);
+        assert_eq!(info.branch.as_deref(), Some("feature/merged"));
+        assert!(!info.annotations.dirty);
+        assert!(!info.remote_tracking);
+        assert_eq!(info.ahead, 0);
+        assert_eq!(info.behind, 0);
+    }
+
+    #[test]
+    fn classify_dangling_ref_with_dirty_files() {
+        let git = MockGitBuilder::new()
+            .with_worktree_branch(&wt(), Some("feature/merged-dirty"))
+            .with_rev_parse_verify(&repo(), "refs/heads/feature/merged-dirty", false)
+            .with_status_porcelain(&wt(), vec![" M src/lib.rs".to_string()])
+            .build();
+
+        let info =
+            classify_worktree(&git, &wt(), &repo(), "main", 100, false, &default_noise()).unwrap();
+        assert_eq!(info.classification, Classification::LandedStale);
+        assert!(info.annotations.dirty);
+        assert_eq!(info.annotations.dirty_file_count, 1);
     }
 }

--- a/crates/git-tidy-core/src/gix_ops.rs
+++ b/crates/git-tidy-core/src/gix_ops.rs
@@ -253,9 +253,9 @@ impl GitOps for GixGitOps {
 
     fn worktree_branch(&self, worktree_path: &Path) -> GitResult<Option<String>> {
         let r = open_repo(worktree_path)?;
-        match r.head_ref() {
-            Ok(Some(reference)) => Ok(Some(reference.name().shorten().to_string())),
-            Ok(None) => Ok(None),
+        match r.head_name() {
+            Ok(Some(name)) => Ok(Some(name.shorten().to_string())),
+            Ok(None) => Ok(None), // genuinely detached HEAD
             Err(_) => Ok(None),
         }
     }

--- a/crates/git-tidy-core/src/output.rs
+++ b/crates/git-tidy-core/src/output.rs
@@ -16,8 +16,13 @@ pub fn write_summary_line(
 ) -> std::io::Result<()> {
     writeln!(
         out,
-        "\n{total} {item_noun} scanned: {} landed, {} content, {} partial, {} active, {} local",
-        counts.landed, counts.landed_content, counts.partial, counts.active, counts.local,
+        "\n{total} {item_noun} scanned: {} landed, {} stale, {} content, {} partial, {} active, {} local",
+        counts.landed,
+        counts.landed_stale,
+        counts.landed_content,
+        counts.partial,
+        counts.active,
+        counts.local,
     )
 }
 
@@ -94,6 +99,7 @@ mod tests {
     fn summary_line_format() {
         let counts = ScanCounts {
             landed: 3,
+            landed_stale: 0,
             landed_content: 1,
             partial: 0,
             active: 2,
@@ -104,7 +110,7 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
         assert_eq!(
             output,
-            "\n7 branches scanned: 3 landed, 1 content, 0 partial, 2 active, 1 local\n"
+            "\n7 branches scanned: 3 landed, 0 stale, 1 content, 0 partial, 2 active, 1 local\n"
         );
     }
 

--- a/crates/git-tidy-core/src/types.rs
+++ b/crates/git-tidy-core/src/types.rs
@@ -61,6 +61,9 @@ pub struct CleanResult<S> {
 pub enum Classification {
     /// Branch tip is a structural ancestor of the default branch (git merge-base proof).
     Landed,
+    /// Branch ref was deleted (typically after a PR merge) but worktree remains.
+    #[serde(rename = "landed-stale")]
+    LandedStale,
     /// All branch commits have matching commits on the default branch (heuristic content matching).
     #[serde(rename = "landed-content")]
     LandedByContent { matched: usize, total: usize },
@@ -80,6 +83,7 @@ impl ClassificationLabel for Classification {
     fn priority(&self) -> u8 {
         match self {
             Classification::Landed => 0,
+            Classification::LandedStale => 0,
             Classification::LandedByContent { .. } => 1,
             Classification::LandedPartial { .. } => 2,
             Classification::Active => 3,
@@ -90,6 +94,7 @@ impl ClassificationLabel for Classification {
     fn label(&self) -> &'static str {
         match self {
             Classification::Landed => "landed",
+            Classification::LandedStale => "landed-stale",
             Classification::LandedByContent { .. } => "landed-content",
             Classification::LandedPartial { .. } => "partial",
             Classification::Active => "active",
@@ -208,6 +213,7 @@ pub struct RepoGroup {
 
 define_counts!(ScanCounts, Classification, {
     Classification::Landed => landed,
+    Classification::LandedStale => landed_stale,
     Classification::LandedByContent { .. } => landed_content,
     Classification::LandedPartial { .. } => partial,
     Classification::Active => active,
@@ -292,6 +298,7 @@ mod tests {
     #[test]
     fn classification_label_trait() {
         assert_eq!(Classification::Landed.label(), "landed");
+        assert_eq!(Classification::LandedStale.label(), "landed-stale");
         assert_eq!(
             Classification::LandedByContent {
                 matched: 1,
@@ -312,6 +319,14 @@ mod tests {
         assert_eq!(Classification::Active.label(), "active");
         assert_eq!(Classification::Local.label(), "local");
         assert!(Classification::Landed.priority() < Classification::Active.priority());
+    }
+
+    #[test]
+    fn landed_stale_priority_same_as_landed() {
+        assert_eq!(
+            Classification::LandedStale.priority(),
+            Classification::Landed.priority()
+        );
     }
 
     #[test]

--- a/crates/git-tidy/src/explain.rs
+++ b/crates/git-tidy/src/explain.rs
@@ -20,6 +20,12 @@ static GLOSSARY: &[GlossaryEntry] = &[
         used_by: &["branches", "worktrees"],
     },
     GlossaryEntry {
+        term: "landed-stale",
+        section: "Branches & Worktrees",
+        description: "Branch ref was deleted (typically after a PR merge) but worktree remains. Safe to remove.",
+        used_by: &["worktrees"],
+    },
+    GlossaryEntry {
         term: "landed-content",
         section: "Branches & Worktrees",
         description: "All branch commits matched on the default branch by content (patch heuristic).",

--- a/crates/git-tidy/src/inprocess.rs
+++ b/crates/git-tidy/src/inprocess.rs
@@ -231,6 +231,7 @@ fn run_tool_scan(
             |r| {
                 vec![
                     ("landed", r.counts.landed),
+                    ("landed-stale", r.counts.landed_stale),
                     ("landed-content", r.counts.landed_content),
                     ("partial", r.counts.partial),
                     ("active", r.counts.active),
@@ -251,6 +252,7 @@ fn run_tool_scan(
             |r| {
                 vec![
                     ("landed", r.counts.landed),
+                    ("landed-stale", r.counts.landed_stale),
                     ("landed-content", r.counts.landed_content),
                     ("partial", r.counts.partial),
                     ("active", r.counts.active),

--- a/crates/git-worktree-tidy/src/clean.rs
+++ b/crates/git-worktree-tidy/src/clean.rs
@@ -120,10 +120,12 @@ fn should_clean(classification: &Classification, options: &CleanOptions) -> bool
         return matches!(classification, Classification::Landed);
     }
 
-    // Default: landed (structural) + landed-by-content
+    // Default: landed (structural) + landed-stale + landed-by-content
     matches!(
         classification,
-        Classification::Landed | Classification::LandedByContent { .. }
+        Classification::Landed
+            | Classification::LandedStale
+            | Classification::LandedByContent { .. }
     )
 }
 
@@ -173,9 +175,10 @@ fn remove_worktree(
         }
     }
 
-    // Delete branch if requested
+    // Delete branch if requested (skip for LandedStale — the branch ref is already gone)
     let mut branch_deleted = false;
     if opts.delete_branches
+        && !matches!(wt.classification, Classification::LandedStale)
         && let Some(branch) = &wt.branch
     {
         if git
@@ -545,6 +548,7 @@ mod tests {
         let options = default_options();
 
         assert!(should_clean(&Classification::Landed, &options));
+        assert!(should_clean(&Classification::LandedStale, &options));
         assert!(should_clean(
             &Classification::LandedByContent {
                 matched: 1,
@@ -572,6 +576,7 @@ mod tests {
         };
 
         assert!(should_clean(&Classification::Landed, &options));
+        assert!(should_clean(&Classification::LandedStale, &options));
         assert!(should_clean(&Classification::Active, &options));
         assert!(should_clean(&Classification::Local, &options));
     }
@@ -584,6 +589,7 @@ mod tests {
         };
 
         assert!(should_clean(&Classification::Landed, &options));
+        assert!(!should_clean(&Classification::LandedStale, &options));
         assert!(!should_clean(
             &Classification::LandedByContent {
                 matched: 1,
@@ -592,5 +598,24 @@ mod tests {
             &options
         ));
         assert!(!should_clean(&Classification::Active, &options));
+    }
+
+    #[test]
+    fn clean_landed_stale_skips_branch_delete() {
+        let git = MockGitBuilder::new().build();
+        let wt = make_worktree("wt-stale", "feature/stale", Classification::LandedStale);
+        let scan = make_scan(vec![wt]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            delete_branches: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+
+        assert_eq!(result.succeeded.len(), 1);
+        assert!(!result.succeeded[0].branch_deleted);
+        // No branch_delete calls — the branch ref is already gone
+        assert!(git.branch_delete_calls().is_empty());
     }
 }

--- a/crates/git-worktree-tidy/src/output.rs
+++ b/crates/git-worktree-tidy/src/output.rs
@@ -223,10 +223,8 @@ mod tests {
             total_scanned: 2,
             counts: ScanCounts {
                 landed: 1,
-                landed_content: 0,
-                partial: 0,
                 active: 1,
-                local: 0,
+                ..Default::default()
             },
             warnings: vec![],
         }
@@ -244,10 +242,9 @@ mod tests {
         assert!(output.contains("active"));
         assert!(output.contains("Backend-parallel"));
         assert!(output.contains("Backend-caps"));
-        assert!(
-            output
-                .contains("2 worktrees scanned: 1 landed, 0 content, 0 partial, 1 active, 0 local")
-        );
+        assert!(output.contains(
+            "2 worktrees scanned: 1 landed, 0 stale, 0 content, 0 partial, 1 active, 0 local"
+        ));
     }
 
     #[test]

--- a/crates/git-worktree-tidy/tests/integration_git.rs
+++ b/crates/git-worktree-tidy/tests/integration_git.rs
@@ -1,7 +1,12 @@
 mod common;
 
+use std::collections::BTreeMap;
+
 use common::TestRepo;
 use git_tidy_core::git::{GitOps, RealGit};
+use git_tidy_core::progress::Progress;
+use git_tidy_core::types::Classification;
+use git_worktree_tidy::discovery::DiscoveredWorktree;
 
 #[test]
 fn diff_commit_handles_root_commit() {
@@ -114,4 +119,61 @@ fn branch_delete_safe_refuses_unmerged_branch() {
         result.is_err(),
         "branch -d should refuse to delete unmerged branch"
     );
+}
+
+#[test]
+fn worktree_with_deleted_branch_classifies_as_landed_stale() {
+    let test = TestRepo::new();
+    let git = RealGit;
+
+    // Create a worktree on a feature branch
+    let wt_path = test.add_worktree("main-repo-stale", "feature/stale-branch");
+
+    // Merge the branch into main, then delete the branch ref directly
+    // (git branch -d won't delete a branch checked out in a worktree)
+    common::git(&test.main_repo, &["merge", "feature/stale-branch"]);
+    common::git(
+        &test.main_repo,
+        &["update-ref", "-d", "refs/heads/feature/stale-branch"],
+    );
+
+    // Verify the branch ref is gone
+    assert!(
+        !git.rev_parse_verify(&test.main_repo, "refs/heads/feature/stale-branch")
+            .unwrap(),
+        "branch ref should be deleted"
+    );
+
+    // Verify the worktree still reports the branch name
+    let branch = git.worktree_branch(&wt_path).unwrap();
+    assert_eq!(
+        branch.as_deref(),
+        Some("feature/stale-branch"),
+        "worktree HEAD should still reference the deleted branch"
+    );
+
+    // Scan using run_scan_repos and verify LandedStale classification
+    let mut groups = BTreeMap::new();
+    groups.insert(
+        test.main_repo.clone(),
+        vec![DiscoveredWorktree {
+            path: wt_path.clone(),
+            parent_repo: test.main_repo.clone(),
+        }],
+    );
+
+    let progress = Progress::disabled();
+    let result =
+        git_worktree_tidy::scan::run_scan_repos(&git, groups, 100, false, &[], &progress).unwrap();
+
+    assert_eq!(result.total_scanned, 1);
+    assert_eq!(result.repos.len(), 1);
+    let wt_info = &result.repos[0].worktrees[0];
+    assert_eq!(
+        wt_info.classification,
+        Classification::LandedStale,
+        "worktree with deleted branch ref should be classified as LandedStale"
+    );
+    assert_eq!(wt_info.branch.as_deref(), Some("feature/stale-branch"));
+    assert_eq!(result.counts.landed_stale, 1);
 }


### PR DESCRIPTION
## Summary

- Add `LandedStale` classification for worktrees whose branch ref was deleted (typically after a PR merge), making previously-invisible stale worktrees discoverable and cleanable
- Fix `GixGitOps::worktree_branch()` to use `head_name()` instead of `head_ref()` so it reads the symbolic ref name even when the target ref doesn't exist
- Detect dangling branch refs early in `classify_worktree()` before attempting classification that would fail

Closes #104

## Test plan

- [x] Unit test: `classify_worktree` with mock returning branch name but `rev_parse_verify("refs/heads/...")` returning `false` yields `LandedStale`
- [x] Unit test: Same scenario with dirty files yields `LandedStale` with `dirty` annotation
- [x] Unit test: `should_clean` returns `true` for `LandedStale` with default options (worktree-tidy)
- [x] Unit test: `should_clean` returns `false` for `LandedStale` with strict mode
- [x] Unit test: Clean with `LandedStale` worktree and `delete_branches: true` makes no `branch_delete` calls
- [x] Unit test: Summary line includes "stale" count
- [x] Unit test: `LandedStale` priority equals `Landed` priority (both 0)
- [x] Integration test: Real git repo with linked worktree, branch merged to main, branch ref deleted via `git update-ref -d`, scan classifies worktree as `LandedStale`