### PR TITLE
Follow-up tests for #149: detached-HEAD field zeroing and remote-only is_commit_reachable

### DIFF
--- a/crates/git-lfs-tidy/src/clean.rs
+++ b/crates/git-lfs-tidy/src/clean.rs
@@ -271,7 +271,6 @@ mod tests {
         let options = CleanOptions {
             dry_run: false,
             prune: true,
-            ..default_options()
         };
 
         let result = run_clean(&git, &scan, &options, &mut buf).unwrap();

--- a/crates/git-tidy-core/src/classification.rs
+++ b/crates/git-tidy-core/src/classification.rs
@@ -630,6 +630,39 @@ mod tests {
         assert!(info.branch.is_none());
     }
 
+    #[test]
+    fn classify_detached_head_zeros_remote_fields() {
+        // Regression: classify_branch is called with the detached commit SHA as branch_ref. If the underlying BranchClassification spuriously reports remote_tracking/ahead/behind (because some ref happens to resolve, or the mock fabricates one as below), the worktree layer must clamp these to false/0 — they are meaningless for a detached HEAD.
+        let detached_sha = "abc123def";
+        let git = MockGitBuilder::new()
+            .with_worktree_branch(&wt(), None) // detached HEAD
+            .with_rev_parse(&wt(), "HEAD", detached_sha)
+            // Force classify_branch to compute non-zero remote analysis: pretend `refs/remotes/origin/<sha>` resolves and the underlying counts are non-zero.
+            .with_rev_parse_verify(
+                &repo(),
+                &format!("refs/remotes/origin/{detached_sha}"),
+                true,
+            )
+            .with_rev_list_counts(&repo(), "origin/main", detached_sha, (3, 5))
+            .with_is_ancestor(&repo(), detached_sha, "origin/main", false)
+            .with_status_porcelain(&wt(), vec![])
+            .build();
+
+        let info =
+            classify_worktree(&git, &wt(), &repo(), "main", 100, false, &default_noise()).unwrap();
+        assert!(info.branch.is_none(), "test premise: branch must be None");
+        assert!(
+            !info.remote_tracking,
+            "detached HEAD must report remote_tracking=false even when classify_branch reports otherwise",
+        );
+        assert_eq!(info.ahead, 0, "detached HEAD ahead must be 0");
+        assert_eq!(info.behind, 0, "detached HEAD behind must be 0");
+        assert!(
+            !info.annotations.remote_deleted,
+            "detached HEAD must not report remote_deleted",
+        );
+    }
+
     // --- classify_branch tests ---
 
     #[test]

--- a/crates/git-tidy-core/src/gix_ops.rs
+++ b/crates/git-tidy-core/src/gix_ops.rs
@@ -515,33 +515,65 @@ impl GitOps for GixGitOps {
             })?
             .detach();
 
-        // Check if any branch tip can reach this commit
-        let refs = r.references().map_err(|e| Error::GitCommand {
-            command: "gix references".to_string(),
-            message: e.to_string(),
-        })?;
-        for reference in refs.local_branches().map_err(|e| Error::GitCommand {
-            command: "gix local_branches".to_string(),
-            message: e.to_string(),
-        })? {
-            let reference = match reference {
-                Ok(r) => r,
-                Err(_) => continue,
-            };
-            let tip = match reference.into_fully_peeled_id() {
-                Ok(id) => id.detach(),
-                Err(_) => continue,
-            };
-            if tip == target_id {
-                return Ok(true);
+        // Helper: given an iterator over ref tips, return true if any of them can reach the target. Closing over r so each pass uses the same open repo handle.
+        let check = |tips: &mut dyn Iterator<Item = gix::ObjectId>| -> bool {
+            for tip in tips {
+                if tip == target_id {
+                    return true;
+                }
+                if let Ok(base) = r.merge_base(tip, target_id)
+                    && base == target_id
+                {
+                    return true;
+                }
             }
-            // Walk from tip towards root, checking if target is reachable
-            if let Ok(base) = r.merge_base(tip, target_id)
-                && base == target_id
-            {
+            false
+        };
+
+        // Local branches.
+        {
+            let refs = r.references().map_err(|e| Error::GitCommand {
+                command: "gix references".to_string(),
+                message: e.to_string(),
+            })?;
+            let mut tips = refs
+                .local_branches()
+                .map_err(|e| Error::GitCommand {
+                    command: "gix local_branches".to_string(),
+                    message: e.to_string(),
+                })?
+                .filter_map(|reference| reference.ok())
+                .filter_map(|reference| {
+                    reference.into_fully_peeled_id().ok().map(|id| id.detach())
+                });
+            if check(&mut tips) {
                 return Ok(true);
             }
         }
+
+        // Remote-tracking branches. Matches RealGit's `git branch -a --contains`. Without this leg, a commit reachable only via origin/<branch> (a merged PR whose local branch was deleted but whose tag still points at the merge commit) is reported as unreachable, and git-tag-tidy classifies the tag as Stale → default delete.
+        {
+            let refs = r.references().map_err(|e| Error::GitCommand {
+                command: "gix references".to_string(),
+                message: e.to_string(),
+            })?;
+            let mut tips = refs
+                .prefixed("refs/remotes/")
+                .map_err(|e| Error::GitCommand {
+                    command: "gix prefixed refs/remotes/".to_string(),
+                    message: e.to_string(),
+                })?
+                .filter_map(|reference| reference.ok())
+                // Skip symbolic HEAD refs (e.g. refs/remotes/origin/HEAD) so they don't double-count what their target ref already covers.
+                .filter(|reference| !reference.name().as_bstr().ends_with(b"/HEAD"))
+                .filter_map(|reference| {
+                    reference.into_fully_peeled_id().ok().map(|id| id.detach())
+                });
+            if check(&mut tips) {
+                return Ok(true);
+            }
+        }
+
         Ok(false)
     }
 

--- a/crates/git-tidy-core/tests/gix_conformance.rs
+++ b/crates/git-tidy-core/tests/gix_conformance.rs
@@ -279,6 +279,38 @@ fn is_commit_reachable_true() {
 }
 
 #[test]
+fn is_commit_reachable_via_remote_only_branch() {
+    // Regression: previously `is_commit_reachable` ran `git branch --contains` without `-a`, so a commit reachable only via a remote-tracking branch (the merged-PR-with-tag-left-behind scenario) reported false → git-tag-tidy classified the tag as Stale → default delete. The `-a` flag fixes this; the test locks the behavior in.
+    let t = TestRepo::new();
+    let bare = t.set_up_remote();
+
+    // Create a feature branch with a unique commit and push it.
+    git(&t.main_repo, &["checkout", "-b", "feature"]);
+    t.commit_file(&t.main_repo, "feat.txt", "f", "feature commit");
+    let feature_sha = git(&t.main_repo, &["rev-parse", "HEAD"]);
+    git(&t.main_repo, &["push", "-u", "origin", "feature"]);
+
+    // Delete the local branch so the commit is reachable ONLY via origin/feature.
+    git(&t.main_repo, &["checkout", "main"]);
+    git(&t.main_repo, &["branch", "-D", "feature"]);
+
+    let real = RealGit;
+    let gix = GixGitOps;
+
+    let real_reachable = real
+        .is_commit_reachable(&t.main_repo, &feature_sha)
+        .unwrap();
+    let gix_reachable = gix.is_commit_reachable(&t.main_repo, &feature_sha).unwrap();
+    assert_eq!(real_reachable, gix_reachable);
+    assert!(
+        real_reachable,
+        "commit reachable only via origin/feature must report reachable",
+    );
+
+    let _ = bare;
+}
+
+#[test]
 fn is_commit_reachable_orphan() {
     let t = TestRepo::new();
     git(&t.main_repo, &["checkout", "--orphan", "orphan"]);


### PR DESCRIPTION
## Summary

- Adds the two regression tests the review-loop on #149 flagged as worthwhile but did not push.
- The second test caught that \`GixGitOps::is_commit_reachable\` was not widened alongside RealGit in #149 — it still only walked \`local_branches()\`. Aligns the gix impl to also walk \`refs/remotes/*\` (skipping symbolic \`*/HEAD\` refs).
- Drops a stranded \`..default_options()\` spread in \`git-lfs-tidy/src/clean.rs\` that became redundant after #137 + #147 both landed and is currently failing main CI under \`clippy::needless_update\`.

Closes #156

## Test plan

- [x] \`cargo test --workspace\` — all pass; new tests \`classify_detached_head_zeros_remote_fields\` and \`is_commit_reachable_via_remote_only_branch\`.
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D clippy::all\` — was failing on main before this PR; clean now.