### PR TITLE
Reuse core::date::format_iso_date in repo-tidy today_iso test helper

### DIFF
--- a/crates/git-repo-tidy/src/scan.rs
+++ b/crates/git-repo-tidy/src/scan.rs
@@ -264,24 +264,16 @@ mod tests {
     }
 
     fn today_iso() -> String {
-        // Use a date that's definitely today
-        let now = std::time::SystemTime::now()
+        // A date that's definitely today, at noon UTC.
+        let days = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
-            .as_secs();
-        let days = now / 86400;
-        // civil_from_days equivalent (simplified)
-        let z = days as i64 + 719468;
-        let era = if z >= 0 { z } else { z - 146096 } / 146097;
-        let doe = z - era * 146097;
-        let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-        let y = yoe + era * 400;
-        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-        let mp = (5 * doy + 2) / 153;
-        let d = doy - (153 * mp + 2) / 5 + 1;
-        let m = if mp < 10 { mp + 3 } else { mp - 9 };
-        let y = if m <= 2 { y + 1 } else { y };
-        format!("{y:04}-{m:02}-{d:02}T12:00:00+00:00")
+            .as_secs()
+            / 86400;
+        format!(
+            "{}T12:00:00+00:00",
+            git_tidy_core::date::format_iso_date(days as i64)
+        )
     }
 
     fn old_iso() -> String {


### PR DESCRIPTION
## Summary

Removes the **third and last** hand-rolled copy of core's Hinnant civil-from-days arithmetic in the workspace. The `#[cfg(test)]` `today_iso()` helper in `git-repo-tidy` re-implemented the calendar conversion line-for-line — its own comment called it a "civil_from_days equivalent (simplified)". #180/#186 centralized that algorithm as `git_tidy_core::date::format_iso_date` and removed the stash-tidy copy; this finishes the job for the repo-tidy test helper.

## Change

`today_iso()` now derives epoch-days from `SystemTime::now()`, defers the `YYYY-MM-DD` conversion to `format_iso_date`, and re-appends the test-specific `T12:00:00+00:00` suffix:

```rust
fn today_iso() -> String {
    let days = std::time::SystemTime::now()
        .duration_since(std::time::UNIX_EPOCH)
        .unwrap()
        .as_secs()
        / 86400;
    format!(
        "{}T12:00:00+00:00",
        git_tidy_core::date::format_iso_date(days as i64)
    )
}
```

`git-repo-tidy` already depends on `git-tidy-core` and `format_iso_date` is a plain `pub fn`, so no `Cargo.toml`/feature changes are needed. The adjacent `old_iso()` helper is a hardcoded constant, not a duplicate — left untouched.

## Why it's safe

Test-only; no production behavior. The deleted inline arithmetic is byte-identical to `core::date::civil_from_days`, so the strings `today_iso()` produces are unchanged and the ~12 scan/clean tests that use it as `last_commit_date` pass with no edits.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D clippy::all` — clean
- `cargo test --workspace` — all green

Closes #191