### PR TITLE
Fix install.sh warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ All tools follow a similar CLI shape:
 - `classify_branch` is the core classification function shared by both tools. `classify_worktree` is a thin wrapper that adds dirty detection. `classify_remote_branch` classifies remote-only branches (on origin but no local counterpart), using `origin/<branch>` as the git ref.
 - Discovery is inverted between tools: worktree discovery finds `.git` files (linked worktrees), branch discovery finds `.git` directories (repos).
 - `delete_fn` pattern: `run_clean` takes `&dyn Fn(&Path) -> io::Result<()>` so tests can verify deletion logic without `rm -rf`. Used in repo-tidy.
-- Injectable `du_fn`: `run_scan_with_du` takes a disk-usage function parameter so unit tests can provide canned sizes without hitting the filesystem. Used in repo-tidy.
+- Injectable `du_fn`: `run_scan_repos_with_du` takes a disk-usage function parameter so unit tests can provide canned sizes without hitting the filesystem. Used in repo-tidy.
 
 ## Project Layout
 

--- a/crates/git-config-tidy/src/output.rs
+++ b/crates/git-config-tidy/src/output.rs
@@ -13,28 +13,24 @@ struct ColumnWidths {
     severity: usize,
     kind: usize,
     setting: usize,
-    message: usize,
 }
 
 fn compute_column_widths(issues: &[ConfigIssue]) -> ColumnWidths {
     let mut max_severity = HEADER_SEVERITY.len();
     let mut max_kind = HEADER_KIND.len();
     let mut max_setting = HEADER_SETTING.len();
-    let mut max_message = HEADER_MESSAGE.len();
 
     for i in issues {
         max_severity = max_severity.max(i.severity.label().len());
         max_kind = max_kind.max(i.kind.label().len());
         // key=value combined
         max_setting = max_setting.max(i.key.len() + 1 + i.value.len());
-        max_message = max_message.max(i.message.len());
     }
 
     ColumnWidths {
         severity: max_severity,
         kind: max_kind,
         setting: max_setting,
-        message: max_message,
     }
 }
 

--- a/crates/git-repo-tidy/src/scan.rs
+++ b/crates/git-repo-tidy/src/scan.rs
@@ -140,42 +140,15 @@ pub fn run_scan(
     repo_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<RepoScanResult, Error> {
-    run_scan_with_du(
-        git,
-        directory,
-        stale_days,
-        noise_patterns,
-        offline,
-        verbose,
-        repo_filter,
-        &disk_usage,
-        progress,
-    )
-}
-
-/// Scan with an injectable disk-usage function (for testing).
-#[allow(clippy::too_many_arguments)]
-pub fn run_scan_with_du(
-    git: &dyn GitOps,
-    directory: &Path,
-    stale_days: u64,
-    noise_patterns: &[String],
-    offline: bool,
-    verbose: bool,
-    repo_filter: &NameFilter,
-    du_fn: &(dyn Fn(&Path) -> u64 + Sync),
-    progress: &Progress,
-) -> Result<RepoScanResult, Error> {
     let repo_paths = discover_repos(directory)?;
     let repo_paths = filter_paths(repo_paths, repo_filter);
-    run_scan_repos_with_du(
+    run_scan_repos(
         git,
         &repo_paths,
         stale_days,
         noise_patterns,
         offline,
         verbose,
-        du_fn,
         progress,
     )
 }

--- a/install.sh
+++ b/install.sh
@@ -23,9 +23,10 @@ COMP_DIR="/usr/local/share/zsh/site-functions"
 if [ -d "$COMP_DIR" ] || mkdir -p "$COMP_DIR" 2>/dev/null; then
   echo "Installing zsh completions to $COMP_DIR..."
 
-  # Sub-tool completions
+  # Sub-tool completions (git-tidy uses a custom dispatcher generator below)
   for crate in crates/*/; do
     [ -f "$crate/src/main.rs" ] || continue
+    [[ "$crate" == crates/git-tidy/ ]] && continue
     name=$(basename "$crate")
     echo "  Generating _${name}..."
     "$name" completions zsh > "$COMP_DIR/_${name}"


### PR DESCRIPTION
## Summary

- Drop dead `message` field from `git-config-tidy::output::ColumnWidths`.
- Route `git-repo-tidy::scan::run_scan` through `run_scan_repos` (matching every other tool) and delete the now-unused `run_scan_with_du`.
- Skip `crates/git-tidy/` in install.sh's completion loop so the dispatcher completion isn't double-generated.

After this PR, `bash install.sh` runs with zero cargo warnings and prints `Generating _git-tidy...` exactly once.

Closes #176

## Test plan

- [x] `cargo build --workspace` — warning-free
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D clippy::all`
- [x] `cargo test --workspace` — green
- [x] `bash install.sh` re-run end-to-end — no `^warning:` lines, single `Generating _git-tidy...`