### PR TITLE
Ignore Dependabot bumps for dtolnay/rust-toolchain (MSRV pin)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,8 @@ updates:
         update-types:
           - minor
           - patch
+    # The dtolnay/rust-toolchain pin in the msrv job is intentional —
+    # bumping it would defeat the MSRV check. Bump it manually when MSRV
+    # is officially raised.
+    ignore:
+      - dependency-name: "dtolnay/rust-toolchain"


### PR DESCRIPTION
## Summary

- Add an `ignore` entry for `dtolnay/rust-toolchain` in the github-actions Dependabot config.
- Reason: the `msrv` CI job pins the action to the MSRV version on purpose; auto-bumping defeats the check (as seen in #127, which raised it to 1.100.0 and failed CI).
- The `@stable` reference in the main `check` job is a moving tag, not a version, so Dependabot already leaves it alone — only the MSRV pin is affected.

Closes #158

## Test plan

- [ ] Verify CI passes on this PR.
- [ ] Close #127 (the MSRV-breaking bump) after this merges.
- [ ] Next weekly Dependabot run should not produce a `dtolnay/rust-toolchain` PR.