### PR TITLE
Fold lfs-tidy and repo-tidy onto shared CleanResult

### DIFF
--- a/crates/git-lfs-tidy/src/clean.rs
+++ b/crates/git-lfs-tidy/src/clean.rs
@@ -1,8 +1,10 @@
 use std::io::Write;
+use std::ops::Deref;
 use std::path::PathBuf;
 
 use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
+use git_tidy_core::types::{CleanResult, FailedItem};
 
 use crate::output::format_bytes;
 use crate::types::{LfsClassification, LfsScanResult};
@@ -15,18 +17,28 @@ pub struct CleanOptions {
     pub prune: bool,
 }
 
-/// Result of a clean operation.
+/// Result of an LFS clean operation: the shared [`CleanResult`] plus the
+/// LFS-specific health recommendations surfaced during the pass.
+///
+/// Derefs to the inner [`CleanResult`] so callers read `succeeded` / `failed` /
+/// `skipped` without going through `.result`.
 #[derive(Debug)]
-#[allow(dead_code)]
-pub struct CleanResult {
-    /// Repos that were pruned (or would be in dry-run).
-    pub pruned: Vec<PrunedRepo>,
-    /// Repos that failed to prune.
-    pub failed: Vec<FailedRepo>,
-    /// Items that were skipped (not actionable).
-    pub skipped: usize,
-    /// Recommendations printed to the user.
+pub struct LfsCleanResult {
+    /// Shared succeeded / failed / skipped aggregation.
+    pub result: CleanResult<PrunedRepo>,
+    /// Recommendations printed to the user (e.g. `git lfs migrate`). Already
+    /// emitted inline during the pass; retained here for tests and future JSON
+    /// output. A candidate to drop once lfs moves onto the shared CleanPipeline.
+    #[allow(dead_code)]
     pub recommendations: Vec<String>,
+}
+
+impl Deref for LfsCleanResult {
+    type Target = CleanResult<PrunedRepo>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.result
+    }
 }
 
 /// A repo whose LFS objects were successfully pruned (or would have been, in dry-run).
@@ -40,21 +52,13 @@ pub struct PrunedRepo {
     pub dry_run: bool,
 }
 
-/// A repo whose LFS prune failed.
-#[derive(Debug)]
-#[allow(dead_code)]
-pub struct FailedRepo {
-    pub repo: PathBuf,
-    pub reason: String,
-}
-
 /// Run the clean operation on a scan result.
 pub fn run_clean(
     git: &dyn GitOps,
     scan_result: &LfsScanResult,
     options: &CleanOptions,
     out: &mut dyn Write,
-) -> Result<CleanResult, Error> {
+) -> Result<LfsCleanResult, Error> {
     let mut pruned = Vec::new();
     let mut failed = Vec::new();
     let mut skipped = 0;
@@ -112,8 +116,9 @@ pub fn run_clean(
                                     "error: could not prune LFS objects in {}: {e}",
                                     group.name,
                                 )?;
-                                failed.push(FailedRepo {
+                                failed.push(FailedItem {
                                     repo: group.repo_path.clone(),
+                                    name: group.name.clone(),
                                     reason: e.to_string(),
                                 });
                             }
@@ -152,10 +157,12 @@ pub fn run_clean(
         }
     }
 
-    Ok(CleanResult {
-        pruned,
-        failed,
-        skipped,
+    Ok(LfsCleanResult {
+        result: CleanResult {
+            succeeded: pruned,
+            failed,
+            skipped,
+        },
         recommendations,
     })
 }
@@ -218,9 +225,9 @@ mod tests {
 
         let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
 
-        assert_eq!(result.pruned.len(), 1);
-        assert_eq!(result.pruned[0].objects_pruned, 3);
-        assert_eq!(result.pruned[0].bytes_freed, 2_500_000);
+        assert_eq!(result.succeeded.len(), 1);
+        assert_eq!(result.succeeded[0].objects_pruned, 3);
+        assert_eq!(result.succeeded[0].bytes_freed, 2_500_000);
         assert_eq!(git.lfs_prune_calls().len(), 1);
 
         let output = String::from_utf8(buf).unwrap();
@@ -245,11 +252,11 @@ mod tests {
 
         let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
 
-        assert_eq!(result.pruned.len(), 1);
+        assert_eq!(result.succeeded.len(), 1);
         assert_eq!(git.lfs_prune_calls().len(), 0);
         // Regression: dry-run entries must be distinguishable from real prunes so downstream JSON consumers can filter them out.
         assert!(
-            result.pruned[0].dry_run,
+            result.succeeded[0].dry_run,
             "dry-run PrunedRepo must have dry_run=true",
         );
 
@@ -274,8 +281,8 @@ mod tests {
         };
 
         let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
-        assert_eq!(result.pruned.len(), 1);
-        assert!(!result.pruned[0].dry_run);
+        assert_eq!(result.succeeded.len(), 1);
+        assert!(!result.succeeded[0].dry_run);
         assert_eq!(git.lfs_prune_calls().len(), 1);
     }
 
@@ -293,7 +300,7 @@ mod tests {
 
         let result = run_clean(&git, &scan, &default_options(), &mut buf).unwrap();
 
-        assert_eq!(result.pruned.len(), 0);
+        assert_eq!(result.succeeded.len(), 0);
         assert_eq!(result.skipped, 1);
         assert_eq!(git.lfs_prune_calls().len(), 0);
     }
@@ -316,7 +323,7 @@ mod tests {
 
         let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
 
-        assert_eq!(result.pruned.len(), 0);
+        assert_eq!(result.succeeded.len(), 0);
         assert_eq!(result.skipped, 1);
         assert_eq!(git.lfs_prune_calls().len(), 0);
 
@@ -346,7 +353,7 @@ mod tests {
 
         let result = run_clean(&git, &scan, &options, &mut buf).unwrap();
 
-        assert_eq!(result.pruned.len(), 0);
+        assert_eq!(result.succeeded.len(), 0);
         assert_eq!(result.failed.len(), 1);
 
         let output = String::from_utf8(buf).unwrap();
@@ -385,7 +392,7 @@ mod tests {
 
         let result = run_clean(&git, &scan, &default_options(), &mut buf).unwrap();
 
-        assert_eq!(result.pruned.len(), 0);
+        assert_eq!(result.succeeded.len(), 0);
         assert_eq!(result.skipped, 1);
         assert_eq!(result.recommendations.len(), 0);
     }

--- a/crates/git-lfs-tidy/tests/integration_clean.rs
+++ b/crates/git-lfs-tidy/tests/integration_clean.rs
@@ -3,13 +3,13 @@ mod common;
 use common::{git, set_up_repo};
 use git_tidy_core::git::RealGit;
 
-use git_lfs_tidy::clean::{CleanOptions, CleanResult};
+use git_lfs_tidy::clean::{CleanOptions, LfsCleanResult};
 use git_lfs_tidy::types::LfsClassification;
 
 fn run_scan_and_clean(
     scan_dir: &std::path::Path,
     options: &CleanOptions,
-) -> (git_lfs_tidy::types::LfsScanResult, CleanResult) {
+) -> (git_lfs_tidy::types::LfsScanResult, LfsCleanResult) {
     let git_ops = RealGit;
     let scan_result = git_lfs_tidy::scan::run_scan(
         &git_ops,
@@ -54,7 +54,7 @@ fn clean_dry_run_with_untracked_blobs() {
             .any(|i| i.classification == LfsClassification::Untracked),
         "expected untracked items"
     );
-    assert_eq!(clean_result.pruned.len(), 0);
+    assert_eq!(clean_result.succeeded.len(), 0);
     assert!(
         clean_result
             .recommendations
@@ -82,6 +82,6 @@ fn clean_with_no_orphaned_is_noop() {
     let (_scan_result, clean_result) = run_scan_and_clean(&scan_dir, &options);
 
     // No LFS objects to prune, so nothing pruned
-    assert_eq!(clean_result.pruned.len(), 0);
+    assert_eq!(clean_result.succeeded.len(), 0);
     assert_eq!(clean_result.failed.len(), 0);
 }

--- a/crates/git-repo-tidy/src/clean.rs
+++ b/crates/git-repo-tidy/src/clean.rs
@@ -1,8 +1,10 @@
 use std::io;
 use std::io::Write;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
 use git_tidy_core::error::Error;
+use git_tidy_core::types::{CleanResult, FailedItem};
 
 use crate::types::{RepoClassification, RepoScanResult};
 
@@ -21,18 +23,25 @@ pub struct CleanOptions {
     pub all: bool,
 }
 
-/// Result of a clean operation.
+/// Result of a repo clean operation: the shared [`CleanResult`] plus the
+/// repo-specific `dirty_blocked` flag that drives the dirty-blocked exit code.
+///
+/// Derefs to the inner [`CleanResult`] so callers read `succeeded` / `failed` /
+/// `skipped` without going through `.result`.
 #[derive(Debug)]
-#[allow(dead_code)]
-pub struct CleanResult {
-    /// Repos that were deleted (or would be in dry-run).
-    pub deleted: Vec<DeletedRepo>,
-    /// Repos that failed to delete.
-    pub failed: Vec<FailedRepo>,
-    /// Repos that were skipped.
-    pub skipped: usize,
-    /// Whether any dirty repos blocked deletion.
+pub struct RepoCleanResult {
+    /// Shared succeeded / failed / skipped aggregation.
+    pub result: CleanResult<DeletedRepo>,
+    /// Whether any dirty repos blocked deletion (drives exit code 2).
     pub dirty_blocked: bool,
+}
+
+impl Deref for RepoCleanResult {
+    type Target = CleanResult<DeletedRepo>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.result
+    }
 }
 
 /// A repo that was successfully deleted.
@@ -41,15 +50,6 @@ pub struct CleanResult {
 pub struct DeletedRepo {
     pub path: PathBuf,
     pub name: String,
-}
-
-/// A repo that failed to be deleted.
-#[derive(Debug)]
-#[allow(dead_code)]
-pub struct FailedRepo {
-    pub path: PathBuf,
-    pub name: String,
-    pub reason: String,
 }
 
 /// Determine if a repo should be cleaned based on its classification and options.
@@ -70,7 +70,7 @@ pub fn run_clean(
     options: &CleanOptions,
     delete_fn: &dyn Fn(&Path) -> io::Result<()>,
     out: &mut dyn Write,
-) -> Result<CleanResult, Error> {
+) -> Result<RepoCleanResult, Error> {
     let mut deleted = Vec::new();
     let mut failed = Vec::new();
     let mut skipped = 0;
@@ -113,8 +113,8 @@ pub fn run_clean(
             }
             Err(e) => {
                 writeln!(out, "error: could not delete {}: {e}", repo.name)?;
-                failed.push(FailedRepo {
-                    path: repo.path.clone(),
+                failed.push(FailedItem {
+                    repo: repo.path.clone(),
                     name: repo.name.clone(),
                     reason: e.to_string(),
                 });
@@ -122,10 +122,12 @@ pub fn run_clean(
         }
     }
 
-    Ok(CleanResult {
-        deleted,
-        failed,
-        skipped,
+    Ok(RepoCleanResult {
+        result: CleanResult {
+            succeeded: deleted,
+            failed,
+            skipped,
+        },
         dirty_blocked,
     })
 }
@@ -211,8 +213,8 @@ mod tests {
 
         let result = run_clean(&scan, &default_options(), &delete_fn, &mut buf).unwrap();
 
-        assert_eq!(result.deleted.len(), 1);
-        assert_eq!(result.deleted[0].name, "old");
+        assert_eq!(result.succeeded.len(), 1);
+        assert_eq!(result.succeeded[0].name, "old");
         assert_eq!(deleted_paths.borrow().len(), 1);
     }
 
@@ -227,8 +229,8 @@ mod tests {
 
         let result = run_clean(&scan, &default_options(), &noop_delete, &mut buf).unwrap();
 
-        assert_eq!(result.deleted.len(), 1);
-        assert_eq!(result.deleted[0].name, "orphan");
+        assert_eq!(result.succeeded.len(), 1);
+        assert_eq!(result.succeeded[0].name, "orphan");
     }
 
     #[test]
@@ -238,7 +240,7 @@ mod tests {
 
         let result = run_clean(&scan, &default_options(), &noop_delete, &mut buf).unwrap();
 
-        assert_eq!(result.deleted.len(), 0);
+        assert_eq!(result.succeeded.len(), 0);
         assert_eq!(result.skipped, 1);
     }
 
@@ -249,7 +251,7 @@ mod tests {
 
         let result = run_clean(&scan, &default_options(), &noop_delete, &mut buf).unwrap();
 
-        assert_eq!(result.deleted.len(), 0);
+        assert_eq!(result.succeeded.len(), 0);
         assert_eq!(result.skipped, 1);
         assert!(result.dirty_blocked);
 
@@ -269,7 +271,7 @@ mod tests {
 
         let result = run_clean(&scan, &options, &noop_delete, &mut buf).unwrap();
 
-        assert_eq!(result.deleted.len(), 1);
+        assert_eq!(result.succeeded.len(), 1);
         assert!(!result.dirty_blocked);
     }
 
@@ -287,8 +289,8 @@ mod tests {
 
         let result = run_clean(&scan, &options, &noop_delete, &mut buf).unwrap();
 
-        assert_eq!(result.deleted.len(), 1);
-        assert_eq!(result.deleted[0].name, "old");
+        assert_eq!(result.succeeded.len(), 1);
+        assert_eq!(result.succeeded[0].name, "old");
         assert_eq!(result.skipped, 1);
     }
 
@@ -306,8 +308,8 @@ mod tests {
 
         let result = run_clean(&scan, &options, &noop_delete, &mut buf).unwrap();
 
-        assert_eq!(result.deleted.len(), 1);
-        assert_eq!(result.deleted[0].name, "orphan");
+        assert_eq!(result.succeeded.len(), 1);
+        assert_eq!(result.succeeded[0].name, "orphan");
         assert_eq!(result.skipped, 1);
     }
 
@@ -330,7 +332,7 @@ mod tests {
 
         let result = run_clean(&scan, &options, &delete_fn, &mut buf).unwrap();
 
-        assert_eq!(result.deleted.len(), 2);
+        assert_eq!(result.succeeded.len(), 2);
         // Dry run: no actual deletes
         assert_eq!(deleted_paths.borrow().len(), 0);
 
@@ -346,7 +348,7 @@ mod tests {
 
         let result = run_clean(&scan, &default_options(), &failing_delete, &mut buf).unwrap();
 
-        assert_eq!(result.deleted.len(), 0);
+        assert_eq!(result.succeeded.len(), 0);
         assert_eq!(result.failed.len(), 1);
         assert_eq!(result.failed[0].name, "old");
 
@@ -367,7 +369,7 @@ mod tests {
         let result = run_clean(&scan, &default_options(), &noop_delete, &mut buf).unwrap();
 
         // stale-clean + orphan-clean deleted; stale-dirty skipped (dirty); active skipped
-        assert_eq!(result.deleted.len(), 2);
+        assert_eq!(result.succeeded.len(), 2);
         assert_eq!(result.skipped, 2);
         assert!(result.dirty_blocked);
     }

--- a/crates/git-repo-tidy/tests/integration_clean.rs
+++ b/crates/git-repo-tidy/tests/integration_clean.rs
@@ -60,7 +60,7 @@ fn clean_removes_orphaned_repo() {
 
     let result = run_clean(&scan_result, &default_options(), &delete_fn, &mut buf).unwrap();
 
-    assert_eq!(result.deleted.len(), 1);
+    assert_eq!(result.succeeded.len(), 1);
     assert!(!repo.exists(), "repo should have been deleted");
 }
 
@@ -93,7 +93,7 @@ fn clean_dry_run_preserves_repo() {
 
     let result = run_clean(&scan_result, &options, &delete_fn, &mut buf).unwrap();
 
-    assert_eq!(result.deleted.len(), 1); // reported as "would delete"
+    assert_eq!(result.succeeded.len(), 1); // reported as "would delete"
     assert!(repo.exists(), "repo should still exist after dry-run");
 
     let output = String::from_utf8(buf).unwrap();
@@ -128,7 +128,7 @@ fn clean_skips_dirty_repo() {
 
     let result = run_clean(&scan_result, &default_options(), &delete_fn, &mut buf).unwrap();
 
-    assert_eq!(result.deleted.len(), 0);
+    assert_eq!(result.succeeded.len(), 0);
     assert!(result.dirty_blocked);
     assert!(repo.exists(), "dirty repo should not be deleted");
 }
@@ -165,6 +165,6 @@ fn clean_force_deletes_dirty_repo() {
 
     let result = run_clean(&scan_result, &options, &delete_fn, &mut buf).unwrap();
 
-    assert_eq!(result.deleted.len(), 1);
+    assert_eq!(result.succeeded.len(), 1);
     assert!(!repo.exists(), "dirty repo should be deleted with --force");
 }


### PR DESCRIPTION
## What

`git-lfs-tidy` and `git-repo-tidy` were the last two tools carrying private, non-generic `CleanResult` and `FailedRepo` types. This replaces them with the shared `git_tidy_core::types::CleanResult<S>` / `FailedItem` that the other five tools already use.

Each tool keeps the one genuinely tool-specific aggregate field that the shared 3-field `CleanResult` cannot hold:

- repo-tidy's `dirty_blocked` (drives exit code 2)
- lfs-tidy's `recommendations`

Rather than pollute the shared type with fields five tools ignore, each tool wraps the shared result in a thin `RepoCleanResult` / `LfsCleanResult` that embeds `CleanResult<S>` plus its extra field, and `Deref`s to it so call sites read `succeeded` / `failed` / `skipped` directly. Both `main.rs` files are unchanged.

## Why

This is step 1 of #118 (collapse the clean pipeline into one loop). The `CleanPipeline` extraction needs every tool on one result type at the seam; these two were the holdouts. Landing the type unification first keeps that future diff reviewable.

## Behavior

No behavior change: the same items are deleted/pruned, the same messages are printed, and the same exit codes are produced. The change is type-shape only, so it adds a few net lines now (the wrappers) — the LOC reduction lands later when the loop skeleton moves into core.

## Verification

Local run of the full CI matrix (`.github/workflows/ci.yml`):

- `cargo fmt --check` ✓
- `cargo clippy --workspace --all-targets -- -D clippy::all` ✓
- `cargo test --workspace` ✓ (0 failures)

## Notes

- lfs-tidy's `recommendations` is `#[allow(dead_code)]` (read only by tests; already printed inline during the pass). Flagged in a comment as a removal candidate once lfs moves onto the `CleanPipeline`.
- Independent of the now-merged #184 (which unified branch/tag *ref-deletion* records); this touches repo/lfs result *aggregates*.

Refs #118