### PR TITLE
Add Dependabot config for cargo and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` with weekly updates for `cargo` (workspace root) and `github-actions`.
- Group minor + patch updates per ecosystem so the weekly noise stays at ~1 PR each; majors surface individually.
- Raise the cargo open-PR limit to 10 to accommodate the 9 binary crates + shared core library all pinning common deps.

Closes #123

## Test plan

- [ ] Confirm Dependabot picks up the config (first run will be visible under the Insights → Dependency graph → Dependabot tab on GitHub).
- [ ] On the first generated PR, verify CI runs (`cargo fmt --check`, clippy, tests, `cargo audit`, MSRV check) and gates the merge.