### PR TITLE
Deduplicate stash-tidy date formatting via git-tidy-core

### DIFF
--- a/crates/git-stash-tidy/src/scan.rs
+++ b/crates/git-stash-tidy/src/scan.rs
@@ -204,6 +204,7 @@ pub fn run_scan_repos(
 mod tests {
     use std::path::PathBuf;
 
+    use git_tidy_core::date::format_iso_date;
     use git_tidy_core::testutil::MockGitBuilder;
 
     use super::*;
@@ -277,10 +278,7 @@ mod tests {
                 .unwrap()
                 .as_secs();
             let days = secs / 86400;
-            format!(
-                "{}T12:00:00+00:00",
-                format_date_from_epoch_days(days as i64)
-            )
+            format!("{}T12:00:00+00:00", format_iso_date(days as i64))
         };
 
         let (cls, _, branch) = classify_stash(
@@ -357,10 +355,7 @@ mod tests {
                 .as_secs();
             let days = secs / 86400;
             // Approximate today's date
-            format!(
-                "{}T12:00:00+00:00",
-                format_date_from_epoch_days(days as i64)
-            )
+            format!("{}T12:00:00+00:00", format_iso_date(days as i64))
         };
 
         let branches = vec!["main".to_string()];
@@ -388,10 +383,7 @@ mod tests {
                 .unwrap()
                 .as_secs();
             let days = secs / 86400;
-            format!(
-                "{}T12:00:00+00:00",
-                format_date_from_epoch_days(days as i64)
-            )
+            format!("{}T12:00:00+00:00", format_iso_date(days as i64))
         };
 
         let (cls, _, _) = classify_stash(
@@ -483,21 +475,5 @@ mod tests {
         assert_eq!(infos[0].classification, StashClassification::Committed);
         assert_eq!(infos[1].classification, StashClassification::Orphaned);
         assert_eq!(infos[2].classification, StashClassification::Active);
-    }
-
-    /// Helper to format an epoch day count as YYYY-MM-DD.
-    fn format_date_from_epoch_days(days: i64) -> String {
-        // Simple Hinnant civil_from_days
-        let z = days + 719468;
-        let era = if z >= 0 { z } else { z - 146096 } / 146097;
-        let doe = z - era * 146097;
-        let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-        let y = yoe + era * 400;
-        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-        let mp = (5 * doy + 2) / 153;
-        let d = doy - (153 * mp + 2) / 5 + 1;
-        let m = if mp < 10 { mp + 3 } else { mp - 9 };
-        let y = if m <= 2 { y + 1 } else { y };
-        format!("{y:04}-{m:02}-{d:02}")
     }
 }

--- a/crates/git-tidy-core/src/date.rs
+++ b/crates/git-tidy-core/src/date.rs
@@ -50,6 +50,12 @@ fn now_date() -> (i64, i64, i64) {
     civil_from_days(secs / 86400)
 }
 
+/// Format a day count (days since Unix epoch) as an ISO 8601 `YYYY-MM-DD` date.
+pub fn format_iso_date(days: i64) -> String {
+    let (y, m, d) = civil_from_days(days);
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
 /// Convert a day count (days since Unix epoch) to a civil date.
 fn civil_from_days(days: i64) -> (i64, i64, i64) {
     let z = days + 719468;
@@ -89,6 +95,12 @@ mod tests {
 
         let (y2, m2, d2) = civil_from_days(365);
         assert_eq!((y2, m2, d2), (1971, 1, 1));
+    }
+
+    #[test]
+    fn format_iso_date_matches_civil() {
+        assert_eq!(format_iso_date(0), "1970-01-01");
+        assert_eq!(format_iso_date(365), "1971-01-01");
     }
 
     #[test]


### PR DESCRIPTION
Removes `git-stash-tidy`'s private copy of the Hinnant civil-from-days date algorithm and routes date formatting through `git-tidy-core` instead.

## Changes

- Add `pub fn format_iso_date(days: i64) -> String` to `git-tidy-core::date`, wrapping the existing private `civil_from_days` and producing the `YYYY-MM-DD` string. Includes a unit test (`format_iso_date_matches_civil`) modeled on the existing `round_trip_civil`.
- Delete `format_date_from_epoch_days` from `git-stash-tidy/src/scan.rs` and call `format_iso_date` at the three (test-only) call sites.

The calendar conversion now lives once in the workspace. The change is behavior-preserving: `format_iso_date` performs the same `civil_from_days` + `{y:04}-{m:02}-{d:02}` formatting the old helper did, so stash scan date output is byte-identical.

Closes #180