### PR TITLE
Tighten lfs parse_size and distinguish dry-run PrunedRepo entries

### DIFF
--- a/crates/git-lfs-tidy/src/clean.rs
+++ b/crates/git-lfs-tidy/src/clean.rs
@@ -32,13 +32,15 @@ pub struct CleanResult {
     pub recommendations: Vec<String>,
 }
 
-/// A repo whose LFS objects were successfully pruned.
+/// A repo whose LFS objects were successfully pruned (or would have been, in dry-run).
 #[derive(Debug)]
 #[allow(dead_code)]
 pub struct PrunedRepo {
     pub repo: PathBuf,
     pub objects_pruned: usize,
     pub bytes_freed: u64,
+    /// True for dry-run entries — nothing was actually freed. Downstream JSON consumers can filter on this to distinguish a preview from a real prune.
+    pub dry_run: bool,
 }
 
 /// A repo whose LFS prune failed.
@@ -88,6 +90,7 @@ pub fn run_clean(
                             repo: group.repo_path.clone(),
                             objects_pruned: count,
                             bytes_freed: bytes,
+                            dry_run: true,
                         });
                     } else {
                         match git.lfs_prune(&group.repo_path) {
@@ -103,6 +106,7 @@ pub fn run_clean(
                                     repo: group.repo_path.clone(),
                                     objects_pruned: count,
                                     bytes_freed: bytes,
+                                    dry_run: false,
                                 });
                             }
                             Err(e) => {
@@ -248,9 +252,37 @@ mod tests {
 
         assert_eq!(result.pruned.len(), 1);
         assert_eq!(git.lfs_prune_calls().len(), 0);
+        // Regression: dry-run entries must be distinguishable from real prunes so downstream JSON consumers can filter them out.
+        assert!(
+            result.pruned[0].dry_run,
+            "dry-run PrunedRepo must have dry_run=true",
+        );
 
         let output = String::from_utf8(buf).unwrap();
         assert!(output.contains("would prune"));
+    }
+
+    #[test]
+    fn clean_real_prune_marks_dry_run_false() {
+        let git = MockGitBuilder::new().with_lfs_installed(true).build();
+        let scan = make_scan_result(vec![LfsInfo {
+            repo_path: repo(),
+            path: "<3 orphaned LFS objects>".to_string(),
+            classification: LfsClassification::Orphaned,
+            oid: String::new(),
+            size_bytes: Some(2_500_000),
+        }]);
+        let mut buf = Vec::new();
+        let options = CleanOptions {
+            dry_run: false,
+            prune: true,
+            ..default_options()
+        };
+
+        let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
+        assert_eq!(result.pruned.len(), 1);
+        assert!(!result.pruned[0].dry_run);
+        assert_eq!(git.lfs_prune_calls().len(), 1);
     }
 
     #[test]

--- a/crates/git-lfs-tidy/src/scan.rs
+++ b/crates/git-lfs-tidy/src/scan.rs
@@ -29,6 +29,11 @@ pub fn parse_size(s: &str) -> Option<u64> {
 
     let num: f64 = num_str.parse().ok()?;
 
+    // Reject negative and non-finite inputs explicitly. Without this check `--size-threshold -1MB` would compute `-1_000_000.0 as u64 = 0`, silently meaning "flag every blob".
+    if !num.is_finite() || num < 0.0 {
+        return None;
+    }
+
     let multiplier: f64 = match suffix.as_str() {
         "" | "B" => 1.0,
         "K" | "KB" => 1_000.0,
@@ -38,7 +43,12 @@ pub fn parse_size(s: &str) -> Option<u64> {
         _ => return None,
     };
 
-    Some((num * multiplier) as u64)
+    let bytes = num * multiplier;
+    // Reject overflow rather than silently saturating to u64::MAX, so a typo like `99999999999999999999TB` fails parsing instead of pretending to be valid.
+    if !bytes.is_finite() || bytes > u64::MAX as f64 {
+        return None;
+    }
+    Some(bytes as u64)
 }
 
 /// Scan all repos in `directory` for LFS health issues.
@@ -272,6 +282,22 @@ mod tests {
         assert_eq!(parse_size(""), None);
         assert_eq!(parse_size("abc"), None);
         assert_eq!(parse_size("1XB"), None);
+    }
+
+    #[test]
+    fn parse_size_rejects_negative() {
+        // Regression: `--size-threshold -1MB` previously parsed as `-1_000_000.0 as u64 = 0`, silently meaning "flag every blob". Negatives must be rejected so the CLI surfaces an error.
+        assert_eq!(parse_size("-1"), None);
+        assert_eq!(parse_size("-1MB"), None);
+        assert_eq!(parse_size("-0.5GB"), None);
+    }
+
+    #[test]
+    fn parse_size_rejects_overflow() {
+        // Regression: huge values like "9e30 TB" would previously cast to u64 and saturate to u64::MAX without telling the user. Reject so a typo cannot masquerade as a sane threshold.
+        assert!(parse_size("99999999999999999999TB").is_none());
+        // f64 NaN/inf paths via large mantissa-exponent combinations:
+        assert!(parse_size("1e300TB").is_none());
     }
 
     // --- run_scan tests ---


### PR DESCRIPTION
## Summary

- \`parse_size\` now rejects negative, non-finite, and over-\`u64::MAX\` inputs rather than silently casting to 0 or saturating to u64::MAX.
- \`PrunedRepo\` gains \`dry_run: bool\` so downstream consumers can tell a preview from a real prune.

Closes #146

## Test plan

- [x] \`cargo test --workspace\` — all pass; 4 new tests:
  - \`parse_size_rejects_negative\`
  - \`parse_size_rejects_overflow\`
  - \`clean_dry_run_does_not_prune\` asserts \`dry_run\` on result
  - \`clean_real_prune_marks_dry_run_false\`
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D clippy::all\`