### PR TITLE
Migrate git-tag-tidy to TidyItem deep formatter

### DIFF
--- a/crates/git-tag-tidy/src/output.rs
+++ b/crates/git-tag-tidy/src/output.rs
@@ -1,80 +1,65 @@
+use std::borrow::Cow;
 use std::io::Write;
 
 use git_tidy_core::output as shared;
+use git_tidy_core::output::{Align, Cell, ColumnSpec, TidyItem};
 use git_tidy_core::types::ClassificationLabel;
 
-use crate::types::{TagInfo, TagScanResult};
+use crate::types::{TagInfo, TagScanResult, commit_short};
 
-const HEADER_STATUS: &str = "STATUS";
-const HEADER_NAME: &str = "NAME";
-const HEADER_COMMIT: &str = "COMMIT";
-const HEADER_KIND: &str = "KIND";
-const HEADER_DATE: &str = "DATE";
+impl TidyItem for TagInfo {
+    const COLUMNS: &'static [ColumnSpec] = &[
+        ColumnSpec {
+            header: "STATUS",
+            align: Align::Left,
+        },
+        ColumnSpec {
+            header: "NAME",
+            align: Align::Left,
+        },
+        ColumnSpec {
+            header: "COMMIT",
+            align: Align::Left,
+        },
+        ColumnSpec {
+            header: "KIND",
+            align: Align::Left,
+        },
+        ColumnSpec {
+            header: "DATE",
+            align: Align::Left,
+        },
+    ];
 
-struct ColumnWidths {
-    status: usize,
-    name: usize,
-    commit: usize,
-    kind: usize,
-    date: usize,
-    has_date: bool,
-}
-
-fn commit_short(commit: &str) -> &str {
-    if commit.len() >= 7 {
-        &commit[..7]
-    } else {
-        commit
-    }
-}
-
-fn compute_column_widths(tags: &[TagInfo]) -> ColumnWidths {
-    let mut max_status = HEADER_STATUS.len();
-    let mut max_name = HEADER_NAME.len();
-    let mut max_commit = HEADER_COMMIT.len();
-    let mut max_kind = HEADER_KIND.len();
-    let mut max_date = HEADER_DATE.len();
-    let mut has_date = false;
-
-    for t in tags {
-        max_status = max_status.max(t.classification.label().len());
-        max_name = max_name.max(t.name.len());
-        max_commit = max_commit.max(commit_short(&t.commit).len());
-        let kind = if t.is_annotated {
-            "annotated"
+    fn row(&self) -> Vec<Option<Cell>> {
+        let kind: Cell = if self.is_annotated {
+            Cow::Borrowed("annotated")
         } else {
-            "lightweight"
+            Cow::Borrowed("lightweight")
         };
-        max_kind = max_kind.max(kind.len());
-        if let Some(ref d) = t.tagger_date {
-            has_date = true;
-            max_date = max_date.max(d.len());
-        }
+        vec![
+            Some(Cow::Borrowed(self.classification.label())),
+            Some(Cow::Owned(self.name.clone())),
+            Some(Cow::Owned(commit_short(&self.commit).to_string())),
+            Some(kind),
+            // Conditional DATE column: None when absent so format_table hides
+            // the column iff every row's DATE cell is None.
+            self.tagger_date.as_ref().map(|d| Cow::Owned(d.clone())),
+        ]
     }
 
-    ColumnWidths {
-        status: max_status,
-        name: max_name,
-        commit: max_commit,
-        kind: max_kind,
-        date: max_date,
-        has_date,
+    fn porcelain_fields(&self) -> Vec<Cow<'static, str>> {
+        vec![
+            Cow::Owned(self.repo_path.display().to_string()),
+            Cow::Owned(self.name.clone()),
+            Cow::Borrowed(self.classification.label()),
+            Cow::Owned(self.commit.clone()),
+            Cow::Owned(self.is_annotated.to_string()),
+            Cow::Owned(self.tagger_date.clone().unwrap_or_default()),
+            Cow::Owned(self.is_release_tag.to_string()),
+            Cow::Owned(self.remote_names.join(",")),
+        ]
     }
-}
-
-fn write_header(out: &mut dyn Write, widths: &ColumnWidths) -> std::io::Result<()> {
-    let sw = widths.status;
-    let nw = widths.name;
-    let cw = widths.commit;
-    let kw = widths.kind;
-    let mut line = format!(
-        "  {HEADER_STATUS:<sw$} {HEADER_NAME:<nw$} {HEADER_COMMIT:<cw$} {HEADER_KIND:<kw$}"
-    );
-    if widths.has_date {
-        line.push_str(&format!(" {HEADER_DATE}"));
-    }
-    let trimmed = line.trim_end();
-    writeln!(out, "{trimmed}")
 }
 
 /// Write human-readable scan output.
@@ -84,32 +69,7 @@ pub fn write_human(out: &mut dyn Write, result: &TagScanResult) -> std::io::Resu
     for group in &result.repos {
         let noun = if group.tags.len() == 1 { "tag" } else { "tags" };
         writeln!(out, "\n{} ({} {noun})", group.name, group.tags.len())?;
-
-        let widths = compute_column_widths(&group.tags);
-        write_header(out, &widths)?;
-
-        for tag in &group.tags {
-            let label = tag.classification.label();
-            let cs = commit_short(&tag.commit);
-            let kind = if tag.is_annotated {
-                "annotated"
-            } else {
-                "lightweight"
-            };
-            let date = tag.tagger_date.as_deref().unwrap_or("");
-
-            let sw = widths.status;
-            let nw = widths.name;
-            let cw = widths.commit;
-            let kw = widths.kind;
-            let mut line = format!("  {label:<sw$} {:<nw$} {cs:<cw$} {kind:<kw$}", tag.name);
-            if widths.has_date {
-                let dw = widths.date;
-                line.push_str(&format!(" {date:<dw$}"));
-            }
-            let trimmed = line.trim_end();
-            writeln!(out, "{trimmed}")?;
-        }
+        shared::format_table(out, &group.tags)?;
     }
 
     write_tag_summary(out, result)?;
@@ -136,21 +96,7 @@ pub fn write_json(out: &mut dyn Write, result: &TagScanResult) -> std::io::Resul
 /// Write porcelain (machine-readable, tab-delimited) scan output.
 pub fn write_porcelain(out: &mut dyn Write, result: &TagScanResult) -> std::io::Result<()> {
     for group in &result.repos {
-        for tag in &group.tags {
-            let repo = tag.repo_path.display();
-            let remotes = tag.remote_names.join(",");
-
-            writeln!(
-                out,
-                "{repo}\t{}\t{}\t{}\t{}\t{}\t{}\t{remotes}",
-                tag.name,
-                tag.classification.label(),
-                tag.commit,
-                tag.is_annotated,
-                tag.tagger_date.as_deref().unwrap_or(""),
-                tag.is_release_tag,
-            )?;
-        }
+        shared::format_porcelain(out, &group.tags)?;
     }
     Ok(())
 }
@@ -224,6 +170,8 @@ mod tests {
         assert!(output.contains("NAME"));
         assert!(output.contains("COMMIT"));
         assert!(output.contains("KIND"));
+        // At least one tag has tagger_date set, so DATE column is visible.
+        assert!(output.contains("DATE"));
         assert!(output.contains("stale"));
         assert!(output.contains("local_only"));
         assert!(output.contains("synced"));
@@ -320,5 +268,206 @@ mod tests {
         write_human(&mut buf, &result).unwrap();
         let output = String::from_utf8(buf).unwrap();
         assert!(output.contains("test (1 tag)"));
+    }
+
+    #[test]
+    fn human_output_omits_date_column_when_all_missing() {
+        // When no tag in the group carries a tagger_date, format_table's
+        // all-None auto-hide rule should drop the DATE column entirely.
+        let result = TagScanResult {
+            repos: vec![TagRepoGroup {
+                repo_path: PathBuf::from("/repos/r"),
+                name: "r".to_string(),
+                tags: vec![
+                    TagInfo {
+                        repo_path: PathBuf::from("/repos/r"),
+                        name: "a".to_string(),
+                        classification: TagClassification::Stale,
+                        commit: "abc1234".to_string(),
+                        is_annotated: false,
+                        tagger_date: None,
+                        is_release_tag: false,
+                        remote_names: vec![],
+                    },
+                    TagInfo {
+                        repo_path: PathBuf::from("/repos/r"),
+                        name: "b".to_string(),
+                        classification: TagClassification::Synced,
+                        commit: "def5678".to_string(),
+                        is_annotated: true,
+                        tagger_date: None,
+                        is_release_tag: false,
+                        remote_names: vec!["origin".to_string()],
+                    },
+                ],
+            }],
+            total_scanned: 2,
+            counts: TagCounts {
+                stale: 1,
+                synced: 1,
+                ..Default::default()
+            },
+            warnings: vec![],
+        };
+
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(
+            !output.contains("DATE"),
+            "DATE column should be hidden when no row has a date: {output}"
+        );
+    }
+
+    #[test]
+    fn human_output_shows_date_column_when_any_present() {
+        // When at least one tag has a tagger_date, the DATE column appears,
+        // and rows without a date should still render cleanly.
+        let result = TagScanResult {
+            repos: vec![TagRepoGroup {
+                repo_path: PathBuf::from("/repos/r"),
+                name: "r".to_string(),
+                tags: vec![
+                    TagInfo {
+                        repo_path: PathBuf::from("/repos/r"),
+                        name: "lightweight-undated".to_string(),
+                        classification: TagClassification::Stale,
+                        commit: "abc1234".to_string(),
+                        is_annotated: false,
+                        tagger_date: None,
+                        is_release_tag: false,
+                        remote_names: vec![],
+                    },
+                    TagInfo {
+                        repo_path: PathBuf::from("/repos/r"),
+                        name: "annotated-dated".to_string(),
+                        classification: TagClassification::Synced,
+                        commit: "def5678".to_string(),
+                        is_annotated: true,
+                        tagger_date: Some("2024-06-15T10:00:00+00:00".to_string()),
+                        is_release_tag: false,
+                        remote_names: vec!["origin".to_string()],
+                    },
+                ],
+            }],
+            total_scanned: 2,
+            counts: TagCounts {
+                stale: 1,
+                synced: 1,
+                ..Default::default()
+            },
+            warnings: vec![],
+        };
+
+        let mut buf = Vec::new();
+        write_human(&mut buf, &result).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("DATE"), "DATE header missing: {output}");
+        assert!(output.contains("2024-06-15T10:00:00+00:00"));
+        assert!(output.contains("lightweight-undated"));
+        assert!(output.contains("annotated-dated"));
+    }
+
+    // --- TidyItem data-shape tests ---
+
+    fn tag_info(
+        name: &str,
+        classification: TagClassification,
+        commit: &str,
+        is_annotated: bool,
+        tagger_date: Option<&str>,
+        is_release_tag: bool,
+        remote_names: &[&str],
+    ) -> TagInfo {
+        TagInfo {
+            repo_path: PathBuf::from("/repos/backend"),
+            name: name.to_string(),
+            classification,
+            commit: commit.to_string(),
+            is_annotated,
+            tagger_date: tagger_date.map(|s| s.to_string()),
+            is_release_tag,
+            remote_names: remote_names.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn tidyitem_row_shape_tag() {
+        let row = tag_info(
+            "v1.0.0",
+            TagClassification::Synced,
+            "abc1234def5678",
+            true,
+            Some("2024-06-15T10:00:00+00:00"),
+            true,
+            &["origin"],
+        )
+        .row();
+        assert_eq!(row.len(), 5);
+        assert_eq!(row[0].as_deref(), Some("synced"));
+        assert_eq!(row[1].as_deref(), Some("v1.0.0"));
+        assert_eq!(row[2].as_deref(), Some("abc1234"));
+        assert_eq!(row[3].as_deref(), Some("annotated"));
+        assert_eq!(row[4].as_deref(), Some("2024-06-15T10:00:00+00:00"));
+    }
+
+    #[test]
+    fn tidyitem_row_date_none_renders_none_not_empty() {
+        // tagger_date: None must yield a literal None cell (not Some("")) so
+        // format_table's all-None auto-hide rule can drop the DATE column.
+        let row = tag_info(
+            "x",
+            TagClassification::Stale,
+            "abc1234",
+            false,
+            None,
+            false,
+            &[],
+        )
+        .row();
+        assert!(row[4].is_none());
+        // Lightweight tag should yield "lightweight" in KIND.
+        assert_eq!(row[3].as_deref(), Some("lightweight"));
+    }
+
+    #[test]
+    fn tidyitem_porcelain_tag_full_commit_and_remote_join() {
+        let fields = tag_info(
+            "v1.0.0",
+            TagClassification::Synced,
+            "abc1234def5678",
+            true,
+            Some("2024-06-15T10:00:00+00:00"),
+            true,
+            &["origin", "upstream"],
+        )
+        .porcelain_fields();
+        assert_eq!(fields.len(), 8);
+        assert_eq!(fields[0].as_ref(), "/repos/backend");
+        assert_eq!(fields[1].as_ref(), "v1.0.0");
+        assert_eq!(fields[2].as_ref(), "synced");
+        // Full commit, not shortened.
+        assert_eq!(fields[3].as_ref(), "abc1234def5678");
+        assert_eq!(fields[4].as_ref(), "true");
+        assert_eq!(fields[5].as_ref(), "2024-06-15T10:00:00+00:00");
+        assert_eq!(fields[6].as_ref(), "true");
+        // Remotes are comma-joined (no spaces).
+        assert_eq!(fields[7].as_ref(), "origin,upstream");
+    }
+
+    #[test]
+    fn tidyitem_porcelain_date_none_is_empty_field() {
+        let fields = tag_info(
+            "x",
+            TagClassification::Stale,
+            "abc1234",
+            false,
+            None,
+            false,
+            &[],
+        )
+        .porcelain_fields();
+        assert_eq!(fields[5].as_ref(), "");
+        assert_eq!(fields[7].as_ref(), "");
     }
 }

--- a/crates/git-tag-tidy/src/types.rs
+++ b/crates/git-tag-tidy/src/types.rs
@@ -129,6 +129,15 @@ impl From<&TagInfo> for JsonTag {
     }
 }
 
+/// Return the first 7 characters of a commit SHA, or the whole string if shorter.
+pub(crate) fn commit_short(commit: &str) -> &str {
+    if commit.len() >= 7 {
+        &commit[..7]
+    } else {
+        commit
+    }
+}
+
 /// Check if a tag name looks like a release version.
 ///
 /// Matches: `v1.0`, `v1.0.0`, `V1.0`, `1.2.3`, `v1.0.0-rc1`.


### PR DESCRIPTION
## Summary

- Replace `git-tag-tidy`'s hand-rolled `ColumnWidths` / `compute_column_widths` / `write_header` / row-rendering loop with a `TidyItem` impl on `TagInfo` and delegation to `git_tidy_core::output::{format_table, format_porcelain}`. `write_human` collapses to a per-group `format_table` call; `write_porcelain` collapses to a per-group `format_porcelain` call.
- The DATE column exercises `format_table`'s conditional-column wiring: `row()` returns `None` for the DATE cell when `tagger_date.is_none()`, so the column is hidden iff every row in the group is dateless and shown otherwise. Porcelain keeps the historical 8-field shape (`repo_path`, `name`, `classification`, `commit`, `is_annotated`, `tagger_date`, `is_release_tag`, `remote_names`) with `""` for a missing date.
- `commit_short` moves to `types.rs` as `pub(crate) fn` so it has a single source of truth shared by the trait impl. JSON output (`write_json` -> `shared::write_json_flat`) and the custom tag summary line are untouched.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D clippy::all`
- [x] `cargo test --workspace` (all crates pass)
- [x] New behavioral tests cover the conditional DATE column: hidden when all rows are dateless, visible when any row carries a date.
- [x] New `TidyItem` data-shape tests mirror the lfs-tidy precedent (row arity, `None` vs empty for the dateless cell, full-commit + comma-joined remotes in porcelain, empty porcelain field for `None` inputs).

Closes #163. Part of #116.