### PR TITLE
Stop reporting third-party git-* binaries as builtins; keep fix --json valid

### DIFF
--- a/crates/git-config-tidy/src/main.rs
+++ b/crates/git-config-tidy/src/main.rs
@@ -82,7 +82,14 @@ fn main() {
                     yes: *yes,
                 };
 
-                match fix::run_fix(&git, &lint_result, &options, &mut stdout) {
+                // In machine-readable modes the lint JSON / porcelain has already been written to stdout. Fix progress ("removed section X in repo") must NOT corrupt that stream; route it to stderr instead. Without this, `git-config-tidy fix --json` produced a JSON document followed by free-form text — unparseable by anything downstream.
+                let fix_result = if *json || *porcelain {
+                    let mut stderr = io::stderr().lock();
+                    fix::run_fix(&git, &lint_result, &options, &mut stderr)
+                } else {
+                    fix::run_fix(&git, &lint_result, &options, &mut stdout)
+                };
+                match fix_result {
                     Ok(result) => {
                         if !result.failed.is_empty() {
                             process::exit(1);

--- a/crates/git-config-tidy/tests/integration_fix.rs
+++ b/crates/git-config-tidy/tests/integration_fix.rs
@@ -32,6 +32,37 @@ fn set_up_orphaned_config(test: &TestRepo) {
 }
 
 #[test]
+fn fix_json_writes_valid_json_to_stdout_and_progress_to_stderr() {
+    // Regression: previously `fix --json` wrote the lint JSON to stdout then run_fix wrote "removed section X in repo" lines to the same stream, producing a JSON document followed by free-form text that no JSON parser can consume. The fix must keep stdout as a single valid JSON value and route progress to stderr.
+    let test = TestRepo::new();
+    set_up_orphaned_config(&test);
+
+    let binary = env!("CARGO_BIN_EXE_git-config-tidy");
+    let output = std::process::Command::new(binary)
+        .args(["fix", "--json"])
+        .arg(&test.main_repo)
+        .output()
+        .expect("failed to run git-config-tidy");
+
+    assert!(
+        output.status.success() || output.status.code() == Some(0),
+        "git-config-tidy fix --json failed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("non-utf8 stdout");
+    serde_json::from_str::<serde_json::Value>(&stdout).unwrap_or_else(|e| {
+        panic!("stdout is not valid JSON: {e}\n--- stdout ---\n{stdout}");
+    });
+
+    let stderr = String::from_utf8(output.stderr).expect("non-utf8 stderr");
+    assert!(
+        stderr.contains("removed section"),
+        "expected progress on stderr, got: {stderr}",
+    );
+}
+
+#[test]
 fn fix_removes_orphaned_config() {
     let test = TestRepo::new();
     set_up_orphaned_config(&test);

--- a/crates/git-tidy-core/src/git.rs
+++ b/crates/git-tidy-core/src/git.rs
@@ -943,7 +943,8 @@ impl GitOps for RealGit {
     }
 
     fn list_builtin_commands(&self) -> GitResult<Vec<String>> {
-        let text = Self::run_global_text(&["--list-cmds=main,others"])?;
+        // Use `main` only. `others` enumerates every `git-*` binary on $PATH (including this tool's own subcommands and any third-party plugins) — git-config-tidy's alias-shadow check would then report aliases like `tidy` or `lfs` as "shadows built-in git command", which is a false positive.
+        let text = Self::run_global_text(&["--list-cmds=main"])?;
         Ok(text
             .lines()
             .filter(|l| !l.is_empty())


### PR DESCRIPTION
## Summary

- \`list_builtin_commands\` dropped \`others\` from \`--list-cmds\`, eliminating false-positive alias shadows for any \`git-*\` plugin on \$PATH (including this suite's own subcommands).
- \`git-config-tidy fix --json\` (and \`--porcelain\`) now routes fix progress to stderr so stdout stays a single valid JSON document.

Closes #142

## Test plan

- [x] \`cargo test --workspace\` — all pass; new integration test \`fix_json_writes_valid_json_to_stdout_and_progress_to_stderr\` invokes the real binary, parses stdout as JSON, and asserts the progress lands on stderr.
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D clippy::all\`