### PR TITLE
Remove redundant detect_default_branch precedence test that never tested precedence

### DIFF
--- a/crates/git-tidy-core/src/classification.rs
+++ b/crates/git-tidy-core/src/classification.rs
@@ -854,17 +854,14 @@ mod tests {
         assert_eq!(result, "master");
     }
 
-    #[test]
-    fn detect_default_branch_prefers_origin_over_local() {
-        // Both origin/main and local main exist — origin check wins (step 2 before step 4)
-        let git = MockGitBuilder::new()
-            .with_symbolic_ref(&repo(), None)
-            .with_rev_parse_verify(&repo(), "refs/remotes/origin/main", true)
-            // local main also exists, but we never reach step 4
-            .build();
-        let result = detect_default_branch(&git, &repo()).unwrap();
-        assert_eq!(result, "main");
-    }
+    // Origin-over-local precedence is unobservable at this seam: when
+    // `refs/remotes/origin/main` exists, `detect_default_branch` returns at method 2
+    // before ever calling `rev_parse_verify` on `refs/heads/main` (method 4). No mock
+    // configuration of the local ref can change the outcome — the local lookup never
+    // happens — so a "prefers origin over local" test would exercise the identical path
+    // as `detect_default_branch_probe_main` and could not fail if precedence regressed.
+    // The precedence is implied structurally by the method ordering; the local-fallback
+    // path is covered by `detect_default_branch_local_main` / `_local_master`.
 
     // --- classify_branch local-only repo tests ---
 


### PR DESCRIPTION
## Summary

`detect_default_branch_prefers_origin_over_local` had a byte-identical body to `detect_default_branch_probe_main` (flagged by the `function-duplicates` exact-cluster audit). Despite its name and comment claiming it verifies "origin check wins over a local main," its mock never configured a local `main` — so it exercised the same code path as `probe_main` and would still pass if the local-fallback step (method 4) were broken or reordered.

## Reasoning (from the actual control flow)

`detect_default_branch` consults refs in strict order and returns at the first hit:

1. `symbolic_ref_origin_head`
2. `rev_parse_verify("refs/remotes/origin/main")` → returns `"main"` and **short-circuits**
3. `rev_parse_verify("refs/remotes/origin/master")`
4. `rev_parse_verify("refs/heads/main")`
5. `rev_parse_verify("refs/heads/master")`

When `refs/remotes/origin/main` exists, method 2 returns before method 4 is ever reached, so `refs/heads/main` is never queried. The mock's `rev_parse_verify` only responds to configured refs and never sees that lookup. **No mock configuration of the local ref can change the outcome** — the precedence is genuinely unobservable at this seam. A "prefers origin over local" test therefore cannot be strengthened to fail-if-precedence-regresses; adding `.with_rev_parse_verify(&repo(), "refs/heads/main", true)` would be a no-op that gives false confidence.

## Path taken: removed the test

Per the issue's second branch, I removed the redundant test and left a comment in its place explaining why origin-over-local precedence is structural (implied by method ordering) and unobservable through this mock seam. The local-fallback path remains covered by `detect_default_branch_local_main` and `detect_default_branch_local_master`.

## Verification

- `cargo fmt --check` — pass
- `cargo clippy --workspace --all-targets -- -D clippy::all` — pass
- `cargo test --workspace` — pass (the six remaining `detect_default_branch_*` tests run and pass)

Closes #182