### PR TITLE
Fix four classification bugs in git-tidy-core

### DIFF
--- a/crates/git-tidy-core/src/classification.rs
+++ b/crates/git-tidy-core/src/classification.rs
@@ -405,9 +405,10 @@ pub fn classify_worktree(
         default_branch: default_branch.to_string(),
         classification: bc.classification,
         annotations,
-        remote_tracking: bc.remote_tracking,
-        ahead: bc.ahead,
-        behind: bc.behind,
+        // For detached HEAD, branch_ref is a commit SHA. classify_branch computed `remote_tracking` by looking up `refs/remotes/origin/<sha>`, which never resolves — so `bc.remote_tracking` is meaninglessly false. Zero it out explicitly so downstream consumers cannot mistake "no analysis" for "no upstream".
+        remote_tracking: !is_detached && bc.remote_tracking,
+        ahead: if is_detached { 0 } else { bc.ahead },
+        behind: if is_detached { 0 } else { bc.behind },
         dirty_files: dirty_result.all_files,
         meaningful_dirty_files: dirty_result.meaningful_files,
     })

--- a/crates/git-tidy-core/src/dirty.rs
+++ b/crates/git-tidy-core/src/dirty.rs
@@ -46,11 +46,21 @@ pub fn check_dirty(
             continue;
         }
         let status_code = &line[..2];
-        let file_path = line[3..].trim();
+        let raw_path = line[3..].trim();
 
-        if file_path.is_empty() {
+        if raw_path.is_empty() {
             continue;
         }
+
+        // Rename status (R*) and copy status (C*) use the format `<old> -> <new>` in porcelain v1. The "current" file the working tree contains is the new path; using the raw "old -> new" string breaks noise filtering (the basename match runs against the literal "new" segment fine, but a rename of `.DS_Store -> foo` would also be reported and the file_path stored in the result would contain " -> ").
+        let file_path = if status_code.starts_with('R') || status_code.starts_with('C') {
+            raw_path
+                .rsplit_once(" -> ")
+                .map(|(_, new)| new)
+                .unwrap_or(raw_path)
+        } else {
+            raw_path
+        };
 
         all_files.push(file_path.to_string());
 
@@ -256,6 +266,38 @@ mod tests {
 
         let result = check_dirty(&git, &path, &defaults()).unwrap();
         assert_eq!(result.meaningful_files.len(), 2);
+    }
+
+    #[test]
+    fn check_dirty_rename_extracts_new_path() {
+        // Regression: porcelain v1 reports a rename as `R  old -> new`. Previously file_path stored the literal "old -> new", breaking noise filtering and producing confusing dirty-file output.
+        let path = PathBuf::from("/worktree");
+        let git = MockGitBuilder::new()
+            .with_status_porcelain(
+                &path,
+                vec![
+                    "R  src/old.rs -> src/new.rs".to_string(),
+                    "C  src/orig.rs -> src/copy.rs".to_string(),
+                ],
+            )
+            .build();
+
+        let result = check_dirty(&git, &path, &defaults()).unwrap();
+        assert!(
+            result.all_files.contains(&"src/new.rs".to_string()),
+            "rename should store the new path, got {:?}",
+            result.all_files,
+        );
+        assert!(
+            result.all_files.contains(&"src/copy.rs".to_string()),
+            "copy should store the new path, got {:?}",
+            result.all_files,
+        );
+        assert!(
+            !result.all_files.iter().any(|f| f.contains(" -> ")),
+            "no file_path should contain the arrow separator, got {:?}",
+            result.all_files,
+        );
     }
 
     #[test]

--- a/crates/git-tidy-core/src/git.rs
+++ b/crates/git-tidy-core/src/git.rs
@@ -376,9 +376,14 @@ impl RealGit {
         output
             .lines()
             .filter(|l| !l.is_empty())
-            .filter_map(|line| {
-                let (hash, subject) = line.split_once(' ')?;
-                Some((hash.to_string(), subject.to_string()))
+            .map(|line| match line.split_once(' ') {
+                Some((hash, subject)) => (hash.to_string(), subject.to_string()),
+                // A commit with an empty subject still has a hash on its own line.
+                // `split_once(' ')` returns None for it, which previously dropped the
+                // commit from the result and skewed the `total` count in
+                // LandedByContent { matched, total } — flipping the decision in
+                // boundary cases. Treat the whole line as the hash with an empty subject.
+                None => (line.to_string(), String::new()),
             })
             .collect()
     }
@@ -793,7 +798,8 @@ impl GitOps for RealGit {
     }
 
     fn is_commit_reachable(&self, repo: &Path, commit: &str) -> GitResult<bool> {
-        let output = Self::run(repo, &["branch", "--contains", commit])?;
+        // `-a` widens the search to include remote-tracking branches. Without it a commit reachable only from origin/feature (after the local branch was deleted, a common state for merged PRs that left a tag behind) is reported as unreachable, and git-tag-tidy classifies the tag as Stale → eligible for default deletion.
+        let output = Self::run(repo, &["branch", "-a", "--contains", commit])?;
         let text = String::from_utf8_lossy(&output.stdout);
         Ok(!text.trim().is_empty())
     }
@@ -1090,6 +1096,15 @@ mod tests {
     fn parse_log_oneline_empty() {
         let result = RealGit::parse_log_oneline("");
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_log_oneline_keeps_commits_with_empty_subjects() {
+        // Regression: previously `split_once(' ')` returned None for a hash-only line, which dropped the commit from the result and shrank the `total` count in LandedByContent — flipping the matched/total ratio in boundary cases.
+        let output = "abc1234 with subject\ndef5678\nfff9999 another\n";
+        let result = RealGit::parse_log_oneline(output);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[1], ("def5678".to_string(), String::new()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- \`is_commit_reachable\` adds \`-a\` to include remote-tracking branches.
- \`parse_log_oneline\` keeps commits whose subject is empty instead of dropping them.
- \`dirty.rs\` parses the new path out of \`R\`/\`C\` porcelain rename entries.
- \`classify_worktree\` zeroes \`remote_tracking\` / \`ahead\` / \`behind\` for detached HEAD so consumers cannot read meaningless values.

Closes #148

## Test plan

- [x] \`cargo test --workspace\` — all pass; new tests \`parse_log_oneline_keeps_commits_with_empty_subjects\` and \`check_dirty_rename_extracts_new_path\`.
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D clippy::all\`