### PR TITLE
Remove unimplemented --yes flag and interactivity language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ This is a Cargo workspace with a shared core library and seven binary crates.
 All tools follow a similar CLI shape:
 - **Global args**: `directory` (positional, default cwd), plus tool-specific thresholds
 - **Scan subcommand** (default): `--json`, `--porcelain`
-- **Clean subcommand**: `--dry-run` / `-n`, `--yes` / `-y`, classification filters, `--all`, `--json`, `--porcelain`
+- **Clean subcommand**: `--dry-run` / `-n`, classification filters, `--all`, `--json`, `--porcelain`. Clean runs non-interactively; there is no confirmation prompt.
 - Worktree-tidy global args: `--behind-threshold` (default 100), `--verbose` / `-v`, `--match` (repeatable substring filter on worktree basenames, OR semantics, case-insensitive)
 - Branch-tidy global args: `--behind-threshold` (default 100), `--verbose` / `-v`
 - Stash-tidy global arg: `--age-threshold` (default 90) instead of `--behind-threshold`/`--verbose`

--- a/crates/git-branch-tidy/src/clean.rs
+++ b/crates/git-branch-tidy/src/clean.rs
@@ -13,9 +13,6 @@ pub struct CleanOptions {
     pub dry_run: bool,
     /// Force-delete branches (git branch -D instead of -d).
     pub force: bool,
-    /// Skip confirmation prompts.
-    #[allow(dead_code)]
-    pub yes: bool,
     /// Only target structurally-proven landed branches.
     pub strict: bool,
     /// Include all classifications in the interactive flow.
@@ -270,7 +267,6 @@ mod tests {
         CleanOptions {
             dry_run: false,
             force: false,
-            yes: false,
             strict: false,
             all: false,
             include_remote: false,

--- a/crates/git-branch-tidy/src/cli.rs
+++ b/crates/git-branch-tidy/src/cli.rs
@@ -5,7 +5,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser, Debug)]
 #[command(
     name = "git-branch-tidy",
-    about = "Scan, classify, and interactively remove stale local Git branches"
+    about = "Scan, classify, and remove stale local Git branches"
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -60,7 +60,7 @@ pub enum Command {
     #[command(flatten)]
     Shared(git_tidy_core::cli::SharedCommands),
 
-    /// Scan and interactively remove stale local branches
+    /// Scan and remove stale local branches
     Clean {
         /// Show what would be removed without removing
         #[arg(short = 'n', long)]
@@ -70,15 +70,11 @@ pub enum Command {
         #[arg(short, long)]
         force: bool,
 
-        /// Skip confirmation prompts (accept all defaults)
-        #[arg(short = 'y', long)]
-        yes: bool,
-
         /// Only target structurally-proven landed branches
         #[arg(long)]
         strict: bool,
 
-        /// Include active and local branches in the interactive clean flow
+        /// Include active and local branches in the clean flow
         #[arg(long)]
         all: bool,
 
@@ -129,7 +125,6 @@ mod tests {
             "clean",
             "--dry-run",
             "--force",
-            "--yes",
             "--strict",
             "--include-remote",
         ]);
@@ -137,14 +132,12 @@ mod tests {
             Some(Command::Clean {
                 dry_run,
                 force,
-                yes,
                 strict,
                 include_remote,
                 ..
             }) => {
                 assert!(dry_run);
                 assert!(force);
-                assert!(yes);
                 assert!(strict);
                 assert!(include_remote);
             }

--- a/crates/git-branch-tidy/src/main.rs
+++ b/crates/git-branch-tidy/src/main.rs
@@ -73,7 +73,6 @@ fn main() {
         Some(cli::Command::Clean {
             dry_run,
             force,
-            yes,
             strict,
             all,
             include_remote,
@@ -95,7 +94,6 @@ fn main() {
                     let options = clean::CleanOptions {
                         dry_run: *dry_run,
                         force: *force,
-                        yes: *yes,
                         strict: *strict,
                         all: *all,
                         include_remote: *include_remote,

--- a/crates/git-branch-tidy/tests/integration_clean.rs
+++ b/crates/git-branch-tidy/tests/integration_clean.rs
@@ -60,7 +60,6 @@ fn clean_deletes_merged_branch_in_real_repo() {
     let options = git_branch_tidy::clean::CleanOptions {
         dry_run: false,
         force: false,
-        yes: true,
         strict: false,
         all: false,
         include_remote: false,
@@ -101,7 +100,6 @@ fn clean_dry_run_does_not_delete() {
     let options = git_branch_tidy::clean::CleanOptions {
         dry_run: true,
         force: false,
-        yes: true,
         strict: false,
         all: false,
         include_remote: false,
@@ -151,7 +149,6 @@ fn clean_safe_refuses_unmerged_branch() {
     let options = git_branch_tidy::clean::CleanOptions {
         dry_run: false,
         force: false,
-        yes: true,
         strict: false,
         all: true,
         include_remote: false,

--- a/crates/git-config-tidy/src/cli.rs
+++ b/crates/git-config-tidy/src/cli.rs
@@ -50,10 +50,6 @@ pub enum Command {
         #[arg(short = 'n', long)]
         dry_run: bool,
 
-        /// Skip confirmation prompts
-        #[arg(short = 'y', long)]
-        yes: bool,
-
         /// Output results as JSON
         #[arg(long)]
         json: bool,
@@ -116,11 +112,10 @@ mod tests {
 
     #[test]
     fn fix_with_flags() {
-        let cli = Cli::parse_from(["git-config-tidy", "fix", "--dry-run", "--yes"]);
+        let cli = Cli::parse_from(["git-config-tidy", "fix", "--dry-run"]);
         match cli.command {
-            Some(Command::Fix { dry_run, yes, .. }) => {
+            Some(Command::Fix { dry_run, .. }) => {
                 assert!(dry_run);
-                assert!(yes);
             }
             _ => panic!("expected Fix command"),
         }
@@ -128,11 +123,10 @@ mod tests {
 
     #[test]
     fn fix_short_flags() {
-        let cli = Cli::parse_from(["git-config-tidy", "fix", "-n", "-y"]);
+        let cli = Cli::parse_from(["git-config-tidy", "fix", "-n"]);
         match cli.command {
-            Some(Command::Fix { dry_run, yes, .. }) => {
+            Some(Command::Fix { dry_run, .. }) => {
                 assert!(dry_run);
-                assert!(yes);
             }
             _ => panic!("expected Fix command"),
         }

--- a/crates/git-config-tidy/src/fix.rs
+++ b/crates/git-config-tidy/src/fix.rs
@@ -11,9 +11,6 @@ use crate::types::{ConfigLintResult, IssueKind};
 pub struct FixOptions {
     /// Preview only: print what would be fixed.
     pub dry_run: bool,
-    /// Skip confirmation prompts.
-    #[allow(dead_code)]
-    pub yes: bool,
 }
 
 /// A config issue that was successfully fixed.
@@ -174,10 +171,7 @@ mod tests {
     }
 
     fn default_options() -> FixOptions {
-        FixOptions {
-            dry_run: false,
-            yes: false,
-        }
+        FixOptions { dry_run: false }
     }
 
     #[test]
@@ -218,10 +212,7 @@ mod tests {
         let git = MockGitBuilder::new().build();
         let lint = make_lint_result(vec![orphaned_issue("stale-branch")]);
         let mut buf = Vec::new();
-        let options = FixOptions {
-            dry_run: true,
-            yes: false,
-        };
+        let options = FixOptions { dry_run: true };
 
         let result = run_fix(&git, &lint, &options, &mut buf).unwrap();
 

--- a/crates/git-config-tidy/src/main.rs
+++ b/crates/git-config-tidy/src/main.rs
@@ -59,7 +59,6 @@ fn main() {
         }
         Some(cli::Command::Fix {
             dry_run,
-            yes,
             json,
             porcelain,
         }) => match lint::run_lint(&git, &directory, cli.verbose, &repo_filter, &progress) {
@@ -77,10 +76,7 @@ fn main() {
                     process::exit(1);
                 }
 
-                let options = fix::FixOptions {
-                    dry_run: *dry_run,
-                    yes: *yes,
-                };
+                let options = fix::FixOptions { dry_run: *dry_run };
 
                 match fix::run_fix(&git, &lint_result, &options, &mut stdout) {
                     Ok(result) => {

--- a/crates/git-config-tidy/tests/integration_fix.rs
+++ b/crates/git-config-tidy/tests/integration_fix.rs
@@ -59,10 +59,7 @@ fn fix_removes_orphaned_config() {
         warnings: vec![],
     };
 
-    let options = FixOptions {
-        dry_run: false,
-        yes: true,
-    };
+    let options = FixOptions { dry_run: false };
     let mut buf = Vec::new();
     let result = fix::run_fix(&git_ops, &lint_result, &options, &mut buf).unwrap();
 
@@ -99,10 +96,7 @@ fn fix_dry_run_preserves_config() {
         warnings: vec![],
     };
 
-    let options = FixOptions {
-        dry_run: true,
-        yes: true,
-    };
+    let options = FixOptions { dry_run: true };
     let mut buf = Vec::new();
     let result = fix::run_fix(&git_ops, &lint_result, &options, &mut buf).unwrap();
 

--- a/crates/git-lfs-tidy/src/clean.rs
+++ b/crates/git-lfs-tidy/src/clean.rs
@@ -11,9 +11,6 @@ use crate::types::{LfsClassification, LfsScanResult};
 pub struct CleanOptions {
     /// Preview only: print what would be removed.
     pub dry_run: bool,
-    /// Skip confirmation prompts.
-    #[allow(dead_code)]
-    pub yes: bool,
     /// Enable pruning of orphaned LFS objects.
     pub prune: bool,
 }
@@ -195,7 +192,6 @@ mod tests {
     fn default_options() -> CleanOptions {
         CleanOptions {
             dry_run: false,
-            yes: false,
             prune: false,
         }
     }
@@ -213,7 +209,7 @@ mod tests {
         let mut buf = Vec::new();
         let options = CleanOptions {
             prune: true,
-            ..default_options()
+            dry_run: false,
         };
 
         let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
@@ -241,7 +237,6 @@ mod tests {
         let options = CleanOptions {
             dry_run: true,
             prune: true,
-            ..default_options()
         };
 
         let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
@@ -285,7 +280,7 @@ mod tests {
         let mut buf = Vec::new();
         let options = CleanOptions {
             prune: true,
-            ..default_options()
+            dry_run: false,
         };
 
         let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
@@ -315,7 +310,7 @@ mod tests {
         let mut buf = Vec::new();
         let options = CleanOptions {
             prune: true,
-            ..default_options()
+            dry_run: false,
         };
 
         let result = run_clean(&git, &scan, &options, &mut buf).unwrap();

--- a/crates/git-lfs-tidy/src/cli.rs
+++ b/crates/git-lfs-tidy/src/cli.rs
@@ -58,10 +58,6 @@ pub enum Command {
         #[arg(short = 'n', long)]
         dry_run: bool,
 
-        /// Skip confirmation prompts
-        #[arg(short = 'y', long)]
-        yes: bool,
-
         /// Enable pruning of orphaned LFS objects
         #[arg(long)]
         prune: bool,
@@ -148,16 +144,10 @@ mod tests {
 
     #[test]
     fn clean_with_flags() {
-        let cli = Cli::parse_from(["git-lfs-tidy", "clean", "--dry-run", "--yes", "--prune"]);
+        let cli = Cli::parse_from(["git-lfs-tidy", "clean", "--dry-run", "--prune"]);
         match cli.command {
-            Some(Command::Clean {
-                dry_run,
-                yes,
-                prune,
-                ..
-            }) => {
+            Some(Command::Clean { dry_run, prune, .. }) => {
                 assert!(dry_run);
-                assert!(yes);
                 assert!(prune);
             }
             _ => panic!("expected Clean command"),

--- a/crates/git-lfs-tidy/src/main.rs
+++ b/crates/git-lfs-tidy/src/main.rs
@@ -90,12 +90,7 @@ fn main() {
                 Err(e) => error::exit_with_error(&e),
             }
         }
-        Some(cli::Command::Clean {
-            dry_run,
-            yes,
-            prune,
-            ..
-        }) => match scan::run_scan(
+        Some(cli::Command::Clean { dry_run, prune, .. }) => match scan::run_scan(
             &git,
             &directory,
             size_threshold,
@@ -107,7 +102,6 @@ fn main() {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,
-                    yes: *yes,
                     prune: *prune,
                 };
 

--- a/crates/git-lfs-tidy/tests/integration_clean.rs
+++ b/crates/git-lfs-tidy/tests/integration_clean.rs
@@ -61,7 +61,6 @@ fn clean_dry_run_with_untracked_blobs() {
 
     let options = CleanOptions {
         dry_run: true,
-        yes: false,
         prune: true,
     };
 
@@ -98,7 +97,6 @@ fn clean_with_no_orphaned_is_noop() {
 
     let options = CleanOptions {
         dry_run: false,
-        yes: true,
         prune: true,
     };
 

--- a/crates/git-remote-tidy/src/clean.rs
+++ b/crates/git-remote-tidy/src/clean.rs
@@ -11,9 +11,6 @@ use crate::types::{RemoteClassification, RemoteScanResult};
 pub struct CleanOptions {
     /// Preview only: print what would be removed.
     pub dry_run: bool,
-    /// Skip confirmation prompts.
-    #[allow(dead_code)]
-    pub yes: bool,
     /// Allow removing the origin remote.
     pub force: bool,
     /// Include orphaned remotes (default: unreachable only).
@@ -184,7 +181,6 @@ mod tests {
     fn default_options() -> CleanOptions {
         CleanOptions {
             dry_run: false,
-            yes: false,
             force: false,
             all: false,
         }

--- a/crates/git-remote-tidy/src/cli.rs
+++ b/crates/git-remote-tidy/src/cli.rs
@@ -56,15 +56,11 @@ pub enum Command {
     #[command(flatten)]
     Shared(git_tidy_core::cli::SharedCommands),
 
-    /// Scan and interactively remove stale remotes
+    /// Scan and remove stale remotes
     Clean {
         /// Show what would be removed without removing
         #[arg(short = 'n', long)]
         dry_run: bool,
-
-        /// Skip confirmation prompts
-        #[arg(short = 'y', long)]
-        yes: bool,
 
         /// Allow removing the origin remote
         #[arg(short = 'f', long)]
@@ -125,16 +121,10 @@ mod tests {
 
     #[test]
     fn clean_with_flags() {
-        let cli = Cli::parse_from(["git-remote-tidy", "clean", "--dry-run", "--yes", "--force"]);
+        let cli = Cli::parse_from(["git-remote-tidy", "clean", "--dry-run", "--force"]);
         match cli.command {
-            Some(Command::Clean {
-                dry_run,
-                yes,
-                force,
-                ..
-            }) => {
+            Some(Command::Clean { dry_run, force, .. }) => {
                 assert!(dry_run);
-                assert!(yes);
                 assert!(force);
             }
             _ => panic!("expected Clean command"),

--- a/crates/git-remote-tidy/src/main.rs
+++ b/crates/git-remote-tidy/src/main.rs
@@ -68,7 +68,6 @@ fn main() {
         }
         Some(cli::Command::Clean {
             dry_run,
-            yes,
             force,
             all,
             ..
@@ -84,7 +83,6 @@ fn main() {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,
-                    yes: *yes,
                     force: *force,
                     all: *all,
                 };

--- a/crates/git-remote-tidy/tests/integration_clean.rs
+++ b/crates/git-remote-tidy/tests/integration_clean.rs
@@ -54,7 +54,6 @@ fn clean_removes_remote_in_real_repo() {
 
     let options = git_remote_tidy::clean::CleanOptions {
         dry_run: false,
-        yes: true,
         force: false,
         all: false,
     };
@@ -94,7 +93,6 @@ fn clean_dry_run_does_not_remove() {
 
     let options = git_remote_tidy::clean::CleanOptions {
         dry_run: true,
-        yes: true,
         force: false,
         all: false,
     };
@@ -153,7 +151,6 @@ fn clean_prunes_orphaned_refs() {
 
     let options = git_remote_tidy::clean::CleanOptions {
         dry_run: false,
-        yes: true,
         force: false,
         all: true,
     };

--- a/crates/git-repo-tidy/src/clean.rs
+++ b/crates/git-repo-tidy/src/clean.rs
@@ -10,9 +10,6 @@ use crate::types::{RepoClassification, RepoScanResult};
 pub struct CleanOptions {
     /// Preview only: print what would be removed.
     pub dry_run: bool,
-    /// Skip confirmation prompts.
-    #[allow(dead_code)]
-    pub yes: bool,
     /// Allow deleting dirty repos.
     pub force: bool,
     /// Only delete stale repos.
@@ -184,7 +181,6 @@ mod tests {
     fn default_options() -> CleanOptions {
         CleanOptions {
             dry_run: false,
-            yes: true,
             force: false,
             stale_only: false,
             orphaned_only: false,

--- a/crates/git-repo-tidy/src/cli.rs
+++ b/crates/git-repo-tidy/src/cli.rs
@@ -60,15 +60,11 @@ pub enum Command {
     #[command(flatten)]
     Shared(git_tidy_core::cli::SharedCommands),
 
-    /// Scan and interactively remove stale repositories
+    /// Scan and remove stale repositories
     Clean {
         /// Show what would be removed without removing
         #[arg(short = 'n', long)]
         dry_run: bool,
-
-        /// Skip confirmation prompts
-        #[arg(short = 'y', long)]
-        yes: bool,
 
         /// Allow deleting dirty repos
         #[arg(short = 'f', long)]
@@ -143,16 +139,10 @@ mod tests {
 
     #[test]
     fn clean_with_flags() {
-        let cli = Cli::parse_from(["git-repo-tidy", "clean", "--dry-run", "--yes", "--force"]);
+        let cli = Cli::parse_from(["git-repo-tidy", "clean", "--dry-run", "--force"]);
         match cli.command {
-            Some(Command::Clean {
-                dry_run,
-                yes,
-                force,
-                ..
-            }) => {
+            Some(Command::Clean { dry_run, force, .. }) => {
                 assert!(dry_run);
-                assert!(yes);
                 assert!(force);
             }
             _ => panic!("expected Clean command"),

--- a/crates/git-repo-tidy/src/main.rs
+++ b/crates/git-repo-tidy/src/main.rs
@@ -85,7 +85,6 @@ fn main() {
         }
         Some(cli::Command::Clean {
             dry_run,
-            yes,
             force,
             stale_only,
             orphaned_only,
@@ -104,7 +103,6 @@ fn main() {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,
-                    yes: *yes,
                     force: *force,
                     stale_only: *stale_only,
                     orphaned_only: *orphaned_only,

--- a/crates/git-repo-tidy/tests/integration_clean.rs
+++ b/crates/git-repo-tidy/tests/integration_clean.rs
@@ -26,7 +26,6 @@ fn set_up_orphaned_repo(base: &std::path::Path) -> std::path::PathBuf {
 fn default_options() -> CleanOptions {
     CleanOptions {
         dry_run: false,
-        yes: true,
         force: false,
         stale_only: false,
         orphaned_only: false,

--- a/crates/git-stash-tidy/src/clean.rs
+++ b/crates/git-stash-tidy/src/clean.rs
@@ -11,9 +11,6 @@ use crate::types::{StashClassification, StashScanResult};
 pub struct CleanOptions {
     /// Preview only: print what would be dropped.
     pub dry_run: bool,
-    /// Skip confirmation prompts.
-    #[allow(dead_code)]
-    pub yes: bool,
     /// Only target committed stashes.
     pub committed_only: bool,
     /// Only target aged stashes.
@@ -171,7 +168,6 @@ mod tests {
     fn default_options() -> CleanOptions {
         CleanOptions {
             dry_run: false,
-            yes: false,
             committed_only: false,
             aged_only: false,
             all: false,

--- a/crates/git-stash-tidy/src/cli.rs
+++ b/crates/git-stash-tidy/src/cli.rs
@@ -5,7 +5,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser, Debug)]
 #[command(
     name = "git-stash-tidy",
-    about = "Scan, classify, and interactively drop stale Git stashes"
+    about = "Scan, classify, and drop stale Git stashes"
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -56,15 +56,11 @@ pub enum Command {
     #[command(flatten)]
     Shared(git_tidy_core::cli::SharedCommands),
 
-    /// Scan and interactively drop stale stashes
+    /// Scan and drop stale stashes
     Clean {
         /// Show what would be dropped without dropping
         #[arg(short = 'n', long)]
         dry_run: bool,
-
-        /// Skip confirmation prompts
-        #[arg(short = 'y', long)]
-        yes: bool,
 
         /// Only target committed stashes
         #[arg(long)]
@@ -116,22 +112,14 @@ mod tests {
 
     #[test]
     fn clean_with_flags() {
-        let cli = Cli::parse_from([
-            "git-stash-tidy",
-            "clean",
-            "--dry-run",
-            "--yes",
-            "--committed-only",
-        ]);
+        let cli = Cli::parse_from(["git-stash-tidy", "clean", "--dry-run", "--committed-only"]);
         match cli.command {
             Some(Command::Clean {
                 dry_run,
-                yes,
                 committed_only,
                 ..
             }) => {
                 assert!(dry_run);
-                assert!(yes);
                 assert!(committed_only);
             }
             _ => panic!("expected Clean command"),

--- a/crates/git-stash-tidy/src/main.rs
+++ b/crates/git-stash-tidy/src/main.rs
@@ -68,7 +68,6 @@ fn main() {
         }
         Some(cli::Command::Clean {
             dry_run,
-            yes,
             committed_only,
             aged_only,
             all,
@@ -85,7 +84,6 @@ fn main() {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,
-                    yes: *yes,
                     committed_only: *committed_only,
                     aged_only: *aged_only,
                     all: *all,

--- a/crates/git-stash-tidy/tests/integration_clean.rs
+++ b/crates/git-stash-tidy/tests/integration_clean.rs
@@ -56,7 +56,6 @@ fn clean_drops_stash_in_real_repo() {
 
     let options = git_stash_tidy::clean::CleanOptions {
         dry_run: false,
-        yes: true,
         committed_only: false,
         aged_only: false,
         all: false,
@@ -100,7 +99,6 @@ fn clean_dry_run_does_not_drop() {
 
     let options = git_stash_tidy::clean::CleanOptions {
         dry_run: true,
-        yes: true,
         committed_only: false,
         aged_only: false,
         all: false,

--- a/crates/git-tag-tidy/src/clean.rs
+++ b/crates/git-tag-tidy/src/clean.rs
@@ -12,9 +12,6 @@ use crate::types::{TagClassification, TagScanResult};
 pub struct CleanOptions {
     /// Preview only: print what would be removed.
     pub dry_run: bool,
-    /// Skip confirmation prompts.
-    #[allow(dead_code)]
-    pub yes: bool,
     /// Allow deleting synced tags and bypass release tag warnings.
     pub force: bool,
     /// Only delete stale tags.
@@ -242,7 +239,6 @@ mod tests {
     fn default_options() -> CleanOptions {
         CleanOptions {
             dry_run: false,
-            yes: false,
             force: false,
             stale_only: false,
             local_only: false,

--- a/crates/git-tag-tidy/src/cli.rs
+++ b/crates/git-tag-tidy/src/cli.rs
@@ -56,15 +56,11 @@ pub enum Command {
     #[command(flatten)]
     Shared(git_tidy_core::cli::SharedCommands),
 
-    /// Scan and interactively remove stale tags
+    /// Scan and remove stale tags
     Clean {
         /// Show what would be removed without removing
         #[arg(short = 'n', long)]
         dry_run: bool,
-
-        /// Skip confirmation prompts
-        #[arg(short = 'y', long)]
-        yes: bool,
 
         /// Allow deleting synced tags and bypass release tag warnings
         #[arg(short = 'f', long)]
@@ -137,16 +133,10 @@ mod tests {
 
     #[test]
     fn clean_with_flags() {
-        let cli = Cli::parse_from(["git-tag-tidy", "clean", "--dry-run", "--yes", "--force"]);
+        let cli = Cli::parse_from(["git-tag-tidy", "clean", "--dry-run", "--force"]);
         match cli.command {
-            Some(Command::Clean {
-                dry_run,
-                yes,
-                force,
-                ..
-            }) => {
+            Some(Command::Clean { dry_run, force, .. }) => {
                 assert!(dry_run);
-                assert!(yes);
                 assert!(force);
             }
             _ => panic!("expected Clean command"),

--- a/crates/git-tag-tidy/src/main.rs
+++ b/crates/git-tag-tidy/src/main.rs
@@ -68,7 +68,6 @@ fn main() {
         }
         Some(cli::Command::Clean {
             dry_run,
-            yes,
             force,
             stale_only,
             local_only,
@@ -87,7 +86,6 @@ fn main() {
             Ok(scan_result) => {
                 let options = clean::CleanOptions {
                     dry_run: *dry_run,
-                    yes: *yes,
                     force: *force,
                     stale_only: *stale_only,
                     local_only: *local_only,

--- a/crates/git-tag-tidy/tests/integration_clean.rs
+++ b/crates/git-tag-tidy/tests/integration_clean.rs
@@ -58,7 +58,6 @@ fn clean_removes_local_only_tag() {
 
     let options = git_tag_tidy::clean::CleanOptions {
         dry_run: false,
-        yes: true,
         force: false,
         stale_only: false,
         local_only: false,
@@ -105,7 +104,6 @@ fn clean_dry_run_preserves_tags() {
 
     let options = git_tag_tidy::clean::CleanOptions {
         dry_run: true,
-        yes: true,
         force: false,
         stale_only: false,
         local_only: false,
@@ -161,7 +159,6 @@ fn clean_removes_stale_tag() {
 
     let options = git_tag_tidy::clean::CleanOptions {
         dry_run: false,
-        yes: true,
         force: false,
         stale_only: false,
         local_only: false,
@@ -217,7 +214,6 @@ fn clean_include_remote_deletes_from_remote() {
 
     let options = git_tag_tidy::clean::CleanOptions {
         dry_run: false,
-        yes: true,
         force: false,
         stale_only: false,
         local_only: false,

--- a/crates/git-worktree-tidy/src/clean.rs
+++ b/crates/git-worktree-tidy/src/clean.rs
@@ -11,9 +11,6 @@ pub struct CleanOptions {
     pub dry_run: bool,
     /// Remove worktrees with meaningful uncommitted changes.
     pub force: bool,
-    /// Skip confirmation prompts.
-    #[allow(dead_code)]
-    pub yes: bool,
     /// Only target structurally-proven landed worktrees.
     pub strict: bool,
     /// Include active and local worktrees in the clean flow.
@@ -274,7 +271,6 @@ mod tests {
         CleanOptions {
             dry_run: false,
             force: false,
-            yes: false,
             strict: false,
             all: false,
             delete_branches: false,

--- a/crates/git-worktree-tidy/src/cli.rs
+++ b/crates/git-worktree-tidy/src/cli.rs
@@ -5,7 +5,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser, Debug)]
 #[command(
     name = "git-worktree-tidy",
-    about = "Scan, classify, and interactively remove stale Git worktrees"
+    about = "Scan, classify, and remove stale Git worktrees"
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -64,7 +64,7 @@ pub enum Command {
     #[command(flatten)]
     Shared(git_tidy_core::cli::SharedCommands),
 
-    /// Scan and interactively remove stale worktrees
+    /// Scan and remove stale worktrees
     Clean {
         /// Show what would be removed without removing
         #[arg(short = 'n', long)]
@@ -74,15 +74,11 @@ pub enum Command {
         #[arg(short, long)]
         force: bool,
 
-        /// Skip confirmation prompts (accept all defaults)
-        #[arg(short = 'y', long)]
-        yes: bool,
-
         /// Only target structurally-proven landed worktrees
         #[arg(long)]
         strict: bool,
 
-        /// Include active and local worktrees in the interactive clean flow
+        /// Include active and local worktrees in the clean flow
         #[arg(long)]
         all: bool,
 
@@ -133,7 +129,6 @@ mod tests {
             "clean",
             "--dry-run",
             "--force",
-            "--yes",
             "--strict",
             "--delete-branches",
         ]);
@@ -141,14 +136,12 @@ mod tests {
             Some(Command::Clean {
                 dry_run,
                 force,
-                yes,
                 strict,
                 delete_branches,
                 ..
             }) => {
                 assert!(dry_run);
                 assert!(force);
-                assert!(yes);
                 assert!(strict);
                 assert!(delete_branches);
             }

--- a/crates/git-worktree-tidy/src/main.rs
+++ b/crates/git-worktree-tidy/src/main.rs
@@ -85,7 +85,6 @@ fn main() {
         Some(cli::Command::Clean {
             dry_run,
             force,
-            yes,
             strict,
             all,
             delete_branches,
@@ -106,7 +105,6 @@ fn main() {
                     let options = clean::CleanOptions {
                         dry_run: *dry_run,
                         force: *force,
-                        yes: *yes,
                         strict: *strict,
                         all: *all,
                         delete_branches: *delete_branches,


### PR DESCRIPTION
## Summary

- Every clean/fix tool advertised \`--yes\` / \`-y\` and "interactive" cleanup, but no tool ever read the flag — running \`clean\` was always non-interactive and deleted immediately.
- Removes the flag entirely from CLI, options structs, main.rs propagation, tests, and CLAUDE.md.
- Rewrites \`about\` and \`Clean\` doc strings to describe what the tools actually do; CLAUDE.md gains an explicit "Clean runs non-interactively" note.

Closes #136

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo test --workspace\` — 47 test binaries pass
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D clippy::all\` — no errors (pre-existing dead-code warnings unchanged)