### PR TITLE
Make landed detection and large-blob discovery deterministic

### DIFF
--- a/crates/git-tidy-core/src/git.rs
+++ b/crates/git-tidy-core/src/git.rs
@@ -451,7 +451,18 @@ impl GitOps for RealGit {
         branch_or_ref: &str,
         needle: &str,
     ) -> GitResult<Vec<(String, String)>> {
-        let output = Self::run(repo, &["log", branch_or_ref, "--oneline", "--grep", needle])?;
+        // `--fixed-strings` treats the needle as a literal string. Without it, characters like `?`, `*`, `[`, `(`, `\` in commit subjects are interpreted as POSIX BRE metacharacters, producing wrong matches (or, for malformed regex, a non-zero exit that bubbles up as an error).
+        let output = Self::run(
+            repo,
+            &[
+                "log",
+                branch_or_ref,
+                "--oneline",
+                "--fixed-strings",
+                "--grep",
+                needle,
+            ],
+        )?;
         let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
         Ok(Self::parse_log_oneline(&text))
     }
@@ -964,10 +975,13 @@ impl GitOps for RealGit {
         let output = Self::run(repo, &["rev-list", "--all", "--no-walk", "--format=%T"])?;
         let text = String::from_utf8_lossy(&output.stdout);
 
-        let unique_trees: HashSet<&str> = text
+        // De-dupe via HashSet for O(1) membership, but collect into a sorted Vec before applying `depth` so the subset of trees scanned is deterministic across runs (HashSet iteration order is randomized — without sorting, the same repo would surface a different blob list and a different CachingGitOps cache footprint each invocation).
+        let unique_set: HashSet<&str> = text
             .lines()
             .filter(|l| !l.starts_with("commit ") && !l.is_empty())
             .collect();
+        let mut unique_trees: Vec<&str> = unique_set.into_iter().collect();
+        unique_trees.sort_unstable();
 
         if unique_trees.is_empty() {
             return Ok(Vec::new());

--- a/crates/git-tidy-core/src/landed.rs
+++ b/crates/git-tidy-core/src/landed.rs
@@ -303,14 +303,7 @@ fn try_fuzzy_subject_match(
         return Ok(false);
     }
 
-    // Search for commits containing significant tokens
-    let search_term = tokens
-        .iter()
-        .filter(|t| t.len() >= 4)
-        .take(3)
-        .cloned()
-        .collect::<Vec<_>>()
-        .join(" ");
+    let search_term = build_fuzzy_search_term(&tokens);
 
     if search_term.is_empty() {
         return Ok(false);
@@ -364,6 +357,18 @@ fn try_patch_similarity(
     }
 
     Ok(false)
+}
+
+/// Build a deterministic search needle from a token set: lexicographically smallest 3 tokens of length ≥ 4, space-joined. Iterating a HashSet directly produces a randomized order, which would change the `git log --grep` needle (and the CachingGitOps log_grep_cache key) per run.
+fn build_fuzzy_search_term(tokens: &HashSet<String>) -> String {
+    let mut sorted: Vec<&String> = tokens.iter().filter(|t| t.len() >= 4).collect();
+    sorted.sort();
+    sorted
+        .into_iter()
+        .take(3)
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Tokenize a string into lowercase words.
@@ -455,6 +460,38 @@ mod tests {
     #[test]
     fn strip_cc_prefix_feat() {
         assert_eq!(strip_cc_prefix("feat: add login"), "add login");
+    }
+
+    #[test]
+    fn build_fuzzy_search_term_is_deterministic_across_runs() {
+        let tokens: HashSet<String> = ["alpha", "beta", "gamma", "delta", "epsilon"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        // Calling the function many times must always produce the same needle. Without sorting, HashSet iteration order would yield different `.take(3)` results across runs.
+        let first = build_fuzzy_search_term(&tokens);
+        for _ in 0..32 {
+            assert_eq!(build_fuzzy_search_term(&tokens), first);
+        }
+        // And it should be the lexicographically smallest 3 tokens.
+        assert_eq!(first, "alpha beta delta");
+    }
+
+    #[test]
+    fn build_fuzzy_search_term_filters_short_tokens() {
+        let tokens: HashSet<String> = ["fix", "auth", "tokens", "ab"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        // "fix" (3 chars) and "ab" (2 chars) are below the 4-char floor; only "auth" and "tokens" qualify.
+        assert_eq!(build_fuzzy_search_term(&tokens), "auth tokens");
+    }
+
+    #[test]
+    fn build_fuzzy_search_term_returns_empty_when_no_long_tokens() {
+        let tokens: HashSet<String> = ["a", "b", "c"].iter().map(|s| s.to_string()).collect();
+        assert_eq!(build_fuzzy_search_term(&tokens), "");
     }
 
     #[test]

--- a/crates/git-tidy-core/tests/gix_conformance.rs
+++ b/crates/git-tidy-core/tests/gix_conformance.rs
@@ -329,6 +329,32 @@ fn log_grep_passthrough() {
 }
 
 #[test]
+fn log_grep_treats_regex_metacharacters_as_literal() {
+    // Regression: previously log_grep passed the needle to `git log --grep`, which is POSIX BRE. A subject containing `(`, `[`, `?`, `*`, `+`, `\` would either match the wrong commits or fail the regex parse. With --fixed-strings the needle is matched literally.
+    let t = TestRepo::new();
+    t.commit_file(
+        &t.main_repo,
+        "a.txt",
+        "a",
+        "fix(auth): handle [null] tokens?",
+    );
+    t.commit_file(&t.main_repo, "b.txt", "b", "feat: add widget");
+
+    let real = RealGit;
+
+    // Use the literal subject (including parens, brackets, question mark) — regex characters that would either match nothing or error under POSIX BRE.
+    let matches = real
+        .log_grep(&t.main_repo, "main", "fix(auth): handle [null] tokens?")
+        .unwrap();
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].1, "fix(auth): handle [null] tokens?");
+
+    // A literal needle that is a substring should also match.
+    let partial = real.log_grep(&t.main_repo, "main", "[null]").unwrap();
+    assert_eq!(partial.len(), 1);
+}
+
+#[test]
 fn diff_commit_passthrough() {
     let t = TestRepo::new();
     t.commit_file(&t.main_repo, "change.txt", "content", "a change");


### PR DESCRIPTION
## Summary

- \`RealGit::find_large_blobs\` and \`landed::try_fuzzy_subject_match\` iterated \`HashSet\`s before \`take()\`/\`join()\`, producing different output (and different cache footprints) each run.
- \`RealGit::log_grep\` passed the raw needle to \`git log --grep\` (POSIX BRE), so subjects with regex metacharacters silently mismatched or errored.
- Sort the de-duped sets before truncation; extract the fuzzy needle into a unit-tested helper; add \`--fixed-strings\` to log_grep.

Closes #140

## Test plan

- [x] \`cargo test --workspace\` — all pass
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D clippy::all\`
- [x] New tests:
  - \`build_fuzzy_search_term_is_deterministic_across_runs\`
  - \`build_fuzzy_search_term_filters_short_tokens\`
  - \`build_fuzzy_search_term_returns_empty_when_no_long_tokens\`
  - \`log_grep_treats_regex_metacharacters_as_literal\` (real git repo)