### PR TITLE
Optimize find_large_blobs to scan tip trees instead of commit history

### DIFF
--- a/crates/git-lfs-tidy/README.md
+++ b/crates/git-lfs-tidy/README.md
@@ -24,7 +24,7 @@ git-lfs-tidy scan ~/Developer --porcelain          # machine-readable tab-delimi
 
 # Custom thresholds
 git-lfs-tidy scan ~/Developer --size-threshold 500KB  # flag files above 500KB (default: 1MB)
-git-lfs-tidy scan ~/Developer --depth 500              # scan last 500 commits (default: 1000)
+git-lfs-tidy scan ~/Developer --depth 500              # scan up to 500 branch/tag tip trees (default: 1000)
 
 # Clean up orphaned LFS objects
 git-lfs-tidy clean ~/Developer --prune             # prune orphaned LFS objects
@@ -38,7 +38,7 @@ git-lfs-tidy clean ~/Developer --prune --yes       # skip confirmation
 2. If `git lfs` is installed:
    - Lists LFS-tracked files (`git lfs ls-files`) and classifies them as **healthy** or **missing**.
    - Checks for prunable objects (`git lfs prune --dry-run`) and reports **orphaned** count.
-3. Scans commit history for large blobs (`git rev-list` + `git cat-file --batch-check`) above the size threshold and flags **untracked** files not in LFS.
+3. Scans branch/tag tip trees for large blobs (`git rev-list` + `git ls-tree`) above the size threshold and flags **untracked** files not in LFS.
 4. When `git lfs` is not installed, gracefully degrades to only scanning for large untracked blobs.
 
 ## Part of git-tidy

--- a/crates/git-lfs-tidy/src/cli.rs
+++ b/crates/git-lfs-tidy/src/cli.rs
@@ -44,7 +44,7 @@ pub enum Command {
         #[arg(long, default_value = "1MB")]
         size_threshold: String,
 
-        /// Maximum number of commits to scan for large blobs
+        /// Maximum number of branch/tag tip trees to scan for large blobs
         #[arg(long, default_value_t = 1000)]
         depth: usize,
     },
@@ -70,7 +70,7 @@ pub enum Command {
         #[arg(long, default_value = "1MB")]
         size_threshold: String,
 
-        /// Maximum number of commits to scan for large blobs
+        /// Maximum number of branch/tag tip trees to scan for large blobs
         #[arg(long, default_value_t = 1000)]
         depth: usize,
 

--- a/crates/git-tidy-core/src/git.rs
+++ b/crates/git-tidy-core/src/git.rs
@@ -222,7 +222,7 @@ pub trait GitOps: Send + Sync {
     /// Remove orphaned LFS objects.
     fn lfs_prune(&self, repo: &Path) -> GitResult<()>;
 
-    /// Find blobs above `threshold` bytes in the last `depth` commits.
+    /// Find blobs above `threshold` bytes across up to `depth` branch/tag tip trees.
     /// Returns `(hash, size, path)` tuples.
     fn find_large_blobs(
         &self,
@@ -957,96 +957,58 @@ impl GitOps for RealGit {
         threshold: u64,
         depth: usize,
     ) -> GitResult<Vec<(String, u64, String)>> {
-        use std::collections::HashMap;
-        use std::io::{BufRead, BufReader, Write as IoWrite};
-        use std::process::Stdio;
+        use std::collections::HashSet;
 
-        // Phase 1: Get all objects with paths
-        let depth_str = depth.to_string();
-        let output = Self::run(
-            repo,
-            &["rev-list", "--objects", "--all", "--max-count", &depth_str],
-        )?;
-        let rev_list_text = String::from_utf8_lossy(&output.stdout);
+        // Get unique root tree hashes from all ref tips.
+        // Do NOT use --max-count here — it changes --no-walk semantics.
+        let output = Self::run(repo, &["rev-list", "--all", "--no-walk", "--format=%T"])?;
+        let text = String::from_utf8_lossy(&output.stdout);
 
-        // Build hash-to-path mapping and collect blob candidates
-        let mut hash_to_path: HashMap<String, String> = HashMap::new();
-        let mut all_hashes: Vec<String> = Vec::new();
+        let unique_trees: HashSet<&str> = text
+            .lines()
+            .filter(|l| !l.starts_with("commit ") && !l.is_empty())
+            .collect();
 
-        for line in rev_list_text.lines() {
-            if line.is_empty() {
-                continue;
-            }
-            if let Some((hash, path)) = line.split_once(' ')
-                && !path.is_empty()
-            {
-                hash_to_path.insert(hash.to_string(), path.to_string());
-                all_hashes.push(hash.to_string());
-            }
-        }
-
-        if all_hashes.is_empty() {
+        if unique_trees.is_empty() {
             return Ok(Vec::new());
         }
 
-        // Phase 2: Feed hashes to cat-file --batch-check to get sizes
-        let mut child = Command::new("git")
-            .arg("-C")
-            .arg(repo)
-            .args(["cat-file", "--batch-check"])
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .spawn()
-            .map_err(|e| Error::GitCommand {
-                command: "git cat-file --batch-check".to_string(),
-                message: e.to_string(),
-            })?;
+        // For each unique tree (up to depth), scan with ls-tree -r -l.
+        let mut seen_hashes: HashSet<String> = HashSet::new();
+        let mut results: Vec<(String, u64, String)> = Vec::new();
 
-        // Write all hashes to stdin, then drop to close the pipe (signals EOF).
-        {
-            let mut stdin = child.stdin.take().ok_or_else(|| Error::GitCommand {
-                command: "git cat-file --batch-check".to_string(),
-                message: "failed to open stdin".to_string(),
-            })?;
-            for hash in &all_hashes {
-                writeln!(stdin, "{hash}").map_err(|e| Error::GitCommand {
-                    command: "git cat-file --batch-check".to_string(),
-                    message: e.to_string(),
-                })?;
+        for tree in unique_trees.iter().take(depth) {
+            let output = Self::run(repo, &["ls-tree", "-r", "-l", tree])?;
+            let tree_text = String::from_utf8_lossy(&output.stdout);
+
+            for line in tree_text.lines() {
+                // Format: "<mode> <type> <hash> <size>\t<path>"
+                let Some((metadata, path)) = line.split_once('\t') else {
+                    continue;
+                };
+                let parts: Vec<&str> = metadata.split_whitespace().collect();
+                if parts.len() != 4 {
+                    continue;
+                }
+                if parts[1] != "blob" {
+                    continue;
+                }
+                let Ok(size) = parts[3].parse::<u64>() else {
+                    continue;
+                };
+                if size < threshold {
+                    continue;
+                }
+                let hash = parts[2];
+                if !seen_hashes.insert(hash.to_string()) {
+                    continue;
+                }
+                results.push((hash.to_string(), size, path.to_string()));
             }
         }
 
-        // Read results: "<hash> <type> <size>" per line
-        let stdout = child.stdout.take().ok_or_else(|| Error::GitCommand {
-            command: "git cat-file --batch-check".to_string(),
-            message: "failed to capture stdout".to_string(),
-        })?;
-        let reader = BufReader::new(stdout);
-
-        let mut result = Vec::new();
-        for line in reader.lines() {
-            let line = line.map_err(|e| Error::GitCommand {
-                command: "git cat-file --batch-check".to_string(),
-                message: e.to_string(),
-            })?;
-            // Format: "<hash> blob <size>" or "<hash> tree <size>" etc.
-            let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.len() == 3
-                && parts[1] == "blob"
-                && let Ok(size) = parts[2].parse::<u64>()
-                && size >= threshold
-                && let Some(path) = hash_to_path.get(parts[0])
-            {
-                result.push((parts[0].to_string(), size, path.clone()));
-            }
-        }
-
-        let _ = child.wait();
-
-        // Sort by size descending for readability
-        result.sort_by(|a, b| b.1.cmp(&a.1));
-        Ok(result)
+        results.sort_by(|a, b| b.1.cmp(&a.1));
+        Ok(results)
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace the two-phase `rev-list --objects` + `cat-file --batch-check` approach in `find_large_blobs()` with `git rev-list --no-walk --format=%T` + `git ls-tree -r -l` per unique tip tree, reducing objects processed from 100K+ to ~17 unique trees on this repo
- Update `--depth` semantics from "commits to scan" to "branch/tag tip trees to scan" across trait docs, CLI help text, and README
- Intentional semantic change: scan current tip trees (what LFS tracking applies to) instead of walking commit history (which requires filter-repo/BFG for cleanup)

Closes #110

## Test plan

- [x] `cargo test --workspace` — all existing tests pass unchanged
- [ ] Manual: `git-lfs-tidy scan ~/Developer` and compare output/timing against old implementation
- [ ] Edge case: test on an empty repo (no commits) — should return no results without errors