### PR TITLE
Lift shared CLI flags into git-tidy-core CommonArgs/RepoFilterArgs

### DIFF
--- a/crates/git-branch-tidy/src/cli.rs
+++ b/crates/git-branch-tidy/src/cli.rs
@@ -11,9 +11,8 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    /// Directory to scan (default: current directory)
-    #[arg(global = true)]
-    pub directory: Option<PathBuf>,
+    #[command(flatten)]
+    pub common: git_tidy_core::cli::CommonArgs,
 
     /// Commit count for diverged annotation
     #[arg(long, default_value_t = 100, global = true)]
@@ -23,13 +22,8 @@ pub struct Cli {
     #[arg(short, long, global = true)]
     pub verbose: bool,
 
-    /// Filter repos by name substring (can be repeated, OR semantics)
-    #[arg(long = "match-repo", global = true)]
-    pub match_repo_patterns: Vec<String>,
-
-    /// Exclude repos by name substring (takes precedence over --match-repo)
-    #[arg(long = "exclude-repo", global = true)]
-    pub exclude_repo_patterns: Vec<String>,
+    #[command(flatten)]
+    pub repo_filter: git_tidy_core::cli::RepoFilterArgs,
 
     /// Filter branches by name substring (can be repeated, OR semantics)
     #[arg(long = "match", global = true)]
@@ -95,7 +89,7 @@ pub enum Command {
 impl Cli {
     /// Resolve the target directory, defaulting to the current directory.
     pub fn target_directory(&self) -> PathBuf {
-        git_tidy_core::cli::resolve_directory(self.directory.clone())
+        git_tidy_core::cli::resolve_directory(self.common.directory.clone())
     }
 }
 
@@ -115,7 +109,7 @@ mod tests {
     fn scan_with_directory() {
         let cli = Cli::parse_from(["git-branch-tidy", "scan", "/tmp/dev"]);
         assert!(matches!(cli.command, Some(Command::Scan { .. })));
-        assert_eq!(cli.directory, Some(PathBuf::from("/tmp/dev")));
+        assert_eq!(cli.common.directory, Some(PathBuf::from("/tmp/dev")));
     }
 
     #[test]
@@ -242,7 +236,13 @@ mod tests {
             "archive",
             "scan",
         ]);
-        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
-        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
+        assert_eq!(
+            cli.repo_filter.match_repo_patterns,
+            vec!["myproject".to_string()]
+        );
+        assert_eq!(
+            cli.repo_filter.exclude_repo_patterns,
+            vec!["archive".to_string()]
+        );
     }
 }

--- a/crates/git-branch-tidy/src/main.rs
+++ b/crates/git-branch-tidy/src/main.rs
@@ -31,7 +31,10 @@ fn main() {
 
     let git = gix_ops::GixGitOps;
     let progress = Progress::new();
-    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let repo_filter = NameFilter::new(
+        &cli.repo_filter.match_repo_patterns,
+        &cli.repo_filter.exclude_repo_patterns,
+    );
     let entity_filter = NameFilter::new(&cli.match_patterns, &cli.exclude_patterns);
     let mut stdout = io::stdout().lock();
 

--- a/crates/git-config-tidy/src/cli.rs
+++ b/crates/git-config-tidy/src/cli.rs
@@ -11,21 +11,15 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    /// Directory to scan (default: current directory)
-    #[arg(global = true)]
-    pub directory: Option<PathBuf>,
+    #[command(flatten)]
+    pub common: git_tidy_core::cli::CommonArgs,
 
     /// Show detailed lint reasoning
     #[arg(short, long, global = true)]
     pub verbose: bool,
 
-    /// Filter repos by name substring (can be repeated, OR semantics)
-    #[arg(long = "match-repo", global = true)]
-    pub match_repo_patterns: Vec<String>,
-
-    /// Exclude repos by name substring (takes precedence over --match-repo)
-    #[arg(long = "exclude-repo", global = true)]
-    pub exclude_repo_patterns: Vec<String>,
+    #[command(flatten)]
+    pub repo_filter: git_tidy_core::cli::RepoFilterArgs,
 }
 
 #[derive(Subcommand, Debug)]
@@ -63,7 +57,7 @@ pub enum Command {
 impl Cli {
     /// Resolve the target directory, defaulting to the current directory.
     pub fn target_directory(&self) -> PathBuf {
-        git_tidy_core::cli::resolve_directory(self.directory.clone())
+        git_tidy_core::cli::resolve_directory(self.common.directory.clone())
     }
 }
 
@@ -83,7 +77,7 @@ mod tests {
     fn lint_with_directory() {
         let cli = Cli::parse_from(["git-config-tidy", "lint", "/tmp/dev"]);
         assert!(matches!(cli.command, Some(Command::Lint { .. })));
-        assert_eq!(cli.directory, Some(PathBuf::from("/tmp/dev")));
+        assert_eq!(cli.common.directory, Some(PathBuf::from("/tmp/dev")));
     }
 
     #[test]
@@ -164,7 +158,13 @@ mod tests {
             "archive",
             "lint",
         ]);
-        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
-        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
+        assert_eq!(
+            cli.repo_filter.match_repo_patterns,
+            vec!["myproject".to_string()]
+        );
+        assert_eq!(
+            cli.repo_filter.exclude_repo_patterns,
+            vec!["archive".to_string()]
+        );
     }
 }

--- a/crates/git-config-tidy/src/main.rs
+++ b/crates/git-config-tidy/src/main.rs
@@ -30,7 +30,10 @@ fn main() {
 
     let git = gix_ops::GixGitOps;
     let progress = Progress::new();
-    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let repo_filter = NameFilter::new(
+        &cli.repo_filter.match_repo_patterns,
+        &cli.repo_filter.exclude_repo_patterns,
+    );
     let mut stdout = io::stdout().lock();
 
     match &cli.command {

--- a/crates/git-lfs-tidy/src/cli.rs
+++ b/crates/git-lfs-tidy/src/cli.rs
@@ -11,21 +11,15 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    /// Directory to scan (default: current directory)
-    #[arg(global = true)]
-    pub directory: Option<PathBuf>,
+    #[command(flatten)]
+    pub common: git_tidy_core::cli::CommonArgs,
 
     /// Show detailed scan reasoning
     #[arg(short, long, global = true)]
     pub verbose: bool,
 
-    /// Filter repos by name substring (can be repeated, OR semantics)
-    #[arg(long = "match-repo", global = true)]
-    pub match_repo_patterns: Vec<String>,
-
-    /// Exclude repos by name substring (takes precedence over --match-repo)
-    #[arg(long = "exclude-repo", global = true)]
-    pub exclude_repo_patterns: Vec<String>,
+    #[command(flatten)]
+    pub repo_filter: git_tidy_core::cli::RepoFilterArgs,
 }
 
 #[derive(Subcommand, Debug)]
@@ -83,7 +77,7 @@ pub enum Command {
 impl Cli {
     /// Resolve the target directory, defaulting to the current directory.
     pub fn target_directory(&self) -> PathBuf {
-        git_tidy_core::cli::resolve_directory(self.directory.clone())
+        git_tidy_core::cli::resolve_directory(self.common.directory.clone())
     }
 }
 
@@ -103,7 +97,7 @@ mod tests {
     fn scan_with_directory() {
         let cli = Cli::parse_from(["git-lfs-tidy", "scan", "/tmp/dev"]);
         assert!(matches!(cli.command, Some(Command::Scan { .. })));
-        assert_eq!(cli.directory, Some(PathBuf::from("/tmp/dev")));
+        assert_eq!(cli.common.directory, Some(PathBuf::from("/tmp/dev")));
     }
 
     #[test]
@@ -191,7 +185,13 @@ mod tests {
             "archive",
             "scan",
         ]);
-        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
-        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
+        assert_eq!(
+            cli.repo_filter.match_repo_patterns,
+            vec!["myproject".to_string()]
+        );
+        assert_eq!(
+            cli.repo_filter.exclude_repo_patterns,
+            vec!["archive".to_string()]
+        );
     }
 }

--- a/crates/git-lfs-tidy/src/main.rs
+++ b/crates/git-lfs-tidy/src/main.rs
@@ -30,7 +30,10 @@ fn main() {
 
     let git = gix_ops::GixGitOps;
     let progress = Progress::new();
-    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let repo_filter = NameFilter::new(
+        &cli.repo_filter.match_repo_patterns,
+        &cli.repo_filter.exclude_repo_patterns,
+    );
     let mut stdout = io::stdout().lock();
 
     // Extract scan parameters from whichever subcommand is active.

--- a/crates/git-remote-tidy/src/cli.rs
+++ b/crates/git-remote-tidy/src/cli.rs
@@ -11,9 +11,8 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    /// Directory to scan (default: current directory)
-    #[arg(global = true)]
-    pub directory: Option<PathBuf>,
+    #[command(flatten)]
+    pub common: git_tidy_core::cli::CommonArgs,
 
     /// Show detailed classification reasoning
     #[arg(short, long, global = true)]
@@ -23,13 +22,8 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub offline: bool,
 
-    /// Filter repos by name substring (can be repeated, OR semantics)
-    #[arg(long = "match-repo", global = true)]
-    pub match_repo_patterns: Vec<String>,
-
-    /// Exclude repos by name substring (takes precedence over --match-repo)
-    #[arg(long = "exclude-repo", global = true)]
-    pub exclude_repo_patterns: Vec<String>,
+    #[command(flatten)]
+    pub repo_filter: git_tidy_core::cli::RepoFilterArgs,
 
     /// Filter remotes by name substring (can be repeated, OR semantics)
     #[arg(long = "match", global = true)]
@@ -83,7 +77,7 @@ pub enum Command {
 impl Cli {
     /// Resolve the target directory, defaulting to the current directory.
     pub fn target_directory(&self) -> PathBuf {
-        git_tidy_core::cli::resolve_directory(self.directory.clone())
+        git_tidy_core::cli::resolve_directory(self.common.directory.clone())
     }
 }
 
@@ -104,7 +98,7 @@ mod tests {
     fn scan_with_directory() {
         let cli = Cli::parse_from(["git-remote-tidy", "scan", "/tmp/dev"]);
         assert!(matches!(cli.command, Some(Command::Scan { .. })));
-        assert_eq!(cli.directory, Some(PathBuf::from("/tmp/dev")));
+        assert_eq!(cli.common.directory, Some(PathBuf::from("/tmp/dev")));
     }
 
     #[test]
@@ -193,7 +187,13 @@ mod tests {
             "archive",
             "scan",
         ]);
-        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
-        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
+        assert_eq!(
+            cli.repo_filter.match_repo_patterns,
+            vec!["myproject".to_string()]
+        );
+        assert_eq!(
+            cli.repo_filter.exclude_repo_patterns,
+            vec!["archive".to_string()]
+        );
     }
 }

--- a/crates/git-remote-tidy/src/main.rs
+++ b/crates/git-remote-tidy/src/main.rs
@@ -30,7 +30,10 @@ fn main() {
 
     let git = gix_ops::GixGitOps;
     let progress = Progress::new();
-    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let repo_filter = NameFilter::new(
+        &cli.repo_filter.match_repo_patterns,
+        &cli.repo_filter.exclude_repo_patterns,
+    );
     let entity_filter = NameFilter::new(&cli.match_patterns, &cli.exclude_patterns);
     let mut stdout = io::stdout().lock();
 

--- a/crates/git-repo-tidy/src/cli.rs
+++ b/crates/git-repo-tidy/src/cli.rs
@@ -11,9 +11,8 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    /// Directory to scan (default: current directory)
-    #[arg(global = true)]
-    pub directory: Option<PathBuf>,
+    #[command(flatten)]
+    pub common: git_tidy_core::cli::CommonArgs,
 
     /// Show detailed classification reasoning
     #[arg(short, long, global = true)]
@@ -35,13 +34,8 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub no_default_noise: bool,
 
-    /// Filter repos by name substring (can be repeated, OR semantics)
-    #[arg(long = "match-repo", global = true)]
-    pub match_repo_patterns: Vec<String>,
-
-    /// Exclude repos by name substring (takes precedence over --match-repo)
-    #[arg(long = "exclude-repo", global = true)]
-    pub exclude_repo_patterns: Vec<String>,
+    #[command(flatten)]
+    pub repo_filter: git_tidy_core::cli::RepoFilterArgs,
 }
 
 #[derive(Subcommand, Debug)]
@@ -95,7 +89,7 @@ pub enum Command {
 impl Cli {
     /// Resolve the target directory, defaulting to the current directory.
     pub fn target_directory(&self) -> PathBuf {
-        git_tidy_core::cli::resolve_directory(self.directory.clone())
+        git_tidy_core::cli::resolve_directory(self.common.directory.clone())
     }
 
     /// Convert stale_months to days.
@@ -122,7 +116,7 @@ mod tests {
     fn scan_with_directory() {
         let cli = Cli::parse_from(["git-repo-tidy", "scan", "/tmp/dev"]);
         assert!(matches!(cli.command, Some(Command::Scan { .. })));
-        assert_eq!(cli.directory, Some(PathBuf::from("/tmp/dev")));
+        assert_eq!(cli.common.directory, Some(PathBuf::from("/tmp/dev")));
     }
 
     #[test]
@@ -236,7 +230,13 @@ mod tests {
             "archive",
             "scan",
         ]);
-        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
-        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
+        assert_eq!(
+            cli.repo_filter.match_repo_patterns,
+            vec!["myproject".to_string()]
+        );
+        assert_eq!(
+            cli.repo_filter.exclude_repo_patterns,
+            vec!["archive".to_string()]
+        );
     }
 }

--- a/crates/git-repo-tidy/src/main.rs
+++ b/crates/git-repo-tidy/src/main.rs
@@ -46,7 +46,10 @@ fn main() {
     };
     let noise_patterns = noise_config.resolve();
 
-    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let repo_filter = NameFilter::new(
+        &cli.repo_filter.match_repo_patterns,
+        &cli.repo_filter.exclude_repo_patterns,
+    );
 
     let stale_days = cli.stale_threshold_days();
 

--- a/crates/git-stash-tidy/src/cli.rs
+++ b/crates/git-stash-tidy/src/cli.rs
@@ -11,9 +11,8 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    /// Directory to scan (default: current directory)
-    #[arg(global = true)]
-    pub directory: Option<PathBuf>,
+    #[command(flatten)]
+    pub common: git_tidy_core::cli::CommonArgs,
 
     /// Show detailed classification reasoning
     #[arg(short, long, global = true)]
@@ -23,13 +22,8 @@ pub struct Cli {
     #[arg(long, default_value_t = 90, global = true)]
     pub age_threshold: u64,
 
-    /// Filter repos by name substring (can be repeated, OR semantics)
-    #[arg(long = "match-repo", global = true)]
-    pub match_repo_patterns: Vec<String>,
-
-    /// Exclude repos by name substring (takes precedence over --match-repo)
-    #[arg(long = "exclude-repo", global = true)]
-    pub exclude_repo_patterns: Vec<String>,
+    #[command(flatten)]
+    pub repo_filter: git_tidy_core::cli::RepoFilterArgs,
 
     /// Filter stashes by branch name substring (can be repeated, OR semantics)
     #[arg(long = "match", global = true)]
@@ -87,7 +81,7 @@ pub enum Command {
 impl Cli {
     /// Resolve the target directory, defaulting to the current directory.
     pub fn target_directory(&self) -> PathBuf {
-        git_tidy_core::cli::resolve_directory(self.directory.clone())
+        git_tidy_core::cli::resolve_directory(self.common.directory.clone())
     }
 }
 
@@ -107,7 +101,7 @@ mod tests {
     fn scan_with_directory() {
         let cli = Cli::parse_from(["git-stash-tidy", "scan", "/tmp/dev"]);
         assert!(matches!(cli.command, Some(Command::Scan { .. })));
-        assert_eq!(cli.directory, Some(PathBuf::from("/tmp/dev")));
+        assert_eq!(cli.common.directory, Some(PathBuf::from("/tmp/dev")));
     }
 
     #[test]
@@ -219,7 +213,13 @@ mod tests {
             "archive",
             "scan",
         ]);
-        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
-        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
+        assert_eq!(
+            cli.repo_filter.match_repo_patterns,
+            vec!["myproject".to_string()]
+        );
+        assert_eq!(
+            cli.repo_filter.exclude_repo_patterns,
+            vec!["archive".to_string()]
+        );
     }
 }

--- a/crates/git-stash-tidy/src/main.rs
+++ b/crates/git-stash-tidy/src/main.rs
@@ -30,7 +30,10 @@ fn main() {
 
     let git = gix_ops::GixGitOps;
     let progress = Progress::new();
-    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let repo_filter = NameFilter::new(
+        &cli.repo_filter.match_repo_patterns,
+        &cli.repo_filter.exclude_repo_patterns,
+    );
     let entity_filter = NameFilter::new(&cli.match_patterns, &cli.exclude_patterns);
     let mut stdout = io::stdout().lock();
 

--- a/crates/git-tag-tidy/src/cli.rs
+++ b/crates/git-tag-tidy/src/cli.rs
@@ -11,9 +11,8 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    /// Directory to scan (default: current directory)
-    #[arg(global = true)]
-    pub directory: Option<PathBuf>,
+    #[command(flatten)]
+    pub common: git_tidy_core::cli::CommonArgs,
 
     /// Show detailed classification reasoning
     #[arg(short, long, global = true)]
@@ -23,13 +22,8 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub offline: bool,
 
-    /// Filter repos by name substring (can be repeated, OR semantics)
-    #[arg(long = "match-repo", global = true)]
-    pub match_repo_patterns: Vec<String>,
-
-    /// Exclude repos by name substring (takes precedence over --match-repo)
-    #[arg(long = "exclude-repo", global = true)]
-    pub exclude_repo_patterns: Vec<String>,
+    #[command(flatten)]
+    pub repo_filter: git_tidy_core::cli::RepoFilterArgs,
 
     /// Filter tags by name substring (can be repeated, OR semantics)
     #[arg(long = "match", global = true)]
@@ -95,7 +89,7 @@ pub enum Command {
 impl Cli {
     /// Resolve the target directory, defaulting to the current directory.
     pub fn target_directory(&self) -> PathBuf {
-        git_tidy_core::cli::resolve_directory(self.directory.clone())
+        git_tidy_core::cli::resolve_directory(self.common.directory.clone())
     }
 }
 
@@ -116,7 +110,7 @@ mod tests {
     fn scan_with_directory() {
         let cli = Cli::parse_from(["git-tag-tidy", "scan", "/tmp/dev"]);
         assert!(matches!(cli.command, Some(Command::Scan { .. })));
-        assert_eq!(cli.directory, Some(PathBuf::from("/tmp/dev")));
+        assert_eq!(cli.common.directory, Some(PathBuf::from("/tmp/dev")));
     }
 
     #[test]
@@ -231,7 +225,13 @@ mod tests {
             "archive",
             "scan",
         ]);
-        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
-        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
+        assert_eq!(
+            cli.repo_filter.match_repo_patterns,
+            vec!["myproject".to_string()]
+        );
+        assert_eq!(
+            cli.repo_filter.exclude_repo_patterns,
+            vec!["archive".to_string()]
+        );
     }
 }

--- a/crates/git-tag-tidy/src/main.rs
+++ b/crates/git-tag-tidy/src/main.rs
@@ -30,7 +30,10 @@ fn main() {
 
     let git = gix_ops::GixGitOps;
     let progress = Progress::new();
-    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let repo_filter = NameFilter::new(
+        &cli.repo_filter.match_repo_patterns,
+        &cli.repo_filter.exclude_repo_patterns,
+    );
     let entity_filter = NameFilter::new(&cli.match_patterns, &cli.exclude_patterns);
     let mut stdout = io::stdout().lock();
 

--- a/crates/git-tidy-core/src/cli.rs
+++ b/crates/git-tidy-core/src/cli.rs
@@ -2,9 +2,48 @@
 
 use std::path::{Path, PathBuf};
 
-use clap::{CommandFactory, Subcommand};
+use clap::{Args, CommandFactory, Subcommand};
 
 use crate::error::Error;
+
+// The shared `[DIRECTORY]` positional, common to every git-tidy binary.
+//
+// Flatten this into a tool's `Cli` with `#[command(flatten)]` to inherit the
+// directory argument without re-declaring it. The flatten preserves clap's
+// `global = true` semantics, so the directory is accepted both before and
+// after a subcommand.
+//
+// NOTE: this uses a plain `//` comment rather than a `///` doc comment on
+// purpose. clap consumes an `Args` struct's doc comment as the *parent*
+// command's `about`/`long_about` when the struct is flattened at the top
+// level, which would rewrite every binary's `--help` header. The per-field
+// doc comments below still become the flag help text.
+#[derive(Args, Debug)]
+pub struct CommonArgs {
+    /// Directory to scan (default: current directory)
+    #[arg(global = true)]
+    pub directory: Option<PathBuf>,
+}
+
+// The shared repo-name filter flags (`--match-repo` / `--exclude-repo`),
+// common to every scan-shaped git-tidy binary.
+//
+// Flatten this into a tool's `Cli` at the position where the repo filters
+// should appear in `--help`; the surrounding tool-specific flags keep their
+// declaration order. The flags carry `global = true`, so they are accepted
+// after a subcommand.
+//
+// NOTE: plain `//` comment on purpose, for the same reason as `CommonArgs`.
+#[derive(Args, Debug)]
+pub struct RepoFilterArgs {
+    /// Filter repos by name substring (can be repeated, OR semantics)
+    #[arg(long = "match-repo", global = true)]
+    pub match_repo_patterns: Vec<String>,
+
+    /// Exclude repos by name substring (takes precedence over --match-repo)
+    #[arg(long = "exclude-repo", global = true)]
+    pub exclude_repo_patterns: Vec<String>,
+}
 
 /// Shared subcommands available in all git-tidy tools.
 #[derive(Subcommand, Debug)]
@@ -84,6 +123,47 @@ mod tests {
         Scan,
         #[command(flatten)]
         Shared(SharedCommands),
+    }
+
+    #[derive(Parser, Debug)]
+    #[command(name = "filter-tool")]
+    struct FilterCli {
+        #[command(subcommand)]
+        command: Option<TestCommand>,
+
+        #[command(flatten)]
+        common: CommonArgs,
+
+        #[command(flatten)]
+        repo_filter: RepoFilterArgs,
+    }
+
+    #[test]
+    fn common_args_directory_before_subcommand() {
+        let cli = FilterCli::parse_from(["filter-tool", "/tmp/dev"]);
+        assert_eq!(cli.common.directory, Some(PathBuf::from("/tmp/dev")));
+    }
+
+    #[test]
+    fn common_args_directory_after_subcommand() {
+        let cli = FilterCli::parse_from(["filter-tool", "scan", "/tmp/dev"]);
+        assert_eq!(cli.common.directory, Some(PathBuf::from("/tmp/dev")));
+        assert!(matches!(cli.command, Some(TestCommand::Scan)));
+    }
+
+    #[test]
+    fn repo_filter_args_global_after_subcommand() {
+        let cli = FilterCli::parse_from([
+            "filter-tool",
+            "scan",
+            "--match-repo",
+            "myproject",
+            "--exclude-repo",
+            "archive",
+        ]);
+        assert_eq!(cli.repo_filter.match_repo_patterns, vec!["myproject"]);
+        assert_eq!(cli.repo_filter.exclude_repo_patterns, vec!["archive"]);
+        assert!(matches!(cli.command, Some(TestCommand::Scan)));
     }
 
     #[test]

--- a/crates/git-tidy/src/cli.rs
+++ b/crates/git-tidy/src/cli.rs
@@ -29,9 +29,8 @@ Examples:
   git tidy explain partial"
 )]
 pub struct Cli {
-    /// Directory to scan (default: current directory)
-    #[arg(global = true)]
-    pub directory: Option<PathBuf>,
+    #[command(flatten)]
+    pub common: git_tidy_core::cli::CommonArgs,
 
     #[command(subcommand)]
     pub command: Option<Command>,
@@ -75,7 +74,8 @@ pub enum Command {
 impl Cli {
     /// Resolve the target directory, defaulting to the current directory.
     pub fn target_directory(&self) -> PathBuf {
-        self.directory
+        self.common
+            .directory
             .clone()
             .unwrap_or_else(|| std::env::current_dir().expect("cannot determine current directory"))
     }
@@ -91,7 +91,7 @@ mod tests {
     fn default_command_is_none() {
         let cli = Cli::parse_from(["git-tidy"]);
         assert!(cli.command.is_none());
-        assert!(cli.directory.is_none());
+        assert!(cli.common.directory.is_none());
     }
 
     #[test]
@@ -187,14 +187,14 @@ mod tests {
     #[test]
     fn directory_argument() {
         let cli = Cli::parse_from(["git-tidy", "/tmp/dev"]);
-        assert_eq!(cli.directory, Some(PathBuf::from("/tmp/dev")));
+        assert_eq!(cli.common.directory, Some(PathBuf::from("/tmp/dev")));
         assert!(cli.command.is_none());
     }
 
     #[test]
     fn directory_with_audit_subcommand() {
         let cli = Cli::parse_from(["git-tidy", "audit", "--json", "/tmp/dev"]);
-        assert_eq!(cli.directory, Some(PathBuf::from("/tmp/dev")));
+        assert_eq!(cli.common.directory, Some(PathBuf::from("/tmp/dev")));
         assert!(matches!(cli.command, Some(Command::Audit { .. })));
     }
 }

--- a/crates/git-worktree-tidy/src/cli.rs
+++ b/crates/git-worktree-tidy/src/cli.rs
@@ -11,9 +11,8 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    /// Directory to scan (default: current directory)
-    #[arg(global = true)]
-    pub directory: Option<PathBuf>,
+    #[command(flatten)]
+    pub common: git_tidy_core::cli::CommonArgs,
 
     /// Commit count for diverged annotation
     #[arg(long, default_value_t = 100, global = true)]
@@ -39,13 +38,8 @@ pub struct Cli {
     #[arg(long = "exclude", global = true)]
     pub exclude_patterns: Vec<String>,
 
-    /// Filter repos by name substring (can be repeated, OR semantics)
-    #[arg(long = "match-repo", global = true)]
-    pub match_repo_patterns: Vec<String>,
-
-    /// Exclude repos by name substring (takes precedence over --match-repo)
-    #[arg(long = "exclude-repo", global = true)]
-    pub exclude_repo_patterns: Vec<String>,
+    #[command(flatten)]
+    pub repo_filter: git_tidy_core::cli::RepoFilterArgs,
 }
 
 #[derive(Subcommand, Debug)]
@@ -99,7 +93,7 @@ pub enum Command {
 impl Cli {
     /// Resolve the target directory, defaulting to the current directory.
     pub fn target_directory(&self) -> PathBuf {
-        git_tidy_core::cli::resolve_directory(self.directory.clone())
+        git_tidy_core::cli::resolve_directory(self.common.directory.clone())
     }
 }
 
@@ -119,7 +113,7 @@ mod tests {
     fn scan_with_directory() {
         let cli = Cli::parse_from(["git-worktree-tidy", "scan", "/tmp/dev"]);
         assert!(matches!(cli.command, Some(Command::Scan { .. })));
-        assert_eq!(cli.directory, Some(PathBuf::from("/tmp/dev")));
+        assert_eq!(cli.common.directory, Some(PathBuf::from("/tmp/dev")));
     }
 
     #[test]
@@ -322,7 +316,13 @@ mod tests {
             "archive",
             "scan",
         ]);
-        assert_eq!(cli.match_repo_patterns, vec!["myproject".to_string()]);
-        assert_eq!(cli.exclude_repo_patterns, vec!["archive".to_string()]);
+        assert_eq!(
+            cli.repo_filter.match_repo_patterns,
+            vec!["myproject".to_string()]
+        );
+        assert_eq!(
+            cli.repo_filter.exclude_repo_patterns,
+            vec!["archive".to_string()]
+        );
     }
 }

--- a/crates/git-worktree-tidy/src/main.rs
+++ b/crates/git-worktree-tidy/src/main.rs
@@ -43,7 +43,10 @@ fn main() {
     let noise_patterns = noise_config.resolve();
 
     let entity_filter = NameFilter::new(&cli.match_patterns, &cli.exclude_patterns);
-    let repo_filter = NameFilter::new(&cli.match_repo_patterns, &cli.exclude_repo_patterns);
+    let repo_filter = NameFilter::new(
+        &cli.repo_filter.match_repo_patterns,
+        &cli.repo_filter.exclude_repo_patterns,
+    );
 
     let git = gix_ops::GixGitOps;
     let progress = Progress::new();


### PR DESCRIPTION
## Summary

Every binary crate re-declared the same global clap flags by hand. This lifts the byte-stable subset into two flattenable `#[derive(clap::Args)]` structs in `git_tidy_core::cli`:

- `CommonArgs` — the `[DIRECTORY]` positional, flattened into all nine binaries.
- `RepoFilterArgs` — `--match-repo` / `--exclude-repo`, flattened into the eight scan-shaped tools.

Each tool's `Cli` pulls these in via `#[command(flatten)]` at the position that preserves its existing `--help` order, deleting the hand-copied declarations. All read sites (`cli.directory` → `cli.common.directory`, `cli.match_repo_patterns` → `cli.repo_filter.match_repo_patterns`, etc.) were updated.

## What stayed inline (and why)

`verbose` and the entity `--match` / `--exclude` filters were **not** lifted: their help text differs per tool (`verbose` has three distinct strings; the entity filters five — "Filter branches…" vs "Filter stashes by branch name…" vs "Filter worktrees…"), and the entity filters are absent from config/repo entirely. A single shared struct with fixed help could not reproduce these byte-for-byte. Tool-specific flags (`behind-threshold`, `age-threshold`, `offline`, noise patterns, `stale-months`) likewise stay where they are. Only the flags whose help text is byte-identical everywhere were consolidated.

## git-config-tidy

config-tidy has the narrower flag set (no entity `--match`/`--exclude`). It shares the repo-filter subset, so it flattens `CommonArgs` + `RepoFilterArgs` and keeps its unique `verbose` ("Show detailed lint reasoning") inline. Its flag set and `--help` are unchanged.

## --help byte-stability

This is the whole risk of the refactor. `--help` was captured for every binary and every subcommand before and after the change (36 files: 9 binaries + their subcommands). `diff -r` of the two directories is **empty** — output and argument parsing (including global flags after a subcommand) are byte-identical.

One implementation note: the two shared structs use plain `//` comments rather than `///` doc comments. clap consumes an `Args` struct's doc comment as the *parent* command's `about`/`long_about` when flattened at the top level, which would have rewritten every binary's `--help` header and flipped it into long-help mode. Per-field doc comments still supply the flag help text.

## Verification

- `cargo fmt --check` — pass
- `cargo clippy --workspace --all-targets -- -D clippy::all` — pass
- `cargo test --workspace` — pass
- `diff -r /tmp/cli-help-before /tmp/cli-help-after` — empty

Closes #181