### PR TITLE
Move duplicated set_up_repo integration-test helpers into git-tidy-core testutil

### DIFF
--- a/crates/git-branch-tidy/tests/integration_clean.rs
+++ b/crates/git-branch-tidy/tests/integration_clean.rs
@@ -1,35 +1,7 @@
 mod common;
 
-use common::git;
+use common::{git, set_up_repo_with_remote};
 use git_tidy_core::git::{GitOps, RealGit};
-
-/// Set up a repo with a remote so detect_default_branch works.
-fn set_up_repo_with_remote() -> (tempfile::TempDir, std::path::PathBuf) {
-    let dir = tempfile::tempdir().unwrap();
-    let base = dir.path().canonicalize().unwrap();
-
-    let bare = base.join("remote.git");
-    std::fs::create_dir_all(&bare).unwrap();
-    git(&bare, &["init", "--bare"]);
-
-    let scan_dir = base.join("projects");
-    std::fs::create_dir_all(&scan_dir).unwrap();
-
-    let repo = scan_dir.join("my-repo");
-    std::fs::create_dir_all(&repo).unwrap();
-    git(&repo, &["init", "-b", "main"]);
-    git(&repo, &["config", "user.email", "test@test.com"]);
-    git(&repo, &["config", "user.name", "Test"]);
-
-    git(&repo, &["remote", "add", "origin", &bare.to_string_lossy()]);
-
-    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
-    git(&repo, &["add", "README.md"]);
-    git(&repo, &["commit", "-m", "Initial commit"]);
-    git(&repo, &["push", "-u", "origin", "main"]);
-
-    (dir, repo)
-}
 
 #[test]
 fn clean_deletes_merged_branch_in_real_repo() {

--- a/crates/git-branch-tidy/tests/integration_scan.rs
+++ b/crates/git-branch-tidy/tests/integration_scan.rs
@@ -1,44 +1,8 @@
 mod common;
 
-use common::git;
+use common::{git, set_up_repo_with_remote};
 use git_tidy_core::git::RealGit;
 use git_tidy_core::types::Classification;
-
-/// Set up a repo with a remote so detect_default_branch works.
-/// Returns (scan_dir, repo_path) where scan_dir is the directory to pass to run_scan.
-fn set_up_repo_with_remote() -> (tempfile::TempDir, std::path::PathBuf) {
-    let dir = tempfile::tempdir().unwrap();
-    let base = dir.path().canonicalize().unwrap();
-
-    // Create a bare "remote" repo
-    let bare = base.join("remote.git");
-    std::fs::create_dir_all(&bare).unwrap();
-    git(&bare, &["init", "--bare"]);
-
-    // Create the scan directory that holds the working repo
-    let scan_dir = base.join("projects");
-    std::fs::create_dir_all(&scan_dir).unwrap();
-
-    // Create the working repo inside scan_dir
-    let repo = scan_dir.join("my-repo");
-    std::fs::create_dir_all(&repo).unwrap();
-    git(&repo, &["init", "-b", "main"]);
-    git(&repo, &["config", "user.email", "test@test.com"]);
-    git(&repo, &["config", "user.name", "Test"]);
-
-    // Add remote
-    git(&repo, &["remote", "add", "origin", &bare.to_string_lossy()]);
-
-    // Initial commit
-    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
-    git(&repo, &["add", "README.md"]);
-    git(&repo, &["commit", "-m", "Initial commit"]);
-
-    // Push main to remote so origin/main exists
-    git(&repo, &["push", "-u", "origin", "main"]);
-
-    (dir, repo)
-}
 
 #[test]
 fn scan_real_repo_with_mixed_branches() {

--- a/crates/git-lfs-tidy/tests/integration_clean.rs
+++ b/crates/git-lfs-tidy/tests/integration_clean.rs
@@ -1,31 +1,10 @@
 mod common;
 
-use common::git;
+use common::{git, set_up_repo};
 use git_tidy_core::git::RealGit;
 
 use git_lfs_tidy::clean::{CleanOptions, CleanResult};
 use git_lfs_tidy::types::LfsClassification;
-
-/// Set up a repo inside a scan directory so `discover_repos` finds it.
-fn set_up_repo() -> (tempfile::TempDir, std::path::PathBuf) {
-    let dir = tempfile::tempdir().unwrap();
-    let base = dir.path().canonicalize().unwrap();
-
-    let scan_dir = base.join("projects");
-    std::fs::create_dir_all(&scan_dir).unwrap();
-
-    let repo = scan_dir.join("my-repo");
-    std::fs::create_dir_all(&repo).unwrap();
-    git(&repo, &["init", "-b", "main"]);
-    git(&repo, &["config", "user.email", "test@test.com"]);
-    git(&repo, &["config", "user.name", "Test"]);
-
-    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
-    git(&repo, &["add", "README.md"]);
-    git(&repo, &["commit", "-m", "Initial commit"]);
-
-    (dir, repo)
-}
 
 fn run_scan_and_clean(
     scan_dir: &std::path::Path,

--- a/crates/git-lfs-tidy/tests/integration_scan.rs
+++ b/crates/git-lfs-tidy/tests/integration_scan.rs
@@ -1,30 +1,9 @@
 mod common;
 
-use common::git;
+use common::{git, set_up_repo};
 use git_tidy_core::git::RealGit;
 
 use git_lfs_tidy::types::LfsClassification;
-
-/// Set up a repo inside a scan directory so `discover_repos` finds it.
-fn set_up_repo() -> (tempfile::TempDir, std::path::PathBuf) {
-    let dir = tempfile::tempdir().unwrap();
-    let base = dir.path().canonicalize().unwrap();
-
-    let scan_dir = base.join("projects");
-    std::fs::create_dir_all(&scan_dir).unwrap();
-
-    let repo = scan_dir.join("my-repo");
-    std::fs::create_dir_all(&repo).unwrap();
-    git(&repo, &["init", "-b", "main"]);
-    git(&repo, &["config", "user.email", "test@test.com"]);
-    git(&repo, &["config", "user.name", "Test"]);
-
-    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
-    git(&repo, &["add", "README.md"]);
-    git(&repo, &["commit", "-m", "Initial commit"]);
-
-    (dir, repo)
-}
 
 #[test]
 fn scan_repo_with_no_large_blobs() {

--- a/crates/git-remote-tidy/tests/integration_clean.rs
+++ b/crates/git-remote-tidy/tests/integration_clean.rs
@@ -1,28 +1,7 @@
 mod common;
 
-use common::git;
+use common::{git, set_up_repo};
 use git_tidy_core::git::{GitOps, RealGit};
-
-/// Set up a repo inside a scan directory so `discover_repos` finds it.
-fn set_up_repo() -> (tempfile::TempDir, std::path::PathBuf) {
-    let dir = tempfile::tempdir().unwrap();
-    let base = dir.path().canonicalize().unwrap();
-
-    let scan_dir = base.join("projects");
-    std::fs::create_dir_all(&scan_dir).unwrap();
-
-    let repo = scan_dir.join("my-repo");
-    std::fs::create_dir_all(&repo).unwrap();
-    git(&repo, &["init", "-b", "main"]);
-    git(&repo, &["config", "user.email", "test@test.com"]);
-    git(&repo, &["config", "user.name", "Test"]);
-
-    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
-    git(&repo, &["add", "README.md"]);
-    git(&repo, &["commit", "-m", "Initial commit"]);
-
-    (dir, repo)
-}
 
 #[test]
 fn clean_removes_remote_in_real_repo() {

--- a/crates/git-remote-tidy/tests/integration_scan.rs
+++ b/crates/git-remote-tidy/tests/integration_scan.rs
@@ -1,30 +1,9 @@
 mod common;
 
-use common::git;
+use common::{git, set_up_repo};
 use git_tidy_core::git::RealGit;
 
 use git_remote_tidy::types::RemoteClassification;
-
-/// Set up a repo inside a scan directory so `discover_repos` finds it.
-fn set_up_repo() -> (tempfile::TempDir, std::path::PathBuf) {
-    let dir = tempfile::tempdir().unwrap();
-    let base = dir.path().canonicalize().unwrap();
-
-    let scan_dir = base.join("projects");
-    std::fs::create_dir_all(&scan_dir).unwrap();
-
-    let repo = scan_dir.join("my-repo");
-    std::fs::create_dir_all(&repo).unwrap();
-    git(&repo, &["init", "-b", "main"]);
-    git(&repo, &["config", "user.email", "test@test.com"]);
-    git(&repo, &["config", "user.name", "Test"]);
-
-    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
-    git(&repo, &["add", "README.md"]);
-    git(&repo, &["commit", "-m", "Initial commit"]);
-
-    (dir, repo)
-}
 
 #[test]
 fn scan_real_repo_with_reachable_remote() {

--- a/crates/git-stash-tidy/tests/integration_clean.rs
+++ b/crates/git-stash-tidy/tests/integration_clean.rs
@@ -1,28 +1,7 @@
 mod common;
 
-use common::git;
+use common::{git, set_up_repo};
 use git_tidy_core::git::{GitOps, RealGit};
-
-/// Set up a repo inside a scan directory so `discover_repos` finds it.
-fn set_up_repo() -> (tempfile::TempDir, std::path::PathBuf) {
-    let dir = tempfile::tempdir().unwrap();
-    let base = dir.path().canonicalize().unwrap();
-
-    let scan_dir = base.join("projects");
-    std::fs::create_dir_all(&scan_dir).unwrap();
-
-    let repo = scan_dir.join("my-repo");
-    std::fs::create_dir_all(&repo).unwrap();
-    git(&repo, &["init", "-b", "main"]);
-    git(&repo, &["config", "user.email", "test@test.com"]);
-    git(&repo, &["config", "user.name", "Test"]);
-
-    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
-    git(&repo, &["add", "README.md"]);
-    git(&repo, &["commit", "-m", "Initial commit"]);
-
-    (dir, repo)
-}
 
 #[test]
 fn clean_drops_stash_in_real_repo() {

--- a/crates/git-stash-tidy/tests/integration_scan.rs
+++ b/crates/git-stash-tidy/tests/integration_scan.rs
@@ -1,30 +1,9 @@
 mod common;
 
-use common::git;
+use common::{git, set_up_repo};
 use git_tidy_core::git::RealGit;
 
 use git_stash_tidy::types::StashClassification;
-
-/// Set up a repo inside a scan directory so `discover_repos` finds it.
-fn set_up_repo() -> (tempfile::TempDir, std::path::PathBuf) {
-    let dir = tempfile::tempdir().unwrap();
-    let base = dir.path().canonicalize().unwrap();
-
-    let scan_dir = base.join("projects");
-    std::fs::create_dir_all(&scan_dir).unwrap();
-
-    let repo = scan_dir.join("my-repo");
-    std::fs::create_dir_all(&repo).unwrap();
-    git(&repo, &["init", "-b", "main"]);
-    git(&repo, &["config", "user.email", "test@test.com"]);
-    git(&repo, &["config", "user.name", "Test"]);
-
-    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
-    git(&repo, &["add", "README.md"]);
-    git(&repo, &["commit", "-m", "Initial commit"]);
-
-    (dir, repo)
-}
 
 #[test]
 fn scan_real_repo_with_stashes() {

--- a/crates/git-tag-tidy/tests/integration_clean.rs
+++ b/crates/git-tag-tidy/tests/integration_clean.rs
@@ -1,28 +1,7 @@
 mod common;
 
-use common::git;
+use common::{git, set_up_repo};
 use git_tidy_core::git::{GitOps, RealGit};
-
-/// Set up a repo inside a scan directory so `discover_repos` finds it.
-fn set_up_repo() -> (tempfile::TempDir, std::path::PathBuf) {
-    let dir = tempfile::tempdir().unwrap();
-    let base = dir.path().canonicalize().unwrap();
-
-    let scan_dir = base.join("projects");
-    std::fs::create_dir_all(&scan_dir).unwrap();
-
-    let repo = scan_dir.join("my-repo");
-    std::fs::create_dir_all(&repo).unwrap();
-    git(&repo, &["init", "-b", "main"]);
-    git(&repo, &["config", "user.email", "test@test.com"]);
-    git(&repo, &["config", "user.name", "Test"]);
-
-    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
-    git(&repo, &["add", "README.md"]);
-    git(&repo, &["commit", "-m", "Initial commit"]);
-
-    (dir, repo)
-}
 
 #[test]
 fn clean_removes_local_only_tag() {

--- a/crates/git-tag-tidy/tests/integration_scan.rs
+++ b/crates/git-tag-tidy/tests/integration_scan.rs
@@ -1,30 +1,9 @@
 mod common;
 
-use common::git;
+use common::{git, set_up_repo};
 use git_tidy_core::git::RealGit;
 
 use git_tag_tidy::types::TagClassification;
-
-/// Set up a repo inside a scan directory so `discover_repos` finds it.
-fn set_up_repo() -> (tempfile::TempDir, std::path::PathBuf) {
-    let dir = tempfile::tempdir().unwrap();
-    let base = dir.path().canonicalize().unwrap();
-
-    let scan_dir = base.join("projects");
-    std::fs::create_dir_all(&scan_dir).unwrap();
-
-    let repo = scan_dir.join("my-repo");
-    std::fs::create_dir_all(&repo).unwrap();
-    git(&repo, &["init", "-b", "main"]);
-    git(&repo, &["config", "user.email", "test@test.com"]);
-    git(&repo, &["config", "user.name", "Test"]);
-
-    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
-    git(&repo, &["add", "README.md"]);
-    git(&repo, &["commit", "-m", "Initial commit"]);
-
-    (dir, repo)
-}
 
 #[test]
 fn scan_synced_tag() {

--- a/crates/git-tidy-core/src/testutil.rs
+++ b/crates/git-tidy-core/src/testutil.rs
@@ -1560,6 +1560,68 @@ pub fn git(dir: &Path, args: &[&str]) -> String {
     String::from_utf8_lossy(&output.stdout).trim().to_string()
 }
 
+/// Set up a repo inside a scan directory so `discover_repos` finds it.
+///
+/// Returns `(tempdir, repo_path)`; the tempdir guards the lifetime of the
+/// on-disk repo and must be kept alive for the duration of the test.
+pub fn set_up_repo() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().canonicalize().unwrap();
+
+    let scan_dir = base.join("projects");
+    std::fs::create_dir_all(&scan_dir).unwrap();
+
+    let repo = scan_dir.join("my-repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    git(&repo, &["init", "-b", "main"]);
+    git(&repo, &["config", "user.email", "test@test.com"]);
+    git(&repo, &["config", "user.name", "Test"]);
+
+    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
+    git(&repo, &["add", "README.md"]);
+    git(&repo, &["commit", "-m", "Initial commit"]);
+
+    (dir, repo)
+}
+
+/// Set up a repo with an `origin` remote so default-branch detection works.
+///
+/// Returns `(tempdir, repo_path)`; the tempdir guards the lifetime of the
+/// on-disk repo and must be kept alive for the duration of the test.
+pub fn set_up_repo_with_remote() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().canonicalize().unwrap();
+
+    // Create a bare "remote" repo
+    let bare = base.join("remote.git");
+    std::fs::create_dir_all(&bare).unwrap();
+    git(&bare, &["init", "--bare"]);
+
+    // Create the scan directory that holds the working repo
+    let scan_dir = base.join("projects");
+    std::fs::create_dir_all(&scan_dir).unwrap();
+
+    // Create the working repo inside scan_dir
+    let repo = scan_dir.join("my-repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    git(&repo, &["init", "-b", "main"]);
+    git(&repo, &["config", "user.email", "test@test.com"]);
+    git(&repo, &["config", "user.name", "Test"]);
+
+    // Add remote
+    git(&repo, &["remote", "add", "origin", &bare.to_string_lossy()]);
+
+    // Initial commit
+    std::fs::write(repo.join("README.md"), "# Test\n").unwrap();
+    git(&repo, &["add", "README.md"]);
+    git(&repo, &["commit", "-m", "Initial commit"]);
+
+    // Push main to remote so origin/main exists
+    git(&repo, &["push", "-u", "origin", "main"]);
+
+    (dir, repo)
+}
+
 #[cfg(test)]
 mod mock_fidelity_tests {
     use super::*;


### PR DESCRIPTION
## Summary

Consolidates the copy-pasted integration-test setup helpers into the shared `git_tidy_core::testutil` module, where `TestRepo` and the `git` helper already live.

- `set_up_repo` was byte-identical across **8** test files — `git-{lfs,remote,stash,tag}-tidy`, each in both `integration_scan.rs` and `integration_clean.rs`. It now lives once in `testutil`.
- `set_up_repo_with_remote` was duplicated across `git-branch-tidy`'s `integration_scan.rs` and `integration_clean.rs` (functionally identical, differing only in comments). It now lives once in `testutil`.

Each consuming crate already re-exports `git_tidy_core::testutil::*` through its `tests/common/mod.rs` and already enables the `testutil` feature on the `git-tidy-core` dev-dependency, so the consumers just import the helpers via `common` and the local copies are deleted. No `Cargo.toml` changes were required.

`git-repo-tidy`'s `set_up_repo(dir, name)` has a different signature (takes the temp dir and repo name as arguments, returns just the `PathBuf`) and is **not** a duplicate — it was left untouched.

Net: 10 duplicated helper definitions removed; test behaviour is unchanged (same repos, same assertions).

## Verification

- `cargo fmt --check` — pass
- `cargo clippy --workspace --all-targets -- -D clippy::all` — pass
- `cargo test --workspace` — pass

## Follow-up (out of scope)

The issue also flags near-duplicate test families (`clean_skips_*_by_default`, `scan_empty_repo_no_*`) as parameterisation candidates. That is intentionally left for a separate change to keep this PR focused on the load-bearing de-duplication.

Closes #183