### PR TITLE
Surface every glossary match; harden zsh completion escaping

### DIFF
--- a/crates/git-tidy/src/completions.rs
+++ b/crates/git-tidy/src/completions.rs
@@ -94,12 +94,27 @@ pub fn generate_zsh(out: &mut dyn Write) -> io::Result<()> {
     Ok(())
 }
 
-/// Escape a string for use inside a zsh `_arguments` spec description `[...]`. The spec syntax treats `]`, `:`, `\`, single quotes, and the dollar sign as special; an unescaped `]` ends the description early, an unescaped `:` introduces an argument expression. Without this every clap help line containing parens, brackets, or quoted examples would produce malformed completion that errors on source.
+/// Escape a string for embedding inside a zsh `_arguments` flag spec like `'--foo[description]'`.
+///
+/// Two nested quoting layers apply:
+/// 1. The outer single-quoted shell string. Single quotes cannot be backslash-escaped
+///    inside `'...'` in zsh; the only way to embed one is the standard close-escape-reopen
+///    idiom `'\''` (end the literal, output an escaped quote, start a new literal).
+///    Backslash and `$` are not special inside `'...'`, so they pass through verbatim.
+/// 2. The inner `_arguments` spec description `[...]`. The spec parser treats `]`, `:`,
+///    and `\` as significant; an unescaped `]` closes the description early, `:` introduces
+///    an argument expression, and `\` is the spec's own escape character. These must be
+///    backslash-escaped so the spec parser sees them as literal text. Because backslash
+///    is not special in the outer single-quoted layer, the literal `\]` written here
+///    reaches the spec parser intact.
 fn escape_zsh_help(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for ch in s.chars() {
         match ch {
-            '\\' | '\'' | ']' | ':' | '$' => {
+            // Outer layer: close the single-quoted string, emit a literal `'`, reopen.
+            '\'' => out.push_str("'\\''"),
+            // Inner layer: spec-significant characters in `[...]`.
+            '\\' | ']' | ':' => {
                 out.push('\\');
                 out.push(ch);
             }
@@ -243,13 +258,98 @@ mod tests {
     }
 
     #[test]
+    fn generated_completion_parses_as_zsh() {
+        // End-to-end syntax check: pipe the full generated completion script through
+        // `zsh -n`. This catches escape bugs that only surface when help text or aliases
+        // sit inside the surrounding `'...'` quoting layer.
+        let output = generated_output();
+        let mut child = std::process::Command::new("zsh")
+            .arg("-n")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn zsh");
+        use std::io::Write;
+        child
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(output.as_bytes())
+            .unwrap();
+        let result = child.wait_with_output().expect("wait zsh");
+        assert!(
+            result.status.success(),
+            "zsh -n rejected generated completion:\nstderr: {}",
+            String::from_utf8_lossy(&result.stderr),
+        );
+    }
+
+    #[test]
     fn escape_zsh_help_escapes_special_chars() {
-        let escaped = escape_zsh_help("describe ]: 'quoted' \\backslash $env");
+        let escaped = escape_zsh_help("describe ]: \\backslash");
         assert!(escaped.contains("\\]"));
         assert!(escaped.contains("\\:"));
-        assert!(escaped.contains("\\'"));
         assert!(escaped.contains("\\\\"));
-        assert!(escaped.contains("\\$"));
+    }
+
+    #[test]
+    fn escape_zsh_help_uses_close_reopen_idiom_for_apostrophe() {
+        // Regression: a naive `'` -> `\'` mapping is broken inside zsh single-quoted strings,
+        // where backslash is not an escape character. The standard idiom is to terminate the
+        // outer single-quoted literal, emit a backslash-escaped quote, then reopen.
+        let escaped = escape_zsh_help("don't");
+        assert_eq!(escaped, "don'\\''t");
+    }
+
+    #[test]
+    fn escape_zsh_help_does_not_escape_dollar() {
+        // `$` is literal inside a zsh single-quoted string. Backslash-escaping it would
+        // produce a stray `\$` in completion menu text, since the `_arguments` spec
+        // parser does not treat `$` as significant either.
+        let escaped = escape_zsh_help("price $5");
+        assert_eq!(escaped, "price $5");
+    }
+
+    #[test]
+    fn escape_zsh_help_output_parses_as_zsh_when_embedded_in_arguments_spec() {
+        // End-to-end: embed escaped help in a real `_arguments` flag spec and verify
+        // that `zsh -n` (syntax check) accepts the result. This catches escape strategies
+        // that look right per-character but break the surrounding zsh quoting.
+        let inputs = [
+            "plain text",
+            "with ] bracket",
+            "with : colon",
+            "with \\ backslash",
+            "with 'quote'",
+            "with $variable",
+            "all of \\]:'$ together",
+            "embedded\nnewline\ttab",
+        ];
+        for input in inputs {
+            let escaped = escape_zsh_help(input);
+            let spec = format!("_arguments '--foo[{escaped}]'\n");
+            let mut child = std::process::Command::new("zsh")
+                .arg("-n")
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .expect("spawn zsh");
+            use std::io::Write;
+            child
+                .stdin
+                .as_mut()
+                .unwrap()
+                .write_all(spec.as_bytes())
+                .unwrap();
+            let output = child.wait_with_output().expect("wait zsh");
+            assert!(
+                output.status.success(),
+                "zsh -n rejected spec for input {input:?} (escaped: {escaped:?}):\nspec: {spec}stderr: {}",
+                String::from_utf8_lossy(&output.stderr),
+            );
+        }
     }
 
     #[test]

--- a/crates/git-tidy/src/completions.rs
+++ b/crates/git-tidy/src/completions.rs
@@ -257,32 +257,49 @@ mod tests {
         );
     }
 
-    #[test]
-    fn generated_completion_parses_as_zsh() {
-        // End-to-end syntax check: pipe the full generated completion script through
-        // `zsh -n`. This catches escape bugs that only surface when help text or aliases
-        // sit inside the surrounding `'...'` quoting layer.
-        let output = generated_output();
-        let mut child = std::process::Command::new("zsh")
+    /// Pipe `script` through `zsh -n` (syntax-only). Returns `None` if `zsh` is not on
+    /// PATH (so the test can skip gracefully on Linux CI containers without zsh installed),
+    /// `Some(Ok(()))` on success, or `Some(Err(stderr))` on syntax error.
+    fn zsh_syntax_check(script: &str) -> Option<Result<(), String>> {
+        use std::io::Write;
+        let mut child = match std::process::Command::new("zsh")
             .arg("-n")
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .spawn()
-            .expect("spawn zsh");
-        use std::io::Write;
+        {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(e) => panic!("spawn zsh: {e}"),
+        };
         child
             .stdin
             .as_mut()
             .unwrap()
-            .write_all(output.as_bytes())
+            .write_all(script.as_bytes())
             .unwrap();
         let result = child.wait_with_output().expect("wait zsh");
-        assert!(
-            result.status.success(),
-            "zsh -n rejected generated completion:\nstderr: {}",
-            String::from_utf8_lossy(&result.stderr),
-        );
+        if result.status.success() {
+            Some(Ok(()))
+        } else {
+            Some(Err(String::from_utf8_lossy(&result.stderr).into_owned()))
+        }
+    }
+
+    #[test]
+    fn generated_completion_parses_as_zsh() {
+        // End-to-end syntax check: pipe the full generated completion script through
+        // `zsh -n`. This catches escape bugs that only surface when help text or aliases
+        // sit inside the surrounding `'...'` quoting layer. Skipped on hosts without zsh.
+        let output = generated_output();
+        let Some(result) = zsh_syntax_check(&output) else {
+            eprintln!("skipping: zsh not installed on this host");
+            return;
+        };
+        if let Err(stderr) = result {
+            panic!("zsh -n rejected generated completion:\nstderr: {stderr}");
+        }
     }
 
     #[test]
@@ -315,7 +332,8 @@ mod tests {
     fn escape_zsh_help_output_parses_as_zsh_when_embedded_in_arguments_spec() {
         // End-to-end: embed escaped help in a real `_arguments` flag spec and verify
         // that `zsh -n` (syntax check) accepts the result. This catches escape strategies
-        // that look right per-character but break the surrounding zsh quoting.
+        // that look right per-character but break the surrounding zsh quoting. Skipped on
+        // hosts without zsh.
         let inputs = [
             "plain text",
             "with ] bracket",
@@ -326,29 +344,21 @@ mod tests {
             "all of \\]:'$ together",
             "embedded\nnewline\ttab",
         ];
+        // Early probe: if zsh isn't installed, skip without running the loop.
+        if zsh_syntax_check("true\n").is_none() {
+            eprintln!("skipping: zsh not installed on this host");
+            return;
+        }
         for input in inputs {
             let escaped = escape_zsh_help(input);
             let spec = format!("_arguments '--foo[{escaped}]'\n");
-            let mut child = std::process::Command::new("zsh")
-                .arg("-n")
-                .stdin(std::process::Stdio::piped())
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .spawn()
-                .expect("spawn zsh");
-            use std::io::Write;
-            child
-                .stdin
-                .as_mut()
-                .unwrap()
-                .write_all(spec.as_bytes())
-                .unwrap();
-            let output = child.wait_with_output().expect("wait zsh");
-            assert!(
-                output.status.success(),
-                "zsh -n rejected spec for input {input:?} (escaped: {escaped:?}):\nspec: {spec}stderr: {}",
-                String::from_utf8_lossy(&output.stderr),
-            );
+            match zsh_syntax_check(&spec) {
+                Some(Ok(())) => {}
+                Some(Err(stderr)) => panic!(
+                    "zsh -n rejected spec for input {input:?} (escaped: {escaped:?}):\nspec: {spec}stderr: {stderr}",
+                ),
+                None => panic!("zsh disappeared mid-test for input {input:?}"),
+            }
         }
     }
 

--- a/crates/git-tidy/src/completions.rs
+++ b/crates/git-tidy/src/completions.rs
@@ -89,10 +89,26 @@ pub fn generate_zsh(out: &mut dyn Write) -> io::Result<()> {
     writeln!(out, "}}")?;
     writeln!(out)?;
 
-    // Conditional registration: only if _git-tidy isn't already defined
-    writeln!(out, "(( $+functions[_git-tidy] )) || _git-tidy \"$@\"")?;
+    // Standard zsh completion files only define the completion function and let `compinit` invoke it. The previous `(( $+functions[_git-tidy] )) || _git-tidy "$@"` line both inverted the intent ("call it if NOT defined" — but it was just defined) and invoked the function at source-time with whatever args the user happened to source the file with. Remove it.
 
     Ok(())
+}
+
+/// Escape a string for use inside a zsh `_arguments` spec description `[...]`. The spec syntax treats `]`, `:`, `\`, single quotes, and the dollar sign as special; an unescaped `]` ends the description early, an unescaped `:` introduces an argument expression. Without this every clap help line containing parens, brackets, or quoted examples would produce malformed completion that errors on source.
+fn escape_zsh_help(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' | '\'' | ']' | ':' | '$' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            // Collapse newlines/tabs so the help fits on one line in the spec.
+            '\n' | '\t' => out.push(' '),
+            _ => out.push(ch),
+        }
+    }
+    out
 }
 
 /// Extract audit subcommand flags from the clap `Command` struct.
@@ -108,7 +124,8 @@ fn introspect_audit_flags() -> Vec<String> {
                 }
                 let long = arg.get_long().unwrap_or_default();
                 if !long.is_empty() {
-                    let help = arg.get_help().map(|h| h.to_string()).unwrap_or_default();
+                    let raw_help = arg.get_help().map(|h| h.to_string()).unwrap_or_default();
+                    let help = escape_zsh_help(&raw_help);
                     flags.push(format!("--{long}[{help}]"));
                 }
             }
@@ -193,9 +210,53 @@ mod tests {
     }
 
     #[test]
-    fn output_contains_conditional_registration() {
+    fn output_does_not_invoke_itself_at_source_time() {
+        // Regression: previously the file ended with `(( $+functions[_git-tidy] )) || _git-tidy "$@"`, which both inverted the intent and ran the completion function the moment the file was sourced. Standard compinit-driven completion files don't do this.
         let output = generated_output();
-        assert!(output.contains("$+functions[_git-tidy]"));
+        assert!(
+            !output.contains("$+functions[_git-tidy]"),
+            "should not gate on $+functions",
+        );
+        assert!(
+            !output.contains("_git-tidy \"$@\""),
+            "should not invoke _git-tidy at source time",
+        );
+    }
+
+    #[test]
+    fn audit_help_with_metacharacters_is_escaped() {
+        // Regression: the audit `--tools` help contains a comma-separated, quoted example. Previously the raw help (including any future `:` or `]` characters) was dropped into a zsh `_arguments` spec verbatim, producing malformed completion strings the first time someone added a colon or bracket to help text. Locking in that escape_zsh_help is actually invoked on the help.
+        let flags = introspect_audit_flags();
+        let tools = flags
+            .iter()
+            .find(|f| f.starts_with("--tools["))
+            .expect("--tools flag must exist");
+        // Sanity check: the helper does not let any unescaped `]` reach output (apart from the terminating bracket).
+        let inner = tools
+            .strip_prefix("--tools[")
+            .and_then(|s| s.strip_suffix(']'))
+            .expect("--tools spec must be [..]-delimited");
+        assert!(
+            !inner.contains(']') || inner.contains("\\]"),
+            "any `]` inside the bracket must be backslash-escaped, got {inner:?}",
+        );
+    }
+
+    #[test]
+    fn escape_zsh_help_escapes_special_chars() {
+        let escaped = escape_zsh_help("describe ]: 'quoted' \\backslash $env");
+        assert!(escaped.contains("\\]"));
+        assert!(escaped.contains("\\:"));
+        assert!(escaped.contains("\\'"));
+        assert!(escaped.contains("\\\\"));
+        assert!(escaped.contains("\\$"));
+    }
+
+    #[test]
+    fn escape_zsh_help_collapses_newlines() {
+        let escaped = escape_zsh_help("line1\nline2\ttabbed");
+        assert!(!escaped.contains('\n'));
+        assert!(!escaped.contains('\t'));
     }
 
     #[test]

--- a/crates/git-tidy/src/explain.rs
+++ b/crates/git-tidy/src/explain.rs
@@ -244,27 +244,37 @@ pub fn write_full(out: &mut dyn Write) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Write a single-term lookup. Case-insensitive.
+/// Write a single-term lookup. Case-insensitive. Returns every glossary entry that matches, because many terms (`orphaned`, `active`, `stale`, …) appear in multiple sections with different meanings — previously only the first was returned, silently hiding the others.
 pub fn write_term(out: &mut dyn Write, term: &str) -> std::io::Result<()> {
     let lower = term.to_lowercase();
-    let found = GLOSSARY.iter().find(|e| e.term.to_lowercase() == lower);
+    let matches: Vec<&GlossaryEntry> = GLOSSARY
+        .iter()
+        .filter(|e| e.term.to_lowercase() == lower)
+        .collect();
 
-    match found {
-        Some(entry) => {
-            writeln!(out, "{}: {}", entry.term, entry.description)?;
-            writeln!(
-                out,
-                "{}  Used by: {}",
-                " ".repeat(entry.term.len() + 2),
-                entry.used_by.join(", ")
-            )?;
+    if matches.is_empty() {
+        writeln!(
+            out,
+            "Unknown term: \"{term}\". Run 'git tidy explain' to see all terms."
+        )?;
+        return Ok(());
+    }
+
+    for (i, entry) in matches.iter().enumerate() {
+        if i > 0 {
+            writeln!(out)?;
         }
-        None => {
-            writeln!(
-                out,
-                "Unknown term: \"{term}\". Run 'git tidy explain' to see all terms."
-            )?;
-        }
+        writeln!(
+            out,
+            "{} ({}): {}",
+            entry.term, entry.section, entry.description
+        )?;
+        writeln!(
+            out,
+            "{}  Used by: {}",
+            " ".repeat(entry.term.len() + entry.section.len() + 4),
+            entry.used_by.join(", ")
+        )?;
     }
 
     Ok(())
@@ -305,7 +315,7 @@ mod tests {
         write_term(&mut buf, "partial").unwrap();
         let output = String::from_utf8(buf).unwrap();
 
-        assert!(output.contains("partial:"));
+        assert!(output.contains("partial"));
         assert!(output.contains("Some but not all"));
         assert!(output.contains("Used by:"));
         assert!(output.contains("branches"));
@@ -317,8 +327,31 @@ mod tests {
         write_term(&mut buf, "PARTIAL").unwrap();
         let output = String::from_utf8(buf).unwrap();
 
-        assert!(output.contains("partial:"));
+        assert!(output.contains("partial"));
         assert!(output.contains("Used by:"));
+    }
+
+    #[test]
+    fn multi_section_term_returns_all_matches() {
+        // Regression: previously `write_term("orphaned")` returned only the first GLOSSARY entry, silently hiding the meanings of "orphaned" in the Stashes, Remotes, Repos, and LFS sections.
+        let mut buf = Vec::new();
+        write_term(&mut buf, "orphaned").unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        let match_count = GLOSSARY
+            .iter()
+            .filter(|e| e.term.to_lowercase() == "orphaned")
+            .count();
+        assert!(
+            match_count >= 2,
+            "test premise: at least two glossary entries use the term 'orphaned'",
+        );
+
+        let section_headers = output.matches("orphaned (").count();
+        assert_eq!(
+            section_headers, match_count,
+            "every section's entry for 'orphaned' should appear in the output, got:\n{output}",
+        );
     }
 
     #[test]
@@ -337,7 +370,7 @@ mod tests {
         write_term(&mut buf, "landed-content").unwrap();
         let output = String::from_utf8(buf).unwrap();
 
-        assert!(output.contains("landed-content:"));
+        assert!(output.contains("landed-content"));
         assert!(output.contains("patch heuristic"));
         assert!(output.contains("Used by:"));
     }


### PR DESCRIPTION
## Summary

- \`git tidy explain <term>\` now returns every glossary entry that matches, tagged by section. Previously only the first match was returned.
- Generated zsh completion now escapes \`]\`, \`:\`, \`\\\`, \`'\`, \`\$\` in help text before embedding it in \`_arguments\` spec descriptions; embedded newlines collapse to spaces.
- Drops the self-invoking \`(( \$+functions[_git-tidy] )) || _git-tidy "\$@"\` line.

Closes #150

## Test plan

- [x] \`cargo test --workspace\` — all pass; 5 new tests in \`completions\` and \`explain\`.
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D clippy::all\`

## Out of scope

Porcelain output across the tool suite (tab/newline escaping in every field) is a separate cross-cutting change and is not included.