### PR TITLE
Add column headers and dynamic widths to scan output

### DIFF
--- a/crates/git-branch-tidy/src/output.rs
+++ b/crates/git-branch-tidy/src/output.rs
@@ -5,6 +5,70 @@ use git_tidy_core::types::{Classification, ClassificationLabel};
 
 use crate::types::{BranchInfo, BranchScanResult};
 
+const HEADER_STATUS: &str = "STATUS";
+const HEADER_BRANCH: &str = "BRANCH";
+const HEADER_RATIO: &str = "RATIO";
+const HEADER_AHEAD_BEHIND: &str = "AHEAD/BEHIND";
+
+struct ColumnWidths {
+    status: usize,
+    name: usize,
+    ratio: usize,
+    ahead_behind: usize,
+    has_ratio: bool,
+    has_ahead_behind: bool,
+}
+
+fn compute_column_widths(branches: &[BranchInfo]) -> ColumnWidths {
+    let mut max_status = HEADER_STATUS.len();
+    let mut max_name = HEADER_BRANCH.len();
+    let mut max_ratio = HEADER_RATIO.len();
+    let mut max_ab = HEADER_AHEAD_BEHIND.len();
+    let mut has_ratio = false;
+    let mut has_ahead_behind = false;
+
+    for b in branches {
+        max_status = max_status.max(b.classification.label().len());
+        // +2 for "* " or "  " prefix
+        max_name = max_name.max(b.name.len() + 2);
+        let ratio = shared::format_landed_ratio(&b.classification);
+        let ab = shared::format_ahead_behind(b.ahead, b.behind);
+        if !ratio.is_empty() {
+            has_ratio = true;
+            max_ratio = max_ratio.max(ratio.len());
+        }
+        if !ab.is_empty() {
+            has_ahead_behind = true;
+            max_ab = max_ab.max(ab.len());
+        }
+    }
+
+    ColumnWidths {
+        status: max_status,
+        name: max_name,
+        ratio: max_ratio,
+        ahead_behind: max_ab,
+        has_ratio,
+        has_ahead_behind,
+    }
+}
+
+fn write_header(out: &mut dyn Write, widths: &ColumnWidths) -> std::io::Result<()> {
+    let sw = widths.status;
+    let nw = widths.name;
+    let mut line = format!("  {HEADER_STATUS:<sw$} {HEADER_BRANCH:<nw$}");
+    if widths.has_ratio {
+        let rw = widths.ratio;
+        line.push_str(&format!(" {HEADER_RATIO:<rw$}"));
+    }
+    if widths.has_ahead_behind {
+        let aw = widths.ahead_behind;
+        line.push_str(&format!(" {HEADER_AHEAD_BEHIND:<aw$}"));
+    }
+    let trimmed = line.trim_end();
+    writeln!(out, "{trimmed}")
+}
+
 /// Write human-readable scan output.
 pub fn write_human(out: &mut dyn Write, result: &BranchScanResult) -> std::io::Result<()> {
     shared::write_warnings(out, &result.warnings)?;
@@ -12,8 +76,11 @@ pub fn write_human(out: &mut dyn Write, result: &BranchScanResult) -> std::io::R
     for group in &result.repos {
         writeln!(out, "\n{} ({} branches)", group.name, group.branches.len())?;
 
+        let widths = compute_column_widths(&group.branches);
+        write_header(out, &widths)?;
+
         for branch in &group.branches {
-            write_branch_line(out, branch)?;
+            write_branch_line(out, branch, &widths)?;
 
             // For partial landings, list unmatched commits
             if let Classification::LandedPartial { unmatched, .. } = &branch.classification {
@@ -34,8 +101,12 @@ pub fn write_human(out: &mut dyn Write, result: &BranchScanResult) -> std::io::R
     Ok(())
 }
 
-fn write_branch_line(out: &mut dyn Write, branch: &BranchInfo) -> std::io::Result<()> {
-    let label = format!("{:<8}", branch.classification.label());
+fn write_branch_line(
+    out: &mut dyn Write,
+    branch: &BranchInfo,
+    widths: &ColumnWidths,
+) -> std::io::Result<()> {
+    let label = branch.classification.label();
 
     let name = if branch.is_current {
         format!("* {}", branch.name)
@@ -56,17 +127,22 @@ fn write_branch_line(out: &mut dyn Write, branch: &BranchInfo) -> std::io::Resul
     }
     let annotations = shared::format_annotations(&ann_strs);
 
-    write!(out, "  {label} {name:<34}")?;
-    if !ratio.is_empty() {
-        write!(out, " {ratio:<8}")?;
+    let sw = widths.status;
+    let nw = widths.name;
+    let mut line = format!("  {label:<sw$} {name:<nw$}");
+    if widths.has_ratio {
+        let rw = widths.ratio;
+        line.push_str(&format!(" {ratio:<rw$}"));
     }
-    if !ahead_behind.is_empty() {
-        write!(out, " {ahead_behind:<10}")?;
+    if widths.has_ahead_behind {
+        let aw = widths.ahead_behind;
+        line.push_str(&format!(" {ahead_behind:<aw$}"));
     }
     if !annotations.is_empty() {
-        write!(out, "  {annotations}")?;
+        line.push_str(&format!("  {annotations}"));
     }
-    writeln!(out)?;
+    let trimmed = line.trim_end();
+    writeln!(out, "{trimmed}")?;
 
     Ok(())
 }
@@ -162,6 +238,9 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
 
         assert!(output.contains("Backend (2 branches)"));
+        // Header row
+        assert!(output.contains("STATUS"));
+        assert!(output.contains("BRANCH"));
         assert!(output.contains("landed"));
         assert!(output.contains("active"));
         assert!(output.contains("fix/skip-db-init"));

--- a/crates/git-config-tidy/src/output.rs
+++ b/crates/git-config-tidy/src/output.rs
@@ -2,7 +2,52 @@ use std::io::Write;
 
 use git_tidy_core::output as shared;
 
-use crate::types::{ConfigLintResult, JsonConfigIssue};
+use crate::types::{ConfigIssue, ConfigLintResult, JsonConfigIssue};
+
+const HEADER_SEVERITY: &str = "SEVERITY";
+const HEADER_KIND: &str = "KIND";
+const HEADER_SETTING: &str = "SETTING";
+const HEADER_MESSAGE: &str = "MESSAGE";
+
+struct ColumnWidths {
+    severity: usize,
+    kind: usize,
+    setting: usize,
+    message: usize,
+}
+
+fn compute_column_widths(issues: &[ConfigIssue]) -> ColumnWidths {
+    let mut max_severity = HEADER_SEVERITY.len();
+    let mut max_kind = HEADER_KIND.len();
+    let mut max_setting = HEADER_SETTING.len();
+    let mut max_message = HEADER_MESSAGE.len();
+
+    for i in issues {
+        max_severity = max_severity.max(i.severity.label().len());
+        max_kind = max_kind.max(i.kind.label().len());
+        // key=value combined
+        max_setting = max_setting.max(i.key.len() + 1 + i.value.len());
+        max_message = max_message.max(i.message.len());
+    }
+
+    ColumnWidths {
+        severity: max_severity,
+        kind: max_kind,
+        setting: max_setting,
+        message: max_message,
+    }
+}
+
+fn write_header(out: &mut dyn Write, widths: &ColumnWidths) -> std::io::Result<()> {
+    let sw = widths.severity;
+    let kw = widths.kind;
+    let stw = widths.setting;
+    let line = format!(
+        "  {HEADER_SEVERITY:<sw$} {HEADER_KIND:<kw$} {HEADER_SETTING:<stw$} {HEADER_MESSAGE}"
+    );
+    let trimmed = line.trim_end();
+    writeln!(out, "{trimmed}")
+}
 
 /// Write human-readable lint output.
 pub fn write_human(out: &mut dyn Write, result: &ConfigLintResult) -> std::io::Result<()> {
@@ -16,16 +61,23 @@ pub fn write_human(out: &mut dyn Write, result: &ConfigLintResult) -> std::io::R
         };
         writeln!(out, "\n{} ({} {noun})", group.name, group.issues.len())?;
 
+        let widths = compute_column_widths(&group.issues);
+        write_header(out, &widths)?;
+
         for issue in &group.issues {
-            writeln!(
-                out,
-                "  {:<8} {:<26} {}={} {}",
+            let setting = format!("{}={}", issue.key, issue.value);
+
+            let sw = widths.severity;
+            let kw = widths.kind;
+            let stw = widths.setting;
+            let line = format!(
+                "  {:<sw$} {:<kw$} {setting:<stw$} {}",
                 issue.severity.label(),
                 issue.kind.label(),
-                issue.key,
-                issue.value,
                 issue.message,
-            )?;
+            );
+            let trimmed = line.trim_end();
+            writeln!(out, "{trimmed}")?;
         }
     }
 
@@ -126,6 +178,11 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
 
         assert!(output.contains("backend (2 issues)"));
+        // Header row
+        assert!(output.contains("SEVERITY"));
+        assert!(output.contains("KIND"));
+        assert!(output.contains("SETTING"));
+        assert!(output.contains("MESSAGE"));
         assert!(output.contains("warning"));
         assert!(output.contains("orphaned_branch_config"));
         assert!(output.contains("branch.old-feature.remote=origin"));

--- a/crates/git-lfs-tidy/src/output.rs
+++ b/crates/git-lfs-tidy/src/output.rs
@@ -2,7 +2,12 @@ use std::io::Write;
 
 use git_tidy_core::output as shared;
 
-use crate::types::{JsonLfsItem, LfsScanResult};
+use crate::types::{JsonLfsItem, LfsInfo, LfsScanResult};
+
+const HEADER_STATUS: &str = "STATUS";
+const HEADER_PATH: &str = "PATH";
+const HEADER_SIZE: &str = "SIZE";
+const HEADER_OID: &str = "OID";
 
 /// Format bytes into a human-readable string.
 pub fn format_bytes(bytes: u64) -> String {
@@ -15,6 +20,48 @@ pub fn format_bytes(bytes: u64) -> String {
     } else {
         format!("{bytes} B")
     }
+}
+
+struct ColumnWidths {
+    status: usize,
+    path: usize,
+    size: usize,
+    oid: usize,
+}
+
+fn oid_short(oid: &str) -> &str {
+    if oid.len() >= 7 { &oid[..7] } else { oid }
+}
+
+fn compute_column_widths(items: &[LfsInfo]) -> ColumnWidths {
+    let mut max_status = HEADER_STATUS.len();
+    let mut max_path = HEADER_PATH.len();
+    let mut max_size = HEADER_SIZE.len();
+    let mut max_oid = HEADER_OID.len();
+
+    for i in items {
+        max_status = max_status.max(i.classification.label().len());
+        max_path = max_path.max(i.path.len());
+        max_size = max_size.max(i.size_bytes.map(format_bytes).unwrap_or_default().len());
+        max_oid = max_oid.max(oid_short(&i.oid).len());
+    }
+
+    ColumnWidths {
+        status: max_status,
+        path: max_path,
+        size: max_size,
+        oid: max_oid,
+    }
+}
+
+fn write_header(out: &mut dyn Write, widths: &ColumnWidths) -> std::io::Result<()> {
+    let sw = widths.status;
+    let pw = widths.path;
+    let szw = widths.size;
+    let line =
+        format!("  {HEADER_STATUS:<sw$} {HEADER_PATH:<pw$} {HEADER_SIZE:<szw$} {HEADER_OID}");
+    let trimmed = line.trim_end();
+    writeln!(out, "{trimmed}")
 }
 
 /// Write human-readable scan output.
@@ -33,16 +80,20 @@ pub fn write_human(out: &mut dyn Write, result: &LfsScanResult) -> std::io::Resu
             writeln!(out, "  LFS patterns: {}", group.track_patterns.join(", "))?;
         }
 
-        for item in &group.items {
-            let label = format!("{:<11}", item.classification.label());
-            let size = item.size_bytes.map(format_bytes).unwrap_or_default();
-            let oid_short = if item.oid.len() >= 7 {
-                &item.oid[..7]
-            } else {
-                &item.oid
-            };
+        let widths = compute_column_widths(&group.items);
+        write_header(out, &widths)?;
 
-            writeln!(out, "  {label} {:<40} {:<10} {oid_short}", item.path, size)?;
+        for item in &group.items {
+            let label = item.classification.label();
+            let size = item.size_bytes.map(format_bytes).unwrap_or_default();
+            let oid_s = oid_short(&item.oid);
+
+            let sw = widths.status;
+            let pw = widths.path;
+            let szw = widths.size;
+            let line = format!("  {label:<sw$} {:<pw$} {size:<szw$} {oid_s}", item.path);
+            let trimmed = line.trim_end();
+            writeln!(out, "{trimmed}")?;
         }
 
         // Hints for actionable items
@@ -206,6 +257,11 @@ mod tests {
 
         assert!(output.contains("backend (3 items)"));
         assert!(output.contains("LFS patterns: *.bin, *.zip"));
+        // Header row
+        assert!(output.contains("STATUS"));
+        assert!(output.contains("PATH"));
+        assert!(output.contains("SIZE"));
+        assert!(output.contains("OID"));
         assert!(output.contains("untracked"));
         assert!(output.contains("missing"));
         assert!(output.contains("healthy"));

--- a/crates/git-remote-tidy/src/output.rs
+++ b/crates/git-remote-tidy/src/output.rs
@@ -3,7 +3,72 @@ use std::io::Write;
 use git_tidy_core::output as shared;
 use git_tidy_core::types::ClassificationLabel;
 
-use crate::types::RemoteScanResult;
+use crate::types::{RemoteInfo, RemoteScanResult};
+
+const HEADER_STATUS: &str = "STATUS";
+const HEADER_NAME: &str = "NAME";
+const HEADER_URL: &str = "URL";
+const HEADER_TRACKING: &str = "TRACKING";
+
+struct ColumnWidths {
+    status: usize,
+    name: usize,
+    url: usize,
+    tracking: usize,
+    has_tracking: bool,
+}
+
+fn format_tracking(remote: &RemoteInfo) -> String {
+    if remote.tracking_count > 0 {
+        let branch_noun = if remote.tracking_count == 1 {
+            "tracking branch"
+        } else {
+            "tracking branches"
+        };
+        format!("({} {branch_noun})", remote.tracking_count)
+    } else {
+        String::new()
+    }
+}
+
+fn compute_column_widths(remotes: &[RemoteInfo]) -> ColumnWidths {
+    let mut max_status = HEADER_STATUS.len();
+    let mut max_name = HEADER_NAME.len();
+    let mut max_url = HEADER_URL.len();
+    let mut max_tracking = HEADER_TRACKING.len();
+    let mut has_tracking = false;
+
+    for r in remotes {
+        max_status = max_status.max(r.classification.label().len());
+        max_name = max_name.max(r.name.len());
+        max_url = max_url.max(r.url.as_deref().unwrap_or("").len());
+        let tracking = format_tracking(r);
+        if !tracking.is_empty() {
+            has_tracking = true;
+            max_tracking = max_tracking.max(tracking.len());
+        }
+    }
+
+    ColumnWidths {
+        status: max_status,
+        name: max_name,
+        url: max_url,
+        tracking: max_tracking,
+        has_tracking,
+    }
+}
+
+fn write_header(out: &mut dyn Write, widths: &ColumnWidths) -> std::io::Result<()> {
+    let sw = widths.status;
+    let nw = widths.name;
+    let uw = widths.url;
+    let mut line = format!("  {HEADER_STATUS:<sw$} {HEADER_NAME:<nw$} {HEADER_URL:<uw$}");
+    if widths.has_tracking {
+        line.push_str(&format!(" {HEADER_TRACKING}"));
+    }
+    let trimmed = line.trim_end();
+    writeln!(out, "{trimmed}")
+}
 
 /// Write human-readable scan output.
 pub fn write_human(out: &mut dyn Write, result: &RemoteScanResult) -> std::io::Result<()> {
@@ -17,21 +82,24 @@ pub fn write_human(out: &mut dyn Write, result: &RemoteScanResult) -> std::io::R
         };
         writeln!(out, "\n{} ({} {noun})", group.name, group.remotes.len())?;
 
-        for remote in &group.remotes {
-            let label = format!("{:<13}", remote.classification.label());
-            let url = remote.url.as_deref().unwrap_or("");
-            let tracking = if remote.tracking_count > 0 {
-                let branch_noun = if remote.tracking_count == 1 {
-                    "tracking branch"
-                } else {
-                    "tracking branches"
-                };
-                format!("({} {branch_noun})", remote.tracking_count)
-            } else {
-                String::new()
-            };
+        let widths = compute_column_widths(&group.remotes);
+        write_header(out, &widths)?;
 
-            writeln!(out, "  {label} {:<12} {:<50} {tracking}", remote.name, url,)?;
+        for remote in &group.remotes {
+            let label = remote.classification.label();
+            let url = remote.url.as_deref().unwrap_or("");
+            let tracking = format_tracking(remote);
+
+            let sw = widths.status;
+            let nw = widths.name;
+            let uw = widths.url;
+            let mut line = format!("  {label:<sw$} {:<nw$} {url:<uw$}", remote.name);
+            if widths.has_tracking {
+                let tw = widths.tracking;
+                line.push_str(&format!(" {tracking:<tw$}"));
+            }
+            let trimmed = line.trim_end();
+            writeln!(out, "{trimmed}")?;
         }
     }
 
@@ -125,6 +193,11 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
 
         assert!(output.contains("backend (2 remotes)"));
+        // Header row
+        assert!(output.contains("STATUS"));
+        assert!(output.contains("NAME"));
+        assert!(output.contains("URL"));
+        assert!(output.contains("TRACKING"));
         assert!(output.contains("unreachable"));
         assert!(output.contains("active"));
         assert!(output.contains("origin"));

--- a/crates/git-repo-tidy/src/output.rs
+++ b/crates/git-repo-tidy/src/output.rs
@@ -2,7 +2,51 @@ use std::io::Write;
 
 use git_tidy_core::output as shared;
 
-use crate::types::{JsonRepo, RepoScanResult, format_disk_size, format_last_commit_age};
+use crate::types::{JsonRepo, RepoInfo, RepoScanResult, format_disk_size, format_last_commit_age};
+
+const HEADER_STATUS: &str = "STATUS";
+const HEADER_NAME: &str = "NAME";
+const HEADER_AGE: &str = "AGE";
+const HEADER_SIZE: &str = "SIZE";
+
+struct ColumnWidths {
+    status: usize,
+    name: usize,
+    age: usize,
+    size: usize,
+}
+
+fn compute_column_widths(repos: &[RepoInfo]) -> ColumnWidths {
+    let mut max_status = HEADER_STATUS.len();
+    let mut max_name = HEADER_NAME.len();
+    let mut max_age = HEADER_AGE.len();
+    let mut max_size = HEADER_SIZE.len();
+
+    for r in repos {
+        max_status = max_status.max(r.classification.label().len());
+        max_name = max_name.max(r.name.len());
+        max_age = max_age.max(format_last_commit_age(r.last_commit_age_days).len());
+        max_size = max_size.max(format_disk_size(r.disk_usage_bytes).len());
+    }
+
+    ColumnWidths {
+        status: max_status,
+        name: max_name,
+        age: max_age,
+        size: max_size,
+    }
+}
+
+fn write_header(out: &mut dyn Write, widths: &ColumnWidths) -> std::io::Result<()> {
+    let sw = widths.status;
+    let nw = widths.name;
+    let aw = widths.age;
+    let szw = widths.size;
+    let line =
+        format!("  {HEADER_STATUS:<sw$} {HEADER_NAME:<nw$} {HEADER_AGE:<aw$} {HEADER_SIZE:<szw$}");
+    let trimmed = line.trim_end();
+    writeln!(out, "{trimmed}")
+}
 
 /// Write human-readable scan output.
 pub fn write_human(out: &mut dyn Write, result: &RepoScanResult) -> std::io::Result<()> {
@@ -10,29 +54,36 @@ pub fn write_human(out: &mut dyn Write, result: &RepoScanResult) -> std::io::Res
 
     if !result.repos.is_empty() {
         writeln!(out)?;
-    }
+        let widths = compute_column_widths(&result.repos);
+        write_header(out, &widths)?;
 
-    for repo in &result.repos {
-        let label = format!("{:<10}", repo.classification.label());
-        let age = format_last_commit_age(repo.last_commit_age_days);
-        let size = format_disk_size(repo.disk_usage_bytes);
+        for repo in &result.repos {
+            let label = repo.classification.label();
+            let age = format_last_commit_age(repo.last_commit_age_days);
+            let size = format_disk_size(repo.disk_usage_bytes);
 
-        let dirty_note = if repo.is_dirty {
-            let noun = if repo.dirty_file_count == 1 {
-                "file"
+            let dirty_note = if repo.is_dirty {
+                let noun = if repo.dirty_file_count == 1 {
+                    "file"
+                } else {
+                    "files"
+                };
+                format!("  dirty ({} {noun})", repo.dirty_file_count)
             } else {
-                "files"
+                String::new()
             };
-            format!("  dirty ({} {noun})", repo.dirty_file_count)
-        } else {
-            String::new()
-        };
 
-        writeln!(
-            out,
-            "  {label} {:<25} {:<20} {:<10}{dirty_note}",
-            repo.name, age, size,
-        )?;
+            let sw = widths.status;
+            let nw = widths.name;
+            let aw = widths.age;
+            let szw = widths.size;
+            let line = format!(
+                "  {label:<sw$} {:<nw$} {age:<aw$} {size:<szw$}{dirty_note}",
+                repo.name,
+            );
+            let trimmed = line.trim_end();
+            writeln!(out, "{trimmed}")?;
+        }
     }
 
     write_summary(out, result)?;
@@ -166,6 +217,11 @@ mod tests {
         write_human(&mut buf, &result).unwrap();
         let output = String::from_utf8(buf).unwrap();
 
+        // Header row
+        assert!(output.contains("STATUS"));
+        assert!(output.contains("NAME"));
+        assert!(output.contains("AGE"));
+        assert!(output.contains("SIZE"));
         assert!(output.contains("stale"));
         assert!(output.contains("old-project"));
         assert!(output.contains("549 days ago"));

--- a/crates/git-stash-tidy/src/output.rs
+++ b/crates/git-stash-tidy/src/output.rs
@@ -3,7 +3,59 @@ use std::io::Write;
 use git_tidy_core::output as shared;
 use git_tidy_core::types::ClassificationLabel;
 
-use crate::types::StashScanResult;
+use crate::types::{StashInfo, StashScanResult};
+
+const HEADER_STATUS: &str = "STATUS";
+const HEADER_REF: &str = "REF";
+const HEADER_MESSAGE: &str = "MESSAGE";
+const HEADER_AGE: &str = "AGE";
+
+struct ColumnWidths {
+    status: usize,
+    stash_ref: usize,
+    message: usize,
+    age: usize,
+}
+
+fn format_age(age_days: Option<u64>) -> String {
+    match age_days {
+        Some(0) => "today".to_string(),
+        Some(1) => "1 day ago".to_string(),
+        Some(d) => format!("{d} days ago"),
+        None => String::new(),
+    }
+}
+
+fn compute_column_widths(stashes: &[StashInfo]) -> ColumnWidths {
+    let mut max_status = HEADER_STATUS.len();
+    let mut max_ref = HEADER_REF.len();
+    let mut max_msg = HEADER_MESSAGE.len();
+    let mut max_age = HEADER_AGE.len();
+
+    for s in stashes {
+        max_status = max_status.max(s.classification.label().len());
+        max_ref = max_ref.max(s.stash_ref.len());
+        max_msg = max_msg.max(s.message.len());
+        max_age = max_age.max(format_age(s.age_days).len());
+    }
+
+    ColumnWidths {
+        status: max_status,
+        stash_ref: max_ref,
+        message: max_msg,
+        age: max_age,
+    }
+}
+
+fn write_header(out: &mut dyn Write, widths: &ColumnWidths) -> std::io::Result<()> {
+    let sw = widths.status;
+    let rw = widths.stash_ref;
+    let mw = widths.message;
+    let line =
+        format!("  {HEADER_STATUS:<sw$} {HEADER_REF:<rw$} {HEADER_MESSAGE:<mw$} {HEADER_AGE}");
+    let trimmed = line.trim_end();
+    writeln!(out, "{trimmed}")
+}
 
 /// Write human-readable scan output.
 pub fn write_human(out: &mut dyn Write, result: &StashScanResult) -> std::io::Result<()> {
@@ -12,20 +64,22 @@ pub fn write_human(out: &mut dyn Write, result: &StashScanResult) -> std::io::Re
     for group in &result.repos {
         writeln!(out, "\n{} ({} stashes)", group.name, group.stashes.len())?;
 
-        for stash in &group.stashes {
-            let label = format!("{:<10}", stash.classification.label());
-            let age = match stash.age_days {
-                Some(0) => "today".to_string(),
-                Some(1) => "1 day ago".to_string(),
-                Some(d) => format!("{d} days ago"),
-                None => String::new(),
-            };
+        let widths = compute_column_widths(&group.stashes);
+        write_header(out, &widths)?;
 
-            writeln!(
-                out,
-                "  {label} {:<14} {:<50} {age}",
+        for stash in &group.stashes {
+            let label = stash.classification.label();
+            let age = format_age(stash.age_days);
+
+            let sw = widths.status;
+            let rw = widths.stash_ref;
+            let mw = widths.message;
+            let line = format!(
+                "  {label:<sw$} {:<rw$} {:<mw$} {age}",
                 stash.stash_ref, stash.message,
-            )?;
+            );
+            let trimmed = line.trim_end();
+            writeln!(out, "{trimmed}")?;
         }
     }
 
@@ -128,6 +182,11 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
 
         assert!(output.contains("my-repo (3 stashes)"));
+        // Header row
+        assert!(output.contains("STATUS"));
+        assert!(output.contains("REF"));
+        assert!(output.contains("MESSAGE"));
+        assert!(output.contains("AGE"));
         assert!(output.contains("committed"));
         assert!(output.contains("orphaned"));
         assert!(output.contains("active"));

--- a/crates/git-tag-tidy/src/output.rs
+++ b/crates/git-tag-tidy/src/output.rs
@@ -3,7 +3,79 @@ use std::io::Write;
 use git_tidy_core::output as shared;
 use git_tidy_core::types::ClassificationLabel;
 
-use crate::types::TagScanResult;
+use crate::types::{TagInfo, TagScanResult};
+
+const HEADER_STATUS: &str = "STATUS";
+const HEADER_NAME: &str = "NAME";
+const HEADER_COMMIT: &str = "COMMIT";
+const HEADER_KIND: &str = "KIND";
+const HEADER_DATE: &str = "DATE";
+
+struct ColumnWidths {
+    status: usize,
+    name: usize,
+    commit: usize,
+    kind: usize,
+    date: usize,
+    has_date: bool,
+}
+
+fn commit_short(commit: &str) -> &str {
+    if commit.len() >= 7 {
+        &commit[..7]
+    } else {
+        commit
+    }
+}
+
+fn compute_column_widths(tags: &[TagInfo]) -> ColumnWidths {
+    let mut max_status = HEADER_STATUS.len();
+    let mut max_name = HEADER_NAME.len();
+    let mut max_commit = HEADER_COMMIT.len();
+    let mut max_kind = HEADER_KIND.len();
+    let mut max_date = HEADER_DATE.len();
+    let mut has_date = false;
+
+    for t in tags {
+        max_status = max_status.max(t.classification.label().len());
+        max_name = max_name.max(t.name.len());
+        max_commit = max_commit.max(commit_short(&t.commit).len());
+        let kind = if t.is_annotated {
+            "annotated"
+        } else {
+            "lightweight"
+        };
+        max_kind = max_kind.max(kind.len());
+        if let Some(ref d) = t.tagger_date {
+            has_date = true;
+            max_date = max_date.max(d.len());
+        }
+    }
+
+    ColumnWidths {
+        status: max_status,
+        name: max_name,
+        commit: max_commit,
+        kind: max_kind,
+        date: max_date,
+        has_date,
+    }
+}
+
+fn write_header(out: &mut dyn Write, widths: &ColumnWidths) -> std::io::Result<()> {
+    let sw = widths.status;
+    let nw = widths.name;
+    let cw = widths.commit;
+    let kw = widths.kind;
+    let mut line = format!(
+        "  {HEADER_STATUS:<sw$} {HEADER_NAME:<nw$} {HEADER_COMMIT:<cw$} {HEADER_KIND:<kw$}"
+    );
+    if widths.has_date {
+        line.push_str(&format!(" {HEADER_DATE}"));
+    }
+    let trimmed = line.trim_end();
+    writeln!(out, "{trimmed}")
+}
 
 /// Write human-readable scan output.
 pub fn write_human(out: &mut dyn Write, result: &TagScanResult) -> std::io::Result<()> {
@@ -13,13 +85,12 @@ pub fn write_human(out: &mut dyn Write, result: &TagScanResult) -> std::io::Resu
         let noun = if group.tags.len() == 1 { "tag" } else { "tags" };
         writeln!(out, "\n{} ({} {noun})", group.name, group.tags.len())?;
 
+        let widths = compute_column_widths(&group.tags);
+        write_header(out, &widths)?;
+
         for tag in &group.tags {
-            let label = format!("{:<13}", tag.classification.label());
-            let commit_short = if tag.commit.len() >= 7 {
-                &tag.commit[..7]
-            } else {
-                &tag.commit
-            };
+            let label = tag.classification.label();
+            let cs = commit_short(&tag.commit);
             let kind = if tag.is_annotated {
                 "annotated"
             } else {
@@ -27,11 +98,17 @@ pub fn write_human(out: &mut dyn Write, result: &TagScanResult) -> std::io::Resu
             };
             let date = tag.tagger_date.as_deref().unwrap_or("");
 
-            writeln!(
-                out,
-                "  {label} {:<20} {:<9} {:<12} {date}",
-                tag.name, commit_short, kind,
-            )?;
+            let sw = widths.status;
+            let nw = widths.name;
+            let cw = widths.commit;
+            let kw = widths.kind;
+            let mut line = format!("  {label:<sw$} {:<nw$} {cs:<cw$} {kind:<kw$}", tag.name);
+            if widths.has_date {
+                let dw = widths.date;
+                line.push_str(&format!(" {date:<dw$}"));
+            }
+            let trimmed = line.trim_end();
+            writeln!(out, "{trimmed}")?;
         }
     }
 
@@ -142,6 +219,11 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
 
         assert!(output.contains("backend (3 tags)"));
+        // Header row
+        assert!(output.contains("STATUS"));
+        assert!(output.contains("NAME"));
+        assert!(output.contains("COMMIT"));
+        assert!(output.contains("KIND"));
         assert!(output.contains("stale"));
         assert!(output.contains("local_only"));
         assert!(output.contains("synced"));

--- a/crates/git-worktree-tidy/src/output.rs
+++ b/crates/git-worktree-tidy/src/output.rs
@@ -3,12 +3,14 @@ use std::io::Write;
 use git_tidy_core::output as shared;
 use git_tidy_core::types::{Classification, ClassificationLabel, ScanResult, WorktreeInfo};
 
-const MIN_DIR_NAME_WIDTH: usize = 20;
-const MIN_BRANCH_WIDTH: usize = 20;
-const MIN_RATIO_WIDTH: usize = 5;
-const MIN_AHEAD_BEHIND_WIDTH: usize = 10;
+const HEADER_STATUS: &str = "STATUS";
+const HEADER_DIRECTORY: &str = "DIRECTORY";
+const HEADER_BRANCH: &str = "BRANCH";
+const HEADER_RATIO: &str = "RATIO";
+const HEADER_AHEAD_BEHIND: &str = "AHEAD/BEHIND";
 
 struct ColumnWidths {
+    status: usize,
     dir_name: usize,
     branch: usize,
     ratio: usize,
@@ -18,14 +20,16 @@ struct ColumnWidths {
 }
 
 fn compute_column_widths(worktrees: &[WorktreeInfo]) -> ColumnWidths {
-    let mut max_dir = 0usize;
-    let mut max_branch = 0usize;
-    let mut max_ratio = 0usize;
-    let mut max_ab = 0usize;
+    let mut max_status = HEADER_STATUS.len();
+    let mut max_dir = HEADER_DIRECTORY.len();
+    let mut max_branch = HEADER_BRANCH.len();
+    let mut max_ratio = HEADER_RATIO.len();
+    let mut max_ab = HEADER_AHEAD_BEHIND.len();
     let mut has_ratio = false;
     let mut has_ahead_behind = false;
 
     for wt in worktrees {
+        max_status = max_status.max(wt.classification.label().len());
         let dir_name = wt
             .path
             .file_name()
@@ -48,13 +52,31 @@ fn compute_column_widths(worktrees: &[WorktreeInfo]) -> ColumnWidths {
     }
 
     ColumnWidths {
-        dir_name: max_dir.max(MIN_DIR_NAME_WIDTH),
-        branch: max_branch.max(MIN_BRANCH_WIDTH),
-        ratio: max_ratio.max(MIN_RATIO_WIDTH),
-        ahead_behind: max_ab.max(MIN_AHEAD_BEHIND_WIDTH),
+        status: max_status,
+        dir_name: max_dir,
+        branch: max_branch,
+        ratio: max_ratio,
+        ahead_behind: max_ab,
         has_ratio,
         has_ahead_behind,
     }
+}
+
+fn write_header(out: &mut dyn Write, widths: &ColumnWidths) -> std::io::Result<()> {
+    let sw = widths.status;
+    let dw = widths.dir_name;
+    let bw = widths.branch;
+    let mut line = format!("  {HEADER_STATUS:<sw$} {HEADER_DIRECTORY:<dw$} {HEADER_BRANCH:<bw$}");
+    if widths.has_ratio {
+        let rw = widths.ratio;
+        line.push_str(&format!(" {HEADER_RATIO:<rw$}"));
+    }
+    if widths.has_ahead_behind {
+        let aw = widths.ahead_behind;
+        line.push_str(&format!(" {HEADER_AHEAD_BEHIND:<aw$}"));
+    }
+    let trimmed = line.trim_end();
+    writeln!(out, "{trimmed}")
 }
 
 /// Write human-readable scan output.
@@ -70,6 +92,7 @@ pub fn write_human(out: &mut dyn Write, result: &ScanResult) -> std::io::Result<
         )?;
 
         let widths = compute_column_widths(&group.worktrees);
+        write_header(out, &widths)?;
 
         for wt in &group.worktrees {
             write_worktree_line(out, wt, &widths)?;
@@ -98,7 +121,7 @@ fn write_worktree_line(
     wt: &WorktreeInfo,
     widths: &ColumnWidths,
 ) -> std::io::Result<()> {
-    let label = format!("{:<8}", wt.classification.label());
+    let label = wt.classification.label();
     let dir_name = wt
         .path
         .file_name()
@@ -121,9 +144,10 @@ fn write_worktree_line(
         annotations.push("remote deleted".to_string());
     }
 
+    let sw = widths.status;
     let dw = widths.dir_name;
     let bw = widths.branch;
-    let mut line = format!("  {label} {dir_name:<dw$} {branch:<bw$}");
+    let mut line = format!("  {label:<sw$} {dir_name:<dw$} {branch:<bw$}");
     if widths.has_ratio {
         let rw = widths.ratio;
         line.push_str(&format!(" {ratio:<rw$}"));
@@ -238,6 +262,10 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
 
         assert!(output.contains("Backend (2 worktrees)"));
+        // Header row
+        assert!(output.contains("STATUS"));
+        assert!(output.contains("DIRECTORY"));
+        assert!(output.contains("BRANCH"));
         assert!(output.contains("landed"));
         assert!(output.contains("active"));
         assert!(output.contains("Backend-parallel"));
@@ -337,11 +365,15 @@ mod tests {
         assert_eq!(fields2[3], "active");
     }
 
-    /// Collect worktree data lines from human output (lines starting with "  " but not "    unmatched:").
+    /// Collect worktree data lines from human output (lines starting with "  " but not headers or unmatched).
     fn worktree_lines(output: &str) -> Vec<&str> {
         output
             .lines()
-            .filter(|l| l.starts_with("  ") && !l.starts_with("    unmatched:"))
+            .filter(|l| {
+                l.starts_with("  ")
+                    && !l.starts_with("    unmatched:")
+                    && !l.trim_start().starts_with("STATUS")
+            })
             .collect()
     }
 


### PR DESCRIPTION
Closes #112

## Summary

- Add header rows (STATUS, NAME, BRANCH, etc.) to all 8 tools' human-readable scan/lint output
- Replace fixed column widths with dynamic widths computed from data, so long values never clip and short values don't waste space
- Optional columns (RATIO, AHEAD/BEHIND, DATE, TRACKING) only appear when data warrants them

## Test plan

- [x] All existing tests pass (`cargo test --workspace`)
- [x] Header assertions added to `human_output_basic` tests in all 8 tools
- [x] Alignment test (`human_output_columns_align`) updated and passing
- [x] `cargo clippy --workspace` clean
- [x] `cargo fmt --check` clean