### PR TITLE
Fail closed when read-side git queries error before a destructive op

### DIFF
--- a/crates/git-branch-tidy/src/scan.rs
+++ b/crates/git-branch-tidy/src/scan.rs
@@ -94,7 +94,18 @@ pub fn run_scan_repos(
                 }
             };
 
-            let current = git.current_branch(repo_path).unwrap_or(None);
+            // Fail closed: if we cannot determine the current branch, drop this repo from the scan.
+            // is_current gates the safety check in clean.rs that prevents deleting the checked-out branch.
+            let current = match git.current_branch(repo_path) {
+                Ok(b) => b,
+                Err(e) => {
+                    local_warnings.push(format!(
+                        "could not determine current branch for {}: {e}",
+                        repo_path.display()
+                    ));
+                    return (None, local_warnings);
+                }
+            };
             let repo_name = repo_display_name(repo_path);
 
             if verbose {
@@ -168,7 +179,14 @@ pub fn run_scan_repos(
             if include_remote {
                 let local_names: HashSet<&str> = branches.iter().map(|b| b.as_str()).collect();
 
-                if let Ok(tracking_refs) = git.list_remote_tracking_refs(repo_path) {
+                let tracking_refs_result = git.list_remote_tracking_refs(repo_path);
+                if let Err(e) = &tracking_refs_result {
+                    local_warnings.push(format!(
+                        "could not list remote tracking refs for {}: {e}",
+                        repo_path.display()
+                    ));
+                }
+                if let Ok(tracking_refs) = tracking_refs_result {
                     let remote_only_names: Vec<String> = tracking_refs
                         .iter()
                         .filter_map(|(short, _full)| {
@@ -532,6 +550,56 @@ mod tests {
         let result = run_scan_repos(&git, &[repo()], 100, false, &filter, false, &p).unwrap();
         assert_eq!(result.total_scanned, 0);
         assert!(result.repos.is_empty());
+    }
+
+    #[test]
+    fn scan_drops_repo_when_current_branch_errors() {
+        // Regression: previously `current_branch().unwrap_or(None)` silently masked errors, leaving is_current unset on every branch — so the clean.rs safety check that prevents deleting the checked-out branch could not fire.
+        let git = MockGitBuilder::new()
+            .with_symbolic_ref(&repo(), Some("main"))
+            .with_local_branches(&repo(), vec!["main".to_string()])
+            .with_current_branch_error(&repo(), "HEAD is unreadable")
+            .build();
+
+        let p = Progress::disabled();
+        let filter = NameFilter::default();
+        let result = run_scan_repos(&git, &[repo()], 100, false, &filter, false, &p).unwrap();
+
+        // No branches scanned for this repo.
+        assert!(result.repos.is_empty());
+        // The warning surface must mention the repo and the underlying error.
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("current branch") && w.contains("HEAD is unreadable")),
+            "expected current_branch warning, got: {:?}",
+            result.warnings,
+        );
+    }
+
+    #[test]
+    fn scan_warns_when_remote_tracking_refs_errors_with_include_remote() {
+        // Regression: previously the include_remote path used `if let Ok(...)` and silently produced zero remote-only branches when list_remote_tracking_refs errored. The user could not tell why include_remote returned nothing.
+        let git = MockGitBuilder::new()
+            .with_symbolic_ref(&repo(), Some("main"))
+            .with_local_branches(&repo(), vec!["main".to_string()])
+            .with_current_branch(&repo(), Some("main"))
+            .with_rev_parse_verify(&repo(), "refs/remotes/origin/main", true)
+            .with_list_remote_tracking_refs_error(&repo(), "for-each-ref crashed")
+            .build();
+
+        let p = Progress::disabled();
+        let filter = NameFilter::default();
+        let result = run_scan_repos(&git, &[repo()], 100, false, &filter, true, &p).unwrap();
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("remote tracking refs") && w.contains("for-each-ref crashed")),
+            "expected warning, got: {:?}",
+            result.warnings,
+        );
     }
 
     #[test]

--- a/crates/git-remote-tidy/src/scan.rs
+++ b/crates/git-remote-tidy/src/scan.rs
@@ -85,7 +85,17 @@ pub fn run_scan_repos(
                 }
             };
 
-            let tracking_refs = git.list_remote_tracking_refs(repo_path).unwrap_or_default();
+            // Fail closed: if we cannot enumerate tracking refs, surface the warning. Orphan detection will under-report rather than silently report zero, and the user sees the failure.
+            let tracking_refs = match git.list_remote_tracking_refs(repo_path) {
+                Ok(refs) => refs,
+                Err(e) => {
+                    local_warnings.push(format!(
+                        "could not list remote tracking refs for {}: {e}",
+                        repo_path.display()
+                    ));
+                    Vec::new()
+                }
+            };
 
             let mut tracking_counts: HashMap<String, usize> = HashMap::new();
 
@@ -270,6 +280,29 @@ mod tests {
         let result = run_scan_repos(&git, &[repo()], false, false, &filter, &p).unwrap();
         assert_eq!(result.total_scanned, 1);
         assert_eq!(result.counts.active, 1);
+    }
+
+    #[test]
+    fn scan_warns_when_remote_tracking_refs_errors() {
+        // Regression: previously `list_remote_tracking_refs().unwrap_or_default()` silently returned zero orphaned remotes when the query errored. Fail closed: emit a warning so the user can tell the orphan-detection was incomplete.
+        let git = MockGitBuilder::new()
+            .with_list_remotes(&repo(), vec!["origin".to_string()])
+            .with_ls_remote_check(&repo(), "origin", true)
+            .with_remote_url(&repo(), "origin", "https://example.com/repo.git")
+            .with_list_remote_tracking_refs_error(&repo(), "for-each-ref failed")
+            .build();
+
+        let p = Progress::disabled();
+        let filter = NameFilter::default();
+        let result = run_scan_repos(&git, &[repo()], false, false, &filter, &p).unwrap();
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("tracking refs") && w.contains("for-each-ref failed")),
+            "expected warning, got: {:?}",
+            result.warnings,
+        );
     }
 
     #[test]

--- a/crates/git-repo-tidy/src/scan.rs
+++ b/crates/git-repo-tidy/src/scan.rs
@@ -35,7 +35,7 @@ pub fn disk_usage(path: &Path) -> u64 {
     }
 }
 
-/// Classify a single repository.
+/// Classify a single repository. Returns the classified info plus any non-fatal warnings encountered.
 pub fn classify_repo(
     git: &dyn GitOps,
     repo_path: &Path,
@@ -43,7 +43,8 @@ pub fn classify_repo(
     noise_patterns: &[String],
     offline: bool,
     du_fn: &dyn Fn(&Path) -> u64,
-) -> RepoInfo {
+) -> (RepoInfo, Vec<String>) {
+    let mut warnings = Vec::new();
     let name = repo_display_name(repo_path);
 
     // Last commit date and age
@@ -63,17 +64,29 @@ pub fn classify_repo(
         .map(|b| b.len())
         .unwrap_or(0);
 
-    // Remote detection and reachability
-    let remotes = git.list_remotes(repo_path).unwrap_or_default();
-    let has_remote = !remotes.is_empty();
+    // Remote detection. Fail closed: if we cannot read the remote list, assume the repo has one and is reachable so it is not classified as Orphaned and rm -rf'd.
+    let (remotes, remotes_readable) = match git.list_remotes(repo_path) {
+        Ok(r) => (r, true),
+        Err(e) => {
+            warnings.push(format!(
+                "could not list remotes for {}: {e} (treating as having a reachable remote to avoid deletion)",
+                repo_path.display()
+            ));
+            (Vec::new(), false)
+        }
+    };
+    let has_remote = !remotes.is_empty() || !remotes_readable;
 
-    let remote_url = if has_remote {
+    let remote_url = if !remotes.is_empty() {
         git.remote_url(repo_path, &remotes[0]).ok()
     } else {
         None
     };
 
-    let any_reachable = if has_remote && !offline {
+    let any_reachable = if !remotes_readable {
+        // Cannot probe — assume reachable so classification falls through to Active/Stale, not Orphaned.
+        true
+    } else if has_remote && !offline {
         remotes
             .iter()
             .any(|r| git.ls_remote_check(repo_path, r).unwrap_or(false))
@@ -99,7 +112,7 @@ pub fn classify_repo(
         RepoClassification::Active
     };
 
-    RepoInfo {
+    let info = RepoInfo {
         path: repo_path.to_path_buf(),
         name,
         classification,
@@ -111,7 +124,8 @@ pub fn classify_repo(
         has_remote,
         is_dirty,
         dirty_file_count,
-    }
+    };
+    (info, warnings)
 }
 
 /// Scan all repos in `directory` and classify them.
@@ -204,7 +218,8 @@ pub fn run_scan_repos_with_du(
     let (mut repos, warnings) = parallel_classify(
         repo_paths,
         |repo_path| {
-            let info = classify_repo(git, repo_path, stale_days, noise_patterns, offline, du_fn);
+            let (info, classify_warnings) =
+                classify_repo(git, repo_path, stale_days, noise_patterns, offline, du_fn);
             if verbose {
                 eprintln!(
                     "{}: {} (age={}d, remote={}, dirty={})",
@@ -216,7 +231,7 @@ pub fn run_scan_repos_with_du(
                     info.is_dirty,
                 );
             }
-            (Some(info), vec![])
+            (Some(info), classify_warnings)
         },
         "Scanning repos",
         progress,
@@ -312,7 +327,7 @@ mod tests {
             .with_ls_remote_check(&r, "origin", true)
             .build();
 
-        let info = classify_repo(&git, &r, 180, &[], false, &no_du);
+        let (info, _warnings) = classify_repo(&git, &r, 180, &[], false, &no_du);
 
         assert_eq!(info.classification, RepoClassification::Active);
         assert_eq!(info.name, "my-project");
@@ -333,7 +348,7 @@ mod tests {
             .with_ls_remote_check(&r, "origin", true)
             .build();
 
-        let info = classify_repo(&git, &r, 180, &[], false, &no_du);
+        let (info, _warnings) = classify_repo(&git, &r, 180, &[], false, &no_du);
 
         assert_eq!(info.classification, RepoClassification::Stale);
     }
@@ -348,7 +363,7 @@ mod tests {
             .with_list_remotes(&r, vec![])
             .build();
 
-        let info = classify_repo(&git, &r, 180, &[], false, &no_du);
+        let (info, _warnings) = classify_repo(&git, &r, 180, &[], false, &no_du);
 
         assert_eq!(info.classification, RepoClassification::Orphaned);
         assert!(!info.has_remote);
@@ -366,7 +381,7 @@ mod tests {
             .with_ls_remote_check(&r, "origin", false)
             .build();
 
-        let info = classify_repo(&git, &r, 180, &[], false, &no_du);
+        let (info, _warnings) = classify_repo(&git, &r, 180, &[], false, &no_du);
 
         assert_eq!(info.classification, RepoClassification::Orphaned);
         assert!(info.has_remote); // has remote config, just not reachable
@@ -387,7 +402,7 @@ mod tests {
             .with_ls_remote_check(&r, "origin", true)
             .build();
 
-        let info = classify_repo(&git, &r, 180, &[], false, &no_du);
+        let (info, _warnings) = classify_repo(&git, &r, 180, &[], false, &no_du);
 
         assert_eq!(info.classification, RepoClassification::Stale);
         assert!(info.is_dirty);
@@ -404,7 +419,7 @@ mod tests {
             .with_list_remotes(&r, vec![])
             .build();
 
-        let info = classify_repo(&git, &r, 180, &[], false, &no_du);
+        let (info, _warnings) = classify_repo(&git, &r, 180, &[], false, &no_du);
 
         assert_eq!(info.classification, RepoClassification::Orphaned);
         assert!(info.is_dirty);
@@ -423,7 +438,7 @@ mod tests {
             .with_ls_remote_check(&r, "origin", true)
             .build();
 
-        let info = classify_repo(&git, &r, 180, &[], false, &no_du);
+        let (info, _warnings) = classify_repo(&git, &r, 180, &[], false, &no_du);
 
         assert_eq!(info.classification, RepoClassification::Active);
         assert!(info.is_dirty);
@@ -442,7 +457,7 @@ mod tests {
             .with_remote_url(&r, "origin", "https://github.com/user/repo.git")
             .build();
 
-        let info = classify_repo(&git, &r, 180, &[], true, &no_du);
+        let (info, _warnings) = classify_repo(&git, &r, 180, &[], true, &no_du);
 
         assert_eq!(info.classification, RepoClassification::Active);
     }
@@ -459,7 +474,7 @@ mod tests {
             .with_ls_remote_check(&r, "origin", true)
             .build();
 
-        let info = classify_repo(&git, &r, 180, &[], false, &no_du);
+        let (info, _warnings) = classify_repo(&git, &r, 180, &[], false, &no_du);
 
         // Empty repo with reachable remote -> active (newly cloned)
         assert_eq!(info.classification, RepoClassification::Active);
@@ -479,7 +494,7 @@ mod tests {
             .build();
 
         let du = fixed_du(142 * 1024 * 1024);
-        let info = classify_repo(&git, &r, 180, &[], false, &du);
+        let (info, _warnings) = classify_repo(&git, &r, 180, &[], false, &du);
 
         assert_eq!(info.disk_usage_bytes, 142 * 1024 * 1024);
     }
@@ -570,10 +585,35 @@ mod tests {
             .build();
 
         let noise = vec![".DS_Store".to_string()];
-        let info = classify_repo(&git, &r, 180, &noise, false, &no_du);
+        let (info, _warnings) = classify_repo(&git, &r, 180, &noise, false, &no_du);
 
         // .DS_Store is noise, so not dirty
         assert!(!info.is_dirty);
         assert_eq!(info.dirty_file_count, 0);
+    }
+
+    #[test]
+    fn classify_list_remotes_error_does_not_classify_as_orphaned() {
+        // Regression: `list_remotes().unwrap_or_default()` previously made an unreadable .git/config look like "no remotes" → Orphaned → eligible for rm -rf with --all -y -f. Failing closed: classify as Active and surface a warning.
+        let r = repo();
+        let git = MockGitBuilder::new()
+            .with_last_commit_date(&r, Some(&today_iso()))
+            .with_local_branches(&r, vec!["main".to_string()])
+            .with_list_remotes_error(&r, "config unreadable")
+            .build();
+
+        let (info, warnings) = classify_repo(&git, &r, 180, &[], false, &no_du);
+
+        assert_ne!(
+            info.classification,
+            RepoClassification::Orphaned,
+            "repo with unreadable remote config must not be classified Orphaned",
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("list remotes") && w.contains("config unreadable")),
+            "expected warning, got: {warnings:?}",
+        );
     }
 }

--- a/crates/git-tidy-core/src/testutil.rs
+++ b/crates/git-tidy-core/src/testutil.rs
@@ -25,6 +25,10 @@ pub struct MockGitBuilder {
     worktree_branch: HashMap<PathBuf, Option<String>>,
     rev_parse: HashMap<(PathBuf, String), String>,
     is_branch_checked_out: HashMap<(PathBuf, String), bool>,
+    is_branch_checked_out_errors: HashMap<(PathBuf, String), String>,
+    current_branch_errors: HashMap<PathBuf, String>,
+    list_remotes_errors: HashMap<PathBuf, String>,
+    list_remote_tracking_refs_errors: HashMap<PathBuf, String>,
     log_file_history: HashMap<(PathBuf, String, String), Vec<(String, String)>>,
     fetch_prune_calls: std::sync::Mutex<Vec<PathBuf>>,
     remove_calls: std::sync::Mutex<Vec<(PathBuf, PathBuf)>>,
@@ -182,6 +186,35 @@ impl MockGitBuilder {
     ) -> Self {
         self.is_branch_checked_out
             .insert((repo.to_path_buf(), branch.to_string()), checked_out);
+        self
+    }
+
+    pub fn with_is_branch_checked_out_error(
+        mut self,
+        repo: &Path,
+        branch: &str,
+        error: &str,
+    ) -> Self {
+        self.is_branch_checked_out_errors
+            .insert((repo.to_path_buf(), branch.to_string()), error.to_string());
+        self
+    }
+
+    pub fn with_current_branch_error(mut self, repo: &Path, error: &str) -> Self {
+        self.current_branch_errors
+            .insert(repo.to_path_buf(), error.to_string());
+        self
+    }
+
+    pub fn with_list_remotes_error(mut self, repo: &Path, error: &str) -> Self {
+        self.list_remotes_errors
+            .insert(repo.to_path_buf(), error.to_string());
+        self
+    }
+
+    pub fn with_list_remote_tracking_refs_error(mut self, repo: &Path, error: &str) -> Self {
+        self.list_remote_tracking_refs_errors
+            .insert(repo.to_path_buf(), error.to_string());
         self
     }
 
@@ -533,6 +566,10 @@ impl MockGitBuilder {
             worktree_branch: self.worktree_branch,
             rev_parse: self.rev_parse,
             is_branch_checked_out: self.is_branch_checked_out,
+            is_branch_checked_out_errors: self.is_branch_checked_out_errors,
+            current_branch_errors: self.current_branch_errors,
+            list_remotes_errors: self.list_remotes_errors,
+            list_remote_tracking_refs_errors: self.list_remote_tracking_refs_errors,
             log_file_history: self.log_file_history,
             fetch_prune_calls: self.fetch_prune_calls,
             remove_calls: self.remove_calls,
@@ -606,6 +643,10 @@ pub struct MockGit {
     worktree_branch: HashMap<PathBuf, Option<String>>,
     rev_parse: HashMap<(PathBuf, String), String>,
     is_branch_checked_out: HashMap<(PathBuf, String), bool>,
+    is_branch_checked_out_errors: HashMap<(PathBuf, String), String>,
+    current_branch_errors: HashMap<PathBuf, String>,
+    list_remotes_errors: HashMap<PathBuf, String>,
+    list_remote_tracking_refs_errors: HashMap<PathBuf, String>,
     log_file_history: HashMap<(PathBuf, String, String), Vec<(String, String)>>,
     fetch_prune_calls: std::sync::Mutex<Vec<PathBuf>>,
     remove_calls: std::sync::Mutex<Vec<(PathBuf, PathBuf)>>,
@@ -939,10 +980,14 @@ impl GitOps for MockGit {
     }
 
     fn is_branch_checked_out(&self, repo: &Path, branch: &str) -> GitResult<bool> {
-        Ok(*self
-            .is_branch_checked_out
-            .get(&(repo.to_path_buf(), branch.to_string()))
-            .unwrap_or(&false))
+        let key = (repo.to_path_buf(), branch.to_string());
+        if let Some(err) = self.is_branch_checked_out_errors.get(&key) {
+            return Err(Error::GitCommand {
+                command: format!("worktree list (looking for {branch})"),
+                message: err.clone(),
+            });
+        }
+        Ok(*self.is_branch_checked_out.get(&key).unwrap_or(&false))
     }
 
     fn log_file_history(
@@ -984,6 +1029,12 @@ impl GitOps for MockGit {
     }
 
     fn current_branch(&self, repo: &Path) -> GitResult<Option<String>> {
+        if let Some(err) = self.current_branch_errors.get(&repo.to_path_buf()) {
+            return Err(Error::GitCommand {
+                command: "symbolic-ref HEAD".to_string(),
+                message: err.clone(),
+            });
+        }
         Ok(self
             .current_branch
             .get(&repo.to_path_buf())
@@ -1021,6 +1072,12 @@ impl GitOps for MockGit {
     // --- Remote operations ---
 
     fn list_remotes(&self, repo: &Path) -> GitResult<Vec<String>> {
+        if let Some(err) = self.list_remotes_errors.get(&repo.to_path_buf()) {
+            return Err(Error::GitCommand {
+                command: "remote".to_string(),
+                message: err.clone(),
+            });
+        }
         Ok(self
             .list_remotes
             .get(&repo.to_path_buf())
@@ -1064,6 +1121,15 @@ impl GitOps for MockGit {
     }
 
     fn list_remote_tracking_refs(&self, repo: &Path) -> GitResult<Vec<(String, String)>> {
+        if let Some(err) = self
+            .list_remote_tracking_refs_errors
+            .get(&repo.to_path_buf())
+        {
+            return Err(Error::GitCommand {
+                command: "for-each-ref refs/remotes/".to_string(),
+                message: err.clone(),
+            });
+        }
         Ok(self
             .remote_tracking_refs
             .get(&repo.to_path_buf())

--- a/crates/git-worktree-tidy/src/clean.rs
+++ b/crates/git-worktree-tidy/src/clean.rs
@@ -199,16 +199,15 @@ fn remove_worktree(
         && !matches!(wt.classification, Classification::LandedStale)
         && let Some(branch) = &wt.branch
     {
-        if git
-            .is_branch_checked_out(&wt.parent_repo, branch)
-            .unwrap_or(false)
-        {
-            writeln!(
-                out,
-                "skipped branch delete for {branch}: checked out elsewhere"
-            )?;
-        } else {
-            match git.branch_delete(&wt.parent_repo, branch) {
+        // Fail closed: if we cannot determine whether the branch is checked out elsewhere, never delete it.
+        match git.is_branch_checked_out(&wt.parent_repo, branch) {
+            Ok(true) => {
+                writeln!(
+                    out,
+                    "skipped branch delete for {branch}: checked out elsewhere"
+                )?;
+            }
+            Ok(false) => match git.branch_delete(&wt.parent_repo, branch) {
                 Ok(()) => {
                     writeln!(out, "deleted branch {branch}")?;
                     branch_deleted = true;
@@ -216,6 +215,12 @@ fn remove_worktree(
                 Err(e) => {
                     writeln!(out, "warning: could not delete branch {branch}: {e}")?;
                 }
+            },
+            Err(e) => {
+                writeln!(
+                    out,
+                    "warning: skipped branch delete for {branch}: could not check worktree usage: {e}"
+                )?;
             }
         }
     }
@@ -730,6 +735,38 @@ mod tests {
 
         assert_eq!(result.succeeded.len(), 1);
         assert_eq!(git.remove_force_calls().len(), 1);
+    }
+
+    #[test]
+    fn clean_delete_branches_fails_closed_when_checkedout_check_errors() {
+        // Regression: previously `is_branch_checked_out().unwrap_or(false)` silently treated errors as "not checked out" and proceeded to delete the branch. Now the delete is skipped and a warning is emitted.
+        let git = MockGitBuilder::new()
+            .with_is_branch_checked_out_error(&repo(), "feature/done", "git plumbing broke")
+            .build();
+        let wt = make_worktree("wt-done", "feature/done", Classification::Landed);
+        let scan = make_scan(vec![wt]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            delete_branches: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+
+        // Worktree itself is still removed (that path's safety is separate).
+        assert_eq!(result.succeeded.len(), 1);
+        // But the branch must NOT be deleted when we cannot prove it is safe.
+        assert_eq!(git.branch_delete_calls().len(), 0);
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(
+            output.contains("skipped branch delete for feature/done"),
+            "output should warn about skipped delete, got: {output}"
+        );
+        assert!(
+            output.contains("could not check worktree usage"),
+            "output should mention the underlying error, got: {output}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Five sites in worktree/branch/repo/remote tools silently treated read-only git errors as the safe answer, then proceeded to delete. A transient or persistent failure (lock, corrupt config, dead remote, permission denied) could surface as data loss with no warning.
- Each site now fails closed: skip the destructive action, propagate a warning into \`ScanResult.warnings\` or \`run_clean\` output so the user can tell why.
- Adds four \`MockGit\` error-injection builders and five regression tests that exercise each gate end-to-end.

Closes #138

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo test --workspace\` — 47 test binaries pass; 5 new tests:
  - \`clean_delete_branches_fails_closed_when_checkedout_check_errors\` (worktree)
  - \`scan_drops_repo_when_current_branch_errors\` (branch)
  - \`scan_warns_when_remote_tracking_refs_errors_with_include_remote\` (branch)
  - \`classify_list_remotes_error_does_not_classify_as_orphaned\` (repo)
  - \`scan_warns_when_remote_tracking_refs_errors\` (remote)
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D clippy::all\`