### PR TITLE
Add remote-only branch scanning and cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ All tools follow a similar CLI shape:
 - Remote-tidy global arg: `--offline` instead of `--behind-threshold`/`--verbose`
 - Tag-tidy global arg: `--offline` instead of `--behind-threshold`/`--verbose`
 - Repo-tidy global args: `--stale-months` (default 6), `--offline`
-- Tool-specific flags: worktree-tidy has `--delete-branches`, branch-tidy has `--include-remote`/`--force`, remote-tidy has `--force` (allow removing origin)/`--all` (include orphaned), tag-tidy has `--stale-only`/`--local-only`/`--include-remote`/`--force` (bypass release protection)/`--all`, repo-tidy has `--force` (allow deleting dirty repos)/`--stale-only`/`--orphaned-only`/`--all`, lfs-tidy has `--prune` (enable orphaned LFS object removal)
+- Tool-specific flags: worktree-tidy has `--delete-branches`, branch-tidy has `--include-remote` (on both scan and clean: discovers remote-only branches and deletes them)/`--force`, remote-tidy has `--force` (allow removing origin)/`--all` (include orphaned), tag-tidy has `--stale-only`/`--local-only`/`--include-remote`/`--force` (bypass release protection)/`--all`, repo-tidy has `--force` (allow deleting dirty repos)/`--stale-only`/`--orphaned-only`/`--all`, lfs-tidy has `--prune` (enable orphaned LFS object removal)
 - git-tidy (audit runner + dispatch): Pre-clap alias dispatch in `main.rs` checks `args[1]` against `ToolSpec::aliases` and execs the binary. Falls through to `Audit` subcommand (default) with `--json`/`--porcelain`/`--verbose`/`--tools`/`--subprocess`. `Explain` subcommand prints a terminology glossary. Default mode calls tool scan/lint functions in-process with `CachingGitOps`; `--subprocess` shells out via `ToolRunner` trait.
 - Config-tidy uses **lint/fix** subcommands instead of scan/clean (config issues are "lint findings")
 - LFS-tidy scan args: `--size-threshold` (default "1MB"), `--depth` (default 1000)
@@ -68,7 +68,7 @@ All tools follow a similar CLI shape:
 - Path canonicalization in discovery handles macOS `/var` -> `/private/var` symlinks.
 - Classification priority order: landed (0) = landed-stale (0) > landed-content (1) > partial (2) > active (3) > local (4). `LandedStale` is for worktrees whose branch ref was deleted (typically after a PR merge).
 - Shared test utilities (MockGitBuilder, TestRepo, git helper) live in `git-tidy-core/src/testutil.rs`, gated behind the `testutil` feature. Binary crates depend on `git-tidy-core = { features = ["testutil"] }` in `[dev-dependencies]`.
-- `classify_branch` is the core classification function shared by both tools. `classify_worktree` is a thin wrapper that adds dirty detection.
+- `classify_branch` is the core classification function shared by both tools. `classify_worktree` is a thin wrapper that adds dirty detection. `classify_remote_branch` classifies remote-only branches (on origin but no local counterpart), using `origin/<branch>` as the git ref.
 - Discovery is inverted between tools: worktree discovery finds `.git` files (linked worktrees), branch discovery finds `.git` directories (repos).
 - `delete_fn` pattern: `run_clean` takes `&dyn Fn(&Path) -> io::Result<()>` so tests can verify deletion logic without `rm -rf`. Used in repo-tidy.
 - Injectable `du_fn`: `run_scan_with_du` takes a disk-usage function parameter so unit tests can provide canned sizes without hitting the filesystem. Used in repo-tidy.

--- a/crates/git-branch-tidy/src/clean.rs
+++ b/crates/git-branch-tidy/src/clean.rs
@@ -57,6 +57,39 @@ pub fn run_clean(
                 continue;
             }
 
+            // Remote-only branches: delete from origin directly, skip local deletion
+            if branch.remote_only {
+                if options.dry_run {
+                    writeln!(out, "would delete remote {} in {}", branch.name, group.name)?;
+                    succeeded.push(DeletedBranch {
+                        repo: branch.repo_path.clone(),
+                        name: branch.name.clone(),
+                        remote_deleted: true,
+                    });
+                    continue;
+                }
+
+                match git.delete_remote_branch(&branch.repo_path, "origin", &branch.name) {
+                    Ok(()) => {
+                        writeln!(out, "deleted remote {}", branch.name)?;
+                        succeeded.push(DeletedBranch {
+                            repo: branch.repo_path.clone(),
+                            name: branch.name.clone(),
+                            remote_deleted: true,
+                        });
+                    }
+                    Err(e) => {
+                        writeln!(out, "error: could not delete remote {}: {e}", branch.name)?;
+                        failed.push(FailedItem {
+                            repo: branch.repo_path.clone(),
+                            name: branch.name.clone(),
+                            reason: e.to_string(),
+                        });
+                    }
+                }
+                continue;
+            }
+
             if options.dry_run {
                 write!(out, "would delete {}", branch.name)?;
                 if options.include_remote && branch.remote_tracking && !branch.remote_deleted {
@@ -213,6 +246,7 @@ mod tests {
             behind: 0,
             diverged: false,
             is_current: false,
+            remote_only: false,
         }
     }
 
@@ -228,6 +262,7 @@ mod tests {
             behind: 0,
             diverged: false,
             is_current: false,
+            remote_only: false,
         }
     }
 
@@ -450,5 +485,85 @@ mod tests {
         assert_eq!(result.succeeded.len(), 0);
         assert_eq!(result.failed.len(), 1);
         assert_eq!(result.failed[0].name, "feature/unmerged");
+    }
+
+    fn remote_only_branch(name: &str) -> BranchInfo {
+        BranchInfo {
+            repo_path: repo(),
+            name: name.to_string(),
+            default_branch: "main".to_string(),
+            classification: Classification::Landed,
+            remote_tracking: true,
+            remote_deleted: false,
+            ahead: 0,
+            behind: 0,
+            diverged: false,
+            is_current: false,
+            remote_only: true,
+        }
+    }
+
+    #[test]
+    fn clean_deletes_remote_only_branch() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![remote_only_branch("feature/remote")]);
+        let mut buf = Vec::new();
+
+        let result = run_clean(&git, &scan, &default_options(), &mut buf).unwrap();
+
+        assert_eq!(result.succeeded.len(), 1);
+        assert_eq!(result.succeeded[0].name, "feature/remote");
+        assert!(result.succeeded[0].remote_deleted);
+        // Should NOT call local branch_delete
+        assert_eq!(git.branch_delete_calls().len(), 0);
+        assert_eq!(git.branch_delete_safe_calls().len(), 0);
+        // Should call delete_remote_branch
+        assert_eq!(git.delete_remote_branch_calls().len(), 1);
+        assert_eq!(
+            git.delete_remote_branch_calls()[0],
+            (repo(), "origin".to_string(), "feature/remote".to_string())
+        );
+    }
+
+    #[test]
+    fn clean_dry_run_remote_only() {
+        let git = MockGitBuilder::new().build();
+        let scan = make_scan_result(vec![remote_only_branch("feature/remote")]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            dry_run: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+
+        assert_eq!(result.succeeded.len(), 1);
+        assert_eq!(git.delete_remote_branch_calls().len(), 0);
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("would delete remote feature/remote"));
+    }
+
+    #[test]
+    fn clean_dry_run_mixed_local_and_remote_only() {
+        let git = MockGitBuilder::new()
+            .with_upstream_branch(&repo(), "feature/local", Some("origin/feature/local"))
+            .build();
+        let mut local = merged_branch("feature/local");
+        local.remote_tracking = true;
+        local.remote_deleted = false;
+        let scan = make_scan_result(vec![local, remote_only_branch("feature/remote")]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            dry_run: true,
+            include_remote: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+
+        assert_eq!(result.succeeded.len(), 2);
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("would delete feature/local (and remote)"));
+        assert!(output.contains("would delete remote feature/remote"));
     }
 }

--- a/crates/git-branch-tidy/src/cli.rs
+++ b/crates/git-branch-tidy/src/cli.rs
@@ -51,6 +51,10 @@ pub enum Command {
         /// Machine-readable tab-delimited output
         #[arg(long)]
         porcelain: bool,
+
+        /// Include remote-only branches (branches on origin with no local counterpart)
+        #[arg(long)]
+        include_remote: bool,
     },
 
     #[command(flatten)]
@@ -164,7 +168,9 @@ mod tests {
     fn scan_json_flag() {
         let cli = Cli::parse_from(["git-branch-tidy", "scan", "--json"]);
         match cli.command {
-            Some(Command::Scan { json, porcelain }) => {
+            Some(Command::Scan {
+                json, porcelain, ..
+            }) => {
                 assert!(json);
                 assert!(!porcelain);
             }
@@ -176,9 +182,22 @@ mod tests {
     fn scan_porcelain_flag() {
         let cli = Cli::parse_from(["git-branch-tidy", "scan", "--porcelain"]);
         match cli.command {
-            Some(Command::Scan { json, porcelain }) => {
+            Some(Command::Scan {
+                json, porcelain, ..
+            }) => {
                 assert!(!json);
                 assert!(porcelain);
+            }
+            _ => panic!("expected Scan command"),
+        }
+    }
+
+    #[test]
+    fn scan_include_remote_flag() {
+        let cli = Cli::parse_from(["git-branch-tidy", "scan", "--include-remote"]);
+        match cli.command {
+            Some(Command::Scan { include_remote, .. }) => {
+                assert!(include_remote);
             }
             _ => panic!("expected Scan command"),
         }

--- a/crates/git-branch-tidy/src/main.rs
+++ b/crates/git-branch-tidy/src/main.rs
@@ -37,11 +37,13 @@ fn main() {
 
     match &cli.command {
         None | Some(cli::Command::Scan { .. }) => {
-            let format = match &cli.command {
-                Some(cli::Command::Scan { json, porcelain }) => {
-                    OutputFormat::from_flags(*json, *porcelain)
-                }
-                _ => OutputFormat::Human,
+            let (format, include_remote) = match &cli.command {
+                Some(cli::Command::Scan {
+                    json,
+                    porcelain,
+                    include_remote,
+                }) => (OutputFormat::from_flags(*json, *porcelain), *include_remote),
+                _ => (OutputFormat::Human, false),
             };
 
             match scan::run_scan(
@@ -51,6 +53,7 @@ fn main() {
                 cli.verbose,
                 &repo_filter,
                 &entity_filter,
+                include_remote,
                 &progress,
             ) {
                 Ok(result) => {
@@ -76,7 +79,8 @@ fn main() {
             include_remote,
             ..
         }) => {
-            // First, scan to get the current state
+            // First, scan to get the current state.
+            // When --include-remote is set, also discover remote-only branches.
             match scan::run_scan(
                 &git,
                 &directory,
@@ -84,6 +88,7 @@ fn main() {
                 cli.verbose,
                 &repo_filter,
                 &entity_filter,
+                *include_remote,
                 &progress,
             ) {
                 Ok(scan_result) => {

--- a/crates/git-branch-tidy/src/output.rs
+++ b/crates/git-branch-tidy/src/output.rs
@@ -119,6 +119,9 @@ fn write_branch_line(
 
     // Annotations
     let mut ann_strs = Vec::new();
+    if branch.remote_only {
+        ann_strs.push("remote");
+    }
     if branch.diverged {
         ann_strs.push("diverged");
     }
@@ -162,6 +165,9 @@ pub fn write_porcelain(out: &mut dyn Write, result: &BranchScanResult) -> std::i
             let ratio = shared::format_landed_ratio(&branch.classification);
 
             let mut anns = Vec::new();
+            if branch.remote_only {
+                anns.push("remote_only");
+            }
             if branch.remote_deleted {
                 anns.push("remote_deleted");
             }
@@ -205,6 +211,7 @@ mod tests {
                         behind: 0,
                         diverged: false,
                         is_current: false,
+                        remote_only: false,
                     },
                     BranchInfo {
                         repo_path: PathBuf::from("/repos/Backend"),
@@ -217,6 +224,7 @@ mod tests {
                         behind: 0,
                         diverged: false,
                         is_current: true,
+                        remote_only: false,
                     },
                 ],
             }],
@@ -281,6 +289,7 @@ mod tests {
                     behind: 324,
                     diverged: true,
                     is_current: false,
+                    remote_only: false,
                 }],
             }],
             total_scanned: 1,
@@ -338,6 +347,112 @@ mod tests {
         let fields2: Vec<&str> = lines[1].split('\t').collect();
         assert_eq!(fields2[2], "active");
         assert_eq!(fields2[6], "true");
+    }
+
+    #[test]
+    fn human_output_remote_only_annotation() {
+        let result = BranchScanResult {
+            repos: vec![BranchRepoGroup {
+                repo_path: PathBuf::from("/repos/App"),
+                name: "App".to_string(),
+                branches: vec![BranchInfo {
+                    repo_path: PathBuf::from("/repos/App"),
+                    name: "feature/stale-remote".to_string(),
+                    default_branch: "main".to_string(),
+                    classification: Classification::Landed,
+                    remote_tracking: true,
+                    remote_deleted: false,
+                    ahead: 0,
+                    behind: 0,
+                    diverged: false,
+                    is_current: false,
+                    remote_only: true,
+                }],
+            }],
+            total_scanned: 1,
+            counts: ScanCounts {
+                landed: 1,
+                ..Default::default()
+            },
+            warnings: vec![],
+        };
+
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("remote"));
+        assert!(output.contains("feature/stale-remote"));
+    }
+
+    #[test]
+    fn porcelain_output_remote_only_annotation() {
+        let result = BranchScanResult {
+            repos: vec![BranchRepoGroup {
+                repo_path: PathBuf::from("/repos/App"),
+                name: "App".to_string(),
+                branches: vec![BranchInfo {
+                    repo_path: PathBuf::from("/repos/App"),
+                    name: "feature/stale-remote".to_string(),
+                    default_branch: "main".to_string(),
+                    classification: Classification::Landed,
+                    remote_tracking: true,
+                    remote_deleted: false,
+                    ahead: 0,
+                    behind: 0,
+                    diverged: false,
+                    is_current: false,
+                    remote_only: true,
+                }],
+            }],
+            total_scanned: 1,
+            counts: ScanCounts {
+                landed: 1,
+                ..Default::default()
+            },
+            warnings: vec![],
+        };
+
+        let mut buf = Vec::new();
+        write_porcelain(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        let fields: Vec<&str> = output.lines().next().unwrap().split('\t').collect();
+        assert_eq!(fields[7], "remote_only");
+    }
+
+    #[test]
+    fn json_output_includes_remote_only_field() {
+        let result = BranchScanResult {
+            repos: vec![BranchRepoGroup {
+                repo_path: PathBuf::from("/repos/App"),
+                name: "App".to_string(),
+                branches: vec![BranchInfo {
+                    repo_path: PathBuf::from("/repos/App"),
+                    name: "feature/stale-remote".to_string(),
+                    default_branch: "main".to_string(),
+                    classification: Classification::Landed,
+                    remote_tracking: true,
+                    remote_deleted: false,
+                    ahead: 0,
+                    behind: 0,
+                    diverged: false,
+                    is_current: false,
+                    remote_only: true,
+                }],
+            }],
+            total_scanned: 1,
+            counts: ScanCounts {
+                landed: 1,
+                ..Default::default()
+            },
+            warnings: vec![],
+        };
+
+        let mut buf = Vec::new();
+        write_json(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr[0]["remote_only"], true);
     }
 
     #[test]

--- a/crates/git-branch-tidy/src/scan.rs
+++ b/crates/git-branch-tidy/src/scan.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use rayon::prelude::*;
@@ -15,7 +16,11 @@ use git_tidy_core::types::{ClassificationLabel, ScanCounts};
 use crate::discovery;
 use crate::types::{BranchInfo, BranchRepoGroup, BranchScanResult};
 
-/// Scan all repos in `directory` for stale local branches.
+/// Scan all repos in `directory` for stale branches.
+///
+/// When `include_remote` is true, also discovers remote-only branches
+/// (branches on origin with no local counterpart).
+#[allow(clippy::too_many_arguments)]
 pub fn run_scan(
     git: &dyn GitOps,
     directory: &Path,
@@ -23,6 +28,7 @@ pub fn run_scan(
     verbose: bool,
     repo_filter: &NameFilter,
     entity_filter: &NameFilter,
+    include_remote: bool,
     progress: &Progress,
 ) -> Result<BranchScanResult, Error> {
     let repo_paths = discovery::discover_repos(directory)?;
@@ -33,20 +39,25 @@ pub fn run_scan(
         behind_threshold,
         verbose,
         entity_filter,
+        include_remote,
         progress,
     )
 }
 
-/// Scan pre-discovered repos for stale local branches.
+/// Scan pre-discovered repos for stale branches.
 ///
 /// Accepts repo paths directly (skipping discovery), so the audit runner can
 /// call `discover_repos` once and share the result across tools.
+///
+/// When `include_remote` is true, also discovers remote-only branches
+/// (branches on origin with no local counterpart).
 pub fn run_scan_repos(
     git: &dyn GitOps,
     repo_paths: &[PathBuf],
     behind_threshold: usize,
     verbose: bool,
     entity_filter: &NameFilter,
+    include_remote: bool,
     progress: &Progress,
 ) -> Result<BranchScanResult, Error> {
     let repo_paths_owned: Vec<PathBuf> = repo_paths.to_vec();
@@ -133,6 +144,7 @@ pub fn run_scan_repos(
                                 behind: bc.behind,
                                 diverged: bc.diverged,
                                 is_current,
+                                remote_only: false,
                             })
                         }
                         Err(e) => Err(format!(
@@ -149,6 +161,88 @@ pub fn run_scan_repos(
                 match result {
                     Ok(info) => classified.push(info),
                     Err(warning) => local_warnings.push(warning),
+                }
+            }
+
+            // Discover remote-only branches (on origin but no local counterpart)
+            if include_remote {
+                let local_names: HashSet<&str> = branches.iter().map(|b| b.as_str()).collect();
+
+                if let Ok(tracking_refs) = git.list_remote_tracking_refs(repo_path) {
+                    let remote_only_names: Vec<String> = tracking_refs
+                        .iter()
+                        .filter_map(|(short, _full)| {
+                            let branch = short.strip_prefix("origin/")?;
+                            if branch == "HEAD"
+                                || branch == default_branch
+                                || local_names.contains(branch)
+                            {
+                                return None;
+                            }
+                            if !entity_filter.matches(branch) {
+                                return None;
+                            }
+                            Some(branch.to_string())
+                        })
+                        .collect();
+
+                    if verbose && !remote_only_names.is_empty() {
+                        eprintln!(
+                            "{repo_name}: {} remote-only branches",
+                            remote_only_names.len(),
+                        );
+                    }
+
+                    let remote_results: Vec<_> = remote_only_names
+                        .par_iter()
+                        .map(|branch_name| {
+                            match classification::classify_remote_branch(
+                                git,
+                                repo_path,
+                                branch_name,
+                                &default_branch,
+                                behind_threshold,
+                                verbose,
+                                &landed_options,
+                            ) {
+                                Ok(bc) => {
+                                    if verbose {
+                                        eprintln!(
+                                            "  {branch_name} (remote): {} (ahead={}, behind={})",
+                                            bc.classification.label(),
+                                            bc.ahead,
+                                            bc.behind,
+                                        );
+                                    }
+                                    Ok(BranchInfo {
+                                        repo_path: repo_path.to_path_buf(),
+                                        name: branch_name.clone(),
+                                        default_branch: default_branch.clone(),
+                                        classification: bc.classification,
+                                        remote_tracking: true,
+                                        remote_deleted: false,
+                                        ahead: bc.ahead,
+                                        behind: bc.behind,
+                                        diverged: bc.diverged,
+                                        is_current: false,
+                                        remote_only: true,
+                                    })
+                                }
+                                Err(e) => Err(format!(
+                                    "error classifying remote branch {} in {}: {e}",
+                                    branch_name,
+                                    repo_path.display()
+                                )),
+                            }
+                        })
+                        .collect();
+
+                    for result in remote_results {
+                        match result {
+                            Ok(info) => classified.push(info),
+                            Err(warning) => local_warnings.push(warning),
+                        }
+                    }
                 }
             }
 
@@ -335,7 +429,7 @@ mod tests {
 
         let p = Progress::disabled();
         let filter = NameFilter::default();
-        let result = run_scan_repos(&git, &[repo()], 100, false, &filter, &p).unwrap();
+        let result = run_scan_repos(&git, &[repo()], 100, false, &filter, false, &p).unwrap();
         assert_eq!(result.total_scanned, 1);
         assert_eq!(result.counts.landed, 1);
     }
@@ -373,5 +467,97 @@ mod tests {
         let is_current = git.current_branch(&repo()).unwrap() == Some("my-feature".to_string());
         assert!(is_current);
         assert_eq!(bc.classification, Classification::Active);
+    }
+
+    #[test]
+    fn scan_discovers_remote_only_branches() {
+        let git = MockGitBuilder::new()
+            .with_symbolic_ref(&repo(), Some("main"))
+            .with_local_branches(&repo(), vec!["main".to_string()])
+            .with_current_branch(&repo(), Some("main"))
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/main", true)
+            // Remote-only branch: origin/feature/remote-only
+            .with_remote_tracking_refs(
+                &repo(),
+                vec![
+                    (
+                        "origin/main".to_string(),
+                        "refs/remotes/origin/main".to_string(),
+                    ),
+                    (
+                        "origin/feature/remote-only".to_string(),
+                        "refs/remotes/origin/feature/remote-only".to_string(),
+                    ),
+                ],
+            )
+            .with_rev_list_counts(&repo(), "origin/main", "origin/feature/remote-only", (0, 0))
+            .with_is_ancestor(&repo(), "origin/feature/remote-only", "origin/main", true)
+            .build();
+
+        let p = Progress::disabled();
+        let filter = NameFilter::default();
+        let result = run_scan_repos(&git, &[repo()], 100, false, &filter, true, &p).unwrap();
+        assert_eq!(result.total_scanned, 1);
+        assert_eq!(result.counts.landed, 1);
+        let branch = &result.repos[0].branches[0];
+        assert_eq!(branch.name, "feature/remote-only");
+        assert!(branch.remote_only);
+        assert!(branch.remote_tracking);
+    }
+
+    #[test]
+    fn scan_excludes_remote_only_when_flag_false() {
+        let git = MockGitBuilder::new()
+            .with_symbolic_ref(&repo(), Some("main"))
+            .with_local_branches(&repo(), vec!["main".to_string()])
+            .with_current_branch(&repo(), Some("main"))
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/main", true)
+            .with_remote_tracking_refs(
+                &repo(),
+                vec![
+                    (
+                        "origin/main".to_string(),
+                        "refs/remotes/origin/main".to_string(),
+                    ),
+                    (
+                        "origin/feature/remote-only".to_string(),
+                        "refs/remotes/origin/feature/remote-only".to_string(),
+                    ),
+                ],
+            )
+            .build();
+
+        let p = Progress::disabled();
+        let filter = NameFilter::default();
+        let result = run_scan_repos(&git, &[repo()], 100, false, &filter, false, &p).unwrap();
+        assert_eq!(result.total_scanned, 0);
+        assert!(result.repos.is_empty());
+    }
+
+    #[test]
+    fn scan_remote_only_skips_default_branch_and_head() {
+        let git = MockGitBuilder::new()
+            .with_symbolic_ref(&repo(), Some("main"))
+            .with_local_branches(&repo(), vec!["main".to_string()])
+            .with_current_branch(&repo(), Some("main"))
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/main", true)
+            .with_remote_tracking_refs(
+                &repo(),
+                vec![
+                    ("origin".to_string(), "refs/remotes/origin/HEAD".to_string()),
+                    (
+                        "origin/main".to_string(),
+                        "refs/remotes/origin/main".to_string(),
+                    ),
+                ],
+            )
+            .build();
+
+        let p = Progress::disabled();
+        let filter = NameFilter::default();
+        let result = run_scan_repos(&git, &[repo()], 100, false, &filter, true, &p).unwrap();
+        // Neither HEAD nor main should appear
+        assert_eq!(result.total_scanned, 0);
+        assert!(result.repos.is_empty());
     }
 }

--- a/crates/git-branch-tidy/src/types.rs
+++ b/crates/git-branch-tidy/src/types.rs
@@ -5,7 +5,7 @@ use git_tidy_core::types::{
 };
 use serde::Serialize;
 
-/// Information about a single local branch.
+/// Information about a single branch (local or remote-only).
 #[derive(Debug, Clone, Serialize)]
 pub struct BranchInfo {
     /// Path to the repo containing this branch.
@@ -28,6 +28,8 @@ pub struct BranchInfo {
     pub diverged: bool,
     /// Whether this branch is currently checked out.
     pub is_current: bool,
+    /// Whether this branch exists only on the remote (no local counterpart).
+    pub remote_only: bool,
 }
 
 /// A group of branches in the same repo.
@@ -79,6 +81,7 @@ pub struct JsonBranch {
     pub behind: usize,
     pub diverged: bool,
     pub is_current: bool,
+    pub remote_only: bool,
     pub landed_ratio: Option<String>,
     pub landed_total: Option<usize>,
     pub unmatched_commits: Vec<UnmatchedCommit>,
@@ -99,6 +102,7 @@ impl From<&BranchInfo> for JsonBranch {
             behind: b.behind,
             diverged: b.diverged,
             is_current: b.is_current,
+            remote_only: b.remote_only,
             landed_ratio: landed.ratio,
             landed_total: landed.total,
             unmatched_commits: landed.unmatched,

--- a/crates/git-branch-tidy/tests/integration_clean.rs
+++ b/crates/git-branch-tidy/tests/integration_clean.rs
@@ -52,6 +52,7 @@ fn clean_deletes_merged_branch_in_real_repo() {
         false,
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
+        false,
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -92,6 +93,7 @@ fn clean_dry_run_does_not_delete() {
         false,
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
+        false,
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -140,6 +142,7 @@ fn clean_safe_refuses_unmerged_branch() {
         false,
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
+        false,
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();

--- a/crates/git-branch-tidy/tests/integration_scan.rs
+++ b/crates/git-branch-tidy/tests/integration_scan.rs
@@ -63,6 +63,7 @@ fn scan_real_repo_with_mixed_branches() {
         false,
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
+        false,
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -120,6 +121,7 @@ fn scan_marks_current_branch_in_real_repo() {
         false,
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
+        false,
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -151,6 +153,7 @@ fn scan_entity_filter_includes_matching_branches() {
         false,
         &git_tidy_core::filter::NameFilter::default(),
         &entity_filter,
+        false,
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -188,6 +191,7 @@ fn scan_entity_filter_exclude_takes_precedence() {
         false,
         &git_tidy_core::filter::NameFilter::default(),
         &entity_filter,
+        false,
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();
@@ -227,6 +231,7 @@ fn scan_skips_repo_without_default_branch() {
         false,
         &git_tidy_core::filter::NameFilter::default(),
         &git_tidy_core::filter::NameFilter::default(),
+        false,
         &git_tidy_core::progress::Progress::disabled(),
     )
     .unwrap();

--- a/crates/git-config-tidy/src/lint.rs
+++ b/crates/git-config-tidy/src/lint.rs
@@ -66,7 +66,7 @@ pub fn lint_repo(
     }
 
     // Sort by priority
-    issues.sort_by(|a, b| a.kind.priority().cmp(&b.kind.priority()));
+    issues.sort_by_key(|a| a.kind.priority());
 
     Ok(issues)
 }

--- a/crates/git-stash-tidy/src/clean.rs
+++ b/crates/git-stash-tidy/src/clean.rs
@@ -59,7 +59,7 @@ pub fn run_clean(
         }
 
         // Sort by descending index to prevent renumbering
-        to_drop.sort_by(|a, b| b.0.cmp(&a.0));
+        to_drop.sort_by_key(|b| std::cmp::Reverse(b.0));
 
         for (_, stash_ref, _) in &to_drop {
             if options.dry_run {

--- a/crates/git-tidy-core/src/classification.rs
+++ b/crates/git-tidy-core/src/classification.rs
@@ -234,6 +234,82 @@ pub fn classify_branch_cached(
     })
 }
 
+/// Classify a remote-only branch (one that exists on origin but has no local counterpart).
+///
+/// Uses `origin/{branch_name}` as the git ref for all comparisons. Always returns
+/// `remote_tracking: true` and `remote_deleted: false`. Non-merged branches are
+/// classified as `Active` (never `Local`, since they exist on the remote by definition).
+pub fn classify_remote_branch(
+    git: &dyn GitOps,
+    repo: &Path,
+    branch_name: &str,
+    default_branch: &str,
+    behind_threshold: usize,
+    verbose: bool,
+    landed_options: &LandedOptions,
+) -> Result<BranchClassification, Error> {
+    let origin_ref = format!("refs/remotes/origin/{default_branch}");
+    let has_origin = git.rev_parse_verify(repo, &origin_ref)?;
+    let comparison_target = if has_origin {
+        format!("origin/{default_branch}")
+    } else {
+        default_branch.to_string()
+    };
+
+    let remote_ref = format!("origin/{branch_name}");
+
+    let (behind, ahead) = git.rev_list_left_right_count(repo, &comparison_target, &remote_ref)?;
+
+    if verbose {
+        eprintln!("  {branch_name} (remote): ahead={ahead}, behind={behind}");
+    }
+
+    let is_merged = ahead == 0 || git.is_ancestor(repo, &remote_ref, &comparison_target)?;
+
+    let classification = if is_merged {
+        if verbose {
+            eprintln!("  {branch_name} (remote): structurally merged → landed");
+        }
+        Classification::Landed
+    } else {
+        let landed_result = landed::detect_landed(
+            git,
+            repo,
+            &comparison_target,
+            &remote_ref,
+            verbose,
+            landed_options,
+        )?;
+
+        let cls = match &landed_result.classification {
+            Classification::LandedByContent { .. } if landed_result.total > 0 => {
+                landed_result.classification
+            }
+            Classification::LandedByContent { .. } => Classification::Landed,
+            Classification::LandedPartial { .. } => landed_result.classification,
+            _ => Classification::Active,
+        };
+        if verbose {
+            eprintln!(
+                "  {branch_name} (remote): content detection ({}/{}) → {}",
+                landed_result.matched,
+                landed_result.total,
+                cls.label(),
+            );
+        }
+        cls
+    };
+
+    Ok(BranchClassification {
+        classification,
+        remote_tracking: true,
+        remote_deleted: false,
+        ahead,
+        behind,
+        diverged: behind > behind_threshold,
+    })
+}
+
 /// Classify a single worktree.
 ///
 /// Resolves the branch from the worktree, delegates to `classify_branch` for
@@ -868,5 +944,91 @@ mod tests {
         assert_eq!(info.classification, Classification::LandedStale);
         assert!(info.annotations.dirty);
         assert_eq!(info.annotations.dirty_file_count, 1);
+    }
+
+    // --- classify_remote_branch tests ---
+
+    #[test]
+    fn classify_remote_branch_landed() {
+        // Remote branch whose commits are all reachable from origin/main
+        let git = MockGitBuilder::new()
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/main", true)
+            .with_rev_list_counts(&repo(), "origin/main", "origin/feature/done", (0, 0))
+            .with_is_ancestor(&repo(), "origin/feature/done", "origin/main", true)
+            .build();
+
+        let result = classify_remote_branch(
+            &git,
+            &repo(),
+            "feature/done",
+            "main",
+            100,
+            false,
+            &LandedOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(result.classification, Classification::Landed);
+        assert!(result.remote_tracking);
+        assert!(!result.remote_deleted);
+    }
+
+    #[test]
+    fn classify_remote_branch_active() {
+        // Remote branch with commits not yet merged into origin/main
+        let git = MockGitBuilder::new()
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/main", true)
+            .with_rev_list_counts(&repo(), "origin/main", "origin/feature/wip", (5, 3))
+            .with_is_ancestor(&repo(), "origin/feature/wip", "origin/main", false)
+            .with_log_exclusive(
+                &repo(),
+                "origin/main",
+                "origin/feature/wip",
+                vec![("abc".into(), "add feature".into())],
+            )
+            .build();
+
+        let result = classify_remote_branch(
+            &git,
+            &repo(),
+            "feature/wip",
+            "main",
+            100,
+            false,
+            &LandedOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(result.classification, Classification::Active);
+        assert!(result.remote_tracking);
+        assert_eq!(result.ahead, 3);
+        assert_eq!(result.behind, 5);
+    }
+
+    #[test]
+    fn classify_remote_branch_diverged() {
+        let git = MockGitBuilder::new()
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/main", true)
+            .with_rev_list_counts(&repo(), "origin/main", "origin/feature/old", (150, 5))
+            .with_is_ancestor(&repo(), "origin/feature/old", "origin/main", false)
+            .with_log_exclusive(
+                &repo(),
+                "origin/main",
+                "origin/feature/old",
+                vec![("jkl".into(), "old work".into())],
+            )
+            .build();
+
+        let result = classify_remote_branch(
+            &git,
+            &repo(),
+            "feature/old",
+            "main",
+            100,
+            false,
+            &LandedOptions::default(),
+        )
+        .unwrap();
+        assert!(result.diverged);
+        assert_eq!(result.behind, 150);
+        assert_eq!(result.classification, Classification::Active);
     }
 }

--- a/crates/git-tidy-core/src/git.rs
+++ b/crates/git-tidy-core/src/git.rs
@@ -1007,7 +1007,8 @@ impl GitOps for RealGit {
             }
         }
 
-        results.sort_by(|a, b| b.1.cmp(&a.1));
+        // Sort by size descending for readability
+        results.sort_by_key(|b| std::cmp::Reverse(b.1));
         Ok(results)
     }
 }

--- a/crates/git-tidy/src/inprocess.rs
+++ b/crates/git-tidy/src/inprocess.rs
@@ -246,6 +246,7 @@ fn run_tool_scan(
                 DEFAULT_BEHIND_THRESHOLD,
                 verbose,
                 &filter,
+                false, // exclude remote-only branches from audit
                 progress,
             ),
             spec,


### PR DESCRIPTION
## Summary

- Extends `--include-remote` to discover and remove branches that exist only on the remote (no local counterpart)
- Adds `classify_remote_branch` in git-tidy-core for classifying remote-only branches using `origin/<branch>` as the git ref
- Remote-only branches are annotated as "remote" in human output, "remote_only" in porcelain, and include a `remote_only` field in JSON
- The in-process audit excludes remote-only branches to avoid noise

Closes #114

## Test plan

- [x] Unit tests for `classify_remote_branch` (landed, active, diverged)
- [x] Unit tests for remote-only branch discovery in scan (discovers, excludes when flag off, skips default/HEAD)
- [x] Unit tests for remote-only branch cleanup (delete, dry run, mixed local+remote)
- [x] Unit tests for remote annotation in all output formats (human, porcelain, JSON)
- [x] CLI parse test for `scan --include-remote`
- [x] All existing tests pass unchanged
- [x] `cargo fmt --check`, `cargo clippy --workspace` clean