### PR TITLE
Unify DeletedBranch and RemovedTag into core RemovedRef

### DIFF
--- a/crates/git-branch-tidy/src/clean.rs
+++ b/crates/git-branch-tidy/src/clean.rs
@@ -1,9 +1,8 @@
 use std::io::Write;
-use std::path::PathBuf;
 
 use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
-use git_tidy_core::types::{Classification, CleanResult, FailedItem};
+use git_tidy_core::types::{Classification, CleanResult, FailedItem, RemovedRef};
 
 use crate::types::BranchScanResult;
 
@@ -21,21 +20,13 @@ pub struct CleanOptions {
     pub include_remote: bool,
 }
 
-#[derive(Debug)]
-#[allow(dead_code)]
-pub struct DeletedBranch {
-    pub repo: PathBuf,
-    pub name: String,
-    pub remote_deleted: bool,
-}
-
 /// Run the clean operation on a scan result.
 pub fn run_clean(
     git: &dyn GitOps,
     scan_result: &BranchScanResult,
     options: &CleanOptions,
     out: &mut dyn Write,
-) -> Result<CleanResult<DeletedBranch>, Error> {
+) -> Result<CleanResult<RemovedRef>, Error> {
     let mut succeeded = Vec::new();
     let mut failed = Vec::new();
     let mut skipped = 0;
@@ -58,7 +49,7 @@ pub fn run_clean(
             if branch.remote_only {
                 if options.dry_run {
                     writeln!(out, "would delete remote {} in {}", branch.name, group.name)?;
-                    succeeded.push(DeletedBranch {
+                    succeeded.push(RemovedRef {
                         repo: branch.repo_path.clone(),
                         name: branch.name.clone(),
                         remote_deleted: true,
@@ -69,7 +60,7 @@ pub fn run_clean(
                 match git.delete_remote_branch(&branch.repo_path, "origin", &branch.name) {
                     Ok(()) => {
                         writeln!(out, "deleted remote {}", branch.name)?;
-                        succeeded.push(DeletedBranch {
+                        succeeded.push(RemovedRef {
                             repo: branch.repo_path.clone(),
                             name: branch.name.clone(),
                             remote_deleted: true,
@@ -93,7 +84,7 @@ pub fn run_clean(
                     write!(out, " (and remote)")?;
                 }
                 writeln!(out, " in {}", group.name)?;
-                succeeded.push(DeletedBranch {
+                succeeded.push(RemovedRef {
                     repo: branch.repo_path.clone(),
                     name: branch.name.clone(),
                     remote_deleted: false,
@@ -148,7 +139,7 @@ pub fn run_clean(
                         branch.name,
                         if remote_deleted { " (and remote)" } else { "" }
                     )?;
-                    succeeded.push(DeletedBranch {
+                    succeeded.push(RemovedRef {
                         repo: branch.repo_path.clone(),
                         name: branch.name.clone(),
                         remote_deleted,

--- a/crates/git-tag-tidy/src/clean.rs
+++ b/crates/git-tag-tidy/src/clean.rs
@@ -1,10 +1,9 @@
 use std::fmt::Write as _;
 use std::io::Write;
-use std::path::PathBuf;
 
 use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
-use git_tidy_core::types::{CleanResult, FailedItem};
+use git_tidy_core::types::{CleanResult, FailedItem, RemovedRef};
 
 use crate::types::{TagClassification, TagScanResult};
 
@@ -24,23 +23,13 @@ pub struct CleanOptions {
     pub all: bool,
 }
 
-/// A tag that was successfully removed.
-#[derive(Debug)]
-#[allow(dead_code)]
-pub struct RemovedTag {
-    pub repo: PathBuf,
-    pub name: String,
-    /// Whether remote copies were also deleted.
-    pub remote_deleted: bool,
-}
-
 /// Run the clean operation on a scan result.
 pub fn run_clean(
     git: &dyn GitOps,
     scan_result: &TagScanResult,
     options: &CleanOptions,
     out: &mut dyn Write,
-) -> Result<CleanResult<RemovedTag>, Error> {
+) -> Result<CleanResult<RemovedRef>, Error> {
     let mut succeeded = Vec::new();
     let mut failed = Vec::new();
     let mut skipped = 0;
@@ -74,7 +63,7 @@ pub fn run_clean(
                     .unwrap();
                 }
                 writeln!(out, "{action}")?;
-                succeeded.push(RemovedTag {
+                succeeded.push(RemovedRef {
                     repo: group.repo_path.clone(),
                     name: tag.name.clone(),
                     remote_deleted: false,
@@ -152,7 +141,7 @@ pub fn run_clean(
                 }
             }
 
-            succeeded.push(RemovedTag {
+            succeeded.push(RemovedRef {
                 repo: group.repo_path.clone(),
                 name: tag.name.clone(),
                 remote_deleted,

--- a/crates/git-tidy-core/src/types.rs
+++ b/crates/git-tidy-core/src/types.rs
@@ -44,6 +44,17 @@ pub struct FailedItem {
     pub reason: String,
 }
 
+/// Generic record for a named ref (branch, tag, …) removed during a clean
+/// operation, optionally also deleted on the remote.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct RemovedRef {
+    pub repo: PathBuf,
+    pub name: String,
+    /// Whether remote copies were also deleted.
+    pub remote_deleted: bool,
+}
+
 /// Generic result of a clean operation.
 #[derive(Debug)]
 pub struct CleanResult<S> {


### PR DESCRIPTION
## What

`git-branch-tidy` and `git-tag-tidy` each declared a 3-field clean-result record with byte-identical shape — `{ repo: PathBuf, name: String, remote_deleted: bool }` — flagged by the type-catalog `exact-duplicates` query. This unifies them into a single shared `git_tidy_core::types::RemovedRef`, used by both clean paths.

## Path taken: unify (not annotate-separate)

Unification is byte-stable here with no conversions or aliases needed:

- Neither `DeletedBranch` nor `RemovedTag` derived `Serialize` — they are never serialized to JSON, so there is no serde field-name surface to preserve. The structs carried `#[allow(dead_code)]` because their fields are only read by each crate's own tests.
- All human output (the `writeln!` lines in each `run_clean`) is produced independently of these structs and is untouched.
- Both structs already had identical field names and field order, so the merge is a pure rename to the shared type.

`RemovedRef` lives next to the existing `FailedItem` / `CleanResult<S>` family in `crates/git-tidy-core/src/types.rs`, keeping the per-item clean records together.

## Verification

- `cargo fmt --all` + `cargo fmt --check`: pass
- `cargo clippy --workspace --all-targets -- -D clippy::all`: pass (no warnings)
- `cargo test --workspace`: pass (all tests green)

Branch and tag `clean` output (human + JSON) is unchanged.

## Related

Related to #118 (clean-pipeline collapse). If that issue later introduces a generic removed-item type for the clean *loop*, `RemovedRef` is the natural thing to fold into it rather than maintaining a parallel abstraction.

Closes #184