### PR TITLE
Replace per-tool counts structs with a generic Counts map

### DIFF
--- a/crates/git-branch-tidy/src/clean.rs
+++ b/crates/git-branch-tidy/src/clean.rs
@@ -195,8 +195,9 @@ fn derive_remote_name(git: &dyn GitOps, repo: &std::path::Path, branch: &str) ->
 mod tests {
     use std::path::PathBuf;
 
+    use git_tidy_core::counts::Counts;
     use git_tidy_core::testutil::MockGitBuilder;
-    use git_tidy_core::types::ScanCounts;
+    use git_tidy_core::types::ClassificationLabel;
 
     use super::*;
     use crate::types::{BranchInfo, BranchRepoGroup, BranchScanResult};
@@ -206,9 +207,9 @@ mod tests {
     }
 
     fn make_scan_result(branches: Vec<BranchInfo>) -> BranchScanResult {
-        let mut counts = ScanCounts::default();
+        let mut counts = Counts::default();
         for b in &branches {
-            counts.increment(&b.classification);
+            counts.increment(b.classification.label());
         }
         BranchScanResult {
             repos: vec![BranchRepoGroup {

--- a/crates/git-branch-tidy/src/output.rs
+++ b/crates/git-branch-tidy/src/output.rs
@@ -103,7 +103,13 @@ pub fn write_human(out: &mut dyn Write, result: &BranchScanResult) -> std::io::R
         shared::format_table(out, &group.branches)?;
     }
 
-    shared::write_summary_line(out, result.total_scanned, &result.counts, "branches")?;
+    shared::write_summary_line(
+        out,
+        result.total_scanned,
+        &result.counts,
+        "branches",
+        shared::LANDED_SUMMARY,
+    )?;
     shared::write_explain_hint(out)?;
 
     Ok(())

--- a/crates/git-branch-tidy/src/output.rs
+++ b/crates/git-branch-tidy/src/output.rs
@@ -128,6 +128,7 @@ mod tests {
 
     use super::*;
     use crate::types::*;
+    use git_tidy_core::counts::Counts;
     use git_tidy_core::types::*;
 
     fn make_scan_result() -> BranchScanResult {
@@ -165,11 +166,7 @@ mod tests {
                 ],
             }],
             total_scanned: 2,
-            counts: ScanCounts {
-                landed: 1,
-                active: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("landed", 1), ("active", 1)]),
             warnings: vec![],
         }
     }
@@ -247,10 +244,7 @@ mod tests {
                 }],
             }],
             total_scanned: 1,
-            counts: ScanCounts {
-                partial: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("partial", 1)]),
             warnings: vec![],
         };
 
@@ -324,10 +318,7 @@ mod tests {
                 }],
             }],
             total_scanned: 1,
-            counts: ScanCounts {
-                landed: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("landed", 1)]),
             warnings: vec![],
         };
 
@@ -359,10 +350,7 @@ mod tests {
                 }],
             }],
             total_scanned: 1,
-            counts: ScanCounts {
-                landed: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("landed", 1)]),
             warnings: vec![],
         };
 
@@ -394,10 +382,7 @@ mod tests {
                 }],
             }],
             total_scanned: 1,
-            counts: ScanCounts {
-                landed: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("landed", 1)]),
             warnings: vec![],
         };
 
@@ -414,7 +399,7 @@ mod tests {
         let result = BranchScanResult {
             repos: vec![],
             total_scanned: 0,
-            counts: ScanCounts::default(),
+            counts: Counts::default(),
             warnings: vec!["could not determine default branch for /repo/Foo".to_string()],
         };
 

--- a/crates/git-branch-tidy/src/scan.rs
+++ b/crates/git-branch-tidy/src/scan.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use rayon::prelude::*;
 
 use git_tidy_core::classification;
+use git_tidy_core::counts::Counts;
 use git_tidy_core::error::Error;
 use git_tidy_core::filter::{NameFilter, filter_paths};
 use git_tidy_core::git::GitOps;
@@ -11,7 +12,7 @@ use git_tidy_core::landed::{LandedCache, LandedOptions};
 use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
 use git_tidy_core::scan::parallel_classify;
-use git_tidy_core::types::{ClassificationLabel, ScanCounts};
+use git_tidy_core::types::ClassificationLabel;
 
 use crate::discovery;
 use crate::types::{BranchInfo, BranchRepoGroup, BranchScanResult};
@@ -283,11 +284,11 @@ pub fn run_scan_repos(
     );
     warnings.extend(scan_warnings);
 
-    let mut counts = ScanCounts::default();
+    let mut counts = Counts::default();
     let mut total_scanned = 0;
     for g in &repos {
         for b in &g.branches {
-            counts.increment(&b.classification);
+            counts.increment(b.classification.label());
         }
         total_scanned += g.branches.len();
     }
@@ -449,7 +450,7 @@ mod tests {
         let filter = NameFilter::default();
         let result = run_scan_repos(&git, &[repo()], 100, false, &filter, false, &p).unwrap();
         assert_eq!(result.total_scanned, 1);
-        assert_eq!(result.counts.landed, 1);
+        assert_eq!(result.counts.get("landed"), 1);
     }
 
     #[test]
@@ -516,7 +517,7 @@ mod tests {
         let filter = NameFilter::default();
         let result = run_scan_repos(&git, &[repo()], 100, false, &filter, true, &p).unwrap();
         assert_eq!(result.total_scanned, 1);
-        assert_eq!(result.counts.landed, 1);
+        assert_eq!(result.counts.get("landed"), 1);
         let branch = &result.repos[0].branches[0];
         assert_eq!(branch.name, "feature/remote-only");
         assert!(branch.remote_only);

--- a/crates/git-branch-tidy/src/types.rs
+++ b/crates/git-branch-tidy/src/types.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
+use git_tidy_core::counts::Counts;
 use git_tidy_core::types::{
-    Classification, ClassificationLabel, ScanCounts, UnmatchedCommit, extract_landed_fields,
+    Classification, ClassificationLabel, UnmatchedCommit, extract_landed_fields,
 };
 use serde::Serialize;
 
@@ -51,7 +52,7 @@ pub struct BranchScanResult {
     /// Total branches scanned (excluding default branches).
     pub total_scanned: usize,
     /// Summary counts by classification.
-    pub counts: ScanCounts,
+    pub counts: Counts,
     /// Warnings encountered during scanning.
     pub warnings: Vec<String>,
 }

--- a/crates/git-branch-tidy/tests/integration_scan.rs
+++ b/crates/git-branch-tidy/tests/integration_scan.rs
@@ -61,8 +61,8 @@ fn scan_real_repo_with_mixed_branches() {
 
     // Counts
     assert_eq!(result.total_scanned, 2);
-    assert_eq!(result.counts.landed, 1);
-    assert_eq!(result.counts.local, 1);
+    assert_eq!(result.counts.get("landed"), 1);
+    assert_eq!(result.counts.get("local"), 1);
 }
 
 #[test]

--- a/crates/git-config-tidy/src/fix.rs
+++ b/crates/git-config-tidy/src/fix.rs
@@ -124,15 +124,16 @@ mod tests {
 
     use super::*;
     use crate::types::*;
+    use git_tidy_core::counts::Counts;
 
     fn repo() -> PathBuf {
         PathBuf::from("/repo")
     }
 
     fn make_lint_result(issues: Vec<ConfigIssue>) -> ConfigLintResult {
-        let mut counts = IssueCounts::default();
+        let mut counts = Counts::default();
         for issue in &issues {
-            counts.increment(issue.kind);
+            counts.increment(issue.kind.label());
         }
         ConfigLintResult {
             repos: vec![ConfigRepoGroup {

--- a/crates/git-config-tidy/src/lint.rs
+++ b/crates/git-config-tidy/src/lint.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use git_tidy_core::counts::Counts;
 use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
 use git_tidy_core::filter::{NameFilter, filter_paths};
@@ -10,8 +11,7 @@ use git_tidy_core::progress::Progress;
 use git_tidy_core::scan::parallel_classify;
 
 use crate::types::{
-    ConfigIssue, ConfigLintResult, ConfigRepoGroup, IssueCounts, IssueKind,
-    parse_branch_from_config_key,
+    ConfigIssue, ConfigLintResult, ConfigRepoGroup, IssueKind, parse_branch_from_config_key,
 };
 
 /// Lint a single repo for config issues.
@@ -150,10 +150,10 @@ pub fn run_lint_repos(
     );
     warnings.extend(scan_warnings);
 
-    let mut counts = IssueCounts::default();
+    let mut counts = Counts::default();
     for g in &repos {
         for issue in &g.issues {
-            counts.increment(issue.kind);
+            counts.increment(issue.kind.label());
         }
     }
 
@@ -323,7 +323,7 @@ mod tests {
         let p = Progress::disabled();
         let result = run_lint_repos(&git, &[repo()], false, &p).unwrap();
         assert_eq!(result.total_scanned, 1);
-        assert_eq!(result.counts.orphaned_branch_config, 1);
+        assert_eq!(result.counts.get("orphaned_branch_config"), 1);
     }
 
     #[test]

--- a/crates/git-config-tidy/src/output.rs
+++ b/crates/git-config-tidy/src/output.rs
@@ -89,7 +89,9 @@ fn write_lint_summary(out: &mut dyn Write, result: &ConfigLintResult) -> std::io
     writeln!(
         out,
         "\n{} repos scanned: {} orphaned branch config, {} alias shadows builtin",
-        result.total_scanned, c.orphaned_branch_config, c.alias_shadows_builtin,
+        result.total_scanned,
+        c.get("orphaned_branch_config"),
+        c.get("alias_shadows_builtin"),
     )
 }
 
@@ -130,6 +132,7 @@ mod tests {
 
     use super::*;
     use crate::types::*;
+    use git_tidy_core::counts::Counts;
 
     fn make_lint_result() -> ConfigLintResult {
         ConfigLintResult {
@@ -158,10 +161,10 @@ mod tests {
                 ],
             }],
             total_scanned: 3,
-            counts: IssueCounts {
-                orphaned_branch_config: 1,
-                alias_shadows_builtin: 1,
-            },
+            counts: Counts::from_pairs(&[
+                ("orphaned_branch_config", 1),
+                ("alias_shadows_builtin", 1),
+            ]),
             warnings: vec![],
         }
     }
@@ -195,7 +198,7 @@ mod tests {
         let result = ConfigLintResult {
             repos: vec![],
             total_scanned: 0,
-            counts: IssueCounts::default(),
+            counts: Counts::default(),
             warnings: vec!["could not read config for /repo/bad".to_string()],
         };
 
@@ -223,10 +226,7 @@ mod tests {
                 }],
             }],
             total_scanned: 1,
-            counts: IssueCounts {
-                orphaned_branch_config: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("orphaned_branch_config", 1)]),
             warnings: vec![],
         };
 

--- a/crates/git-config-tidy/src/output.rs
+++ b/crates/git-config-tidy/src/output.rs
@@ -83,15 +83,20 @@ pub fn write_human(out: &mut dyn Write, result: &ConfigLintResult) -> std::io::R
     Ok(())
 }
 
+/// Ordered `(display, count key)` pairs for the config lint summary breakdown.
+const CONFIG_SUMMARY: &[(&str, &str)] = &[
+    ("orphaned branch config", "orphaned_branch_config"),
+    ("alias shadows builtin", "alias_shadows_builtin"),
+];
+
 /// Write the lint-specific summary line.
 fn write_lint_summary(out: &mut dyn Write, result: &ConfigLintResult) -> std::io::Result<()> {
-    let c = &result.counts;
-    writeln!(
+    shared::write_summary_line(
         out,
-        "\n{} repos scanned: {} orphaned branch config, {} alias shadows builtin",
         result.total_scanned,
-        c.get("orphaned_branch_config"),
-        c.get("alias_shadows_builtin"),
+        &result.counts,
+        "repos",
+        CONFIG_SUMMARY,
     )
 }
 

--- a/crates/git-config-tidy/src/types.rs
+++ b/crates/git-config-tidy/src/types.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use git_tidy_core::counts::Counts;
 use serde::Serialize;
 
 /// Severity of a config issue.
@@ -89,27 +90,6 @@ pub struct ConfigRepoGroup {
     pub issues: Vec<ConfigIssue>,
 }
 
-/// Summary counts by issue kind.
-#[derive(Debug, Clone, Default, Serialize)]
-pub struct IssueCounts {
-    pub orphaned_branch_config: usize,
-    pub alias_shadows_builtin: usize,
-}
-
-impl IssueCounts {
-    pub fn increment(&mut self, kind: IssueKind) {
-        match kind {
-            IssueKind::OrphanedBranchConfig => self.orphaned_branch_config += 1,
-            IssueKind::AliasShadowsBuiltin => self.alias_shadows_builtin += 1,
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn total(&self) -> usize {
-        self.orphaned_branch_config + self.alias_shadows_builtin
-    }
-}
-
 /// Result of a full config lint.
 #[derive(Debug, Clone, Serialize)]
 pub struct ConfigLintResult {
@@ -118,7 +98,7 @@ pub struct ConfigLintResult {
     /// Total repos scanned.
     pub total_scanned: usize,
     /// Summary counts by kind.
-    pub counts: IssueCounts,
+    pub counts: Counts,
     /// Warnings encountered during scanning.
     pub warnings: Vec<String>,
 }
@@ -201,12 +181,17 @@ mod tests {
 
     #[test]
     fn counts_increment_and_total() {
-        let mut counts = IssueCounts::default();
-        counts.increment(IssueKind::OrphanedBranchConfig);
-        counts.increment(IssueKind::OrphanedBranchConfig);
-        counts.increment(IssueKind::AliasShadowsBuiltin);
-        assert_eq!(counts.orphaned_branch_config, 2);
-        assert_eq!(counts.alias_shadows_builtin, 1);
+        // Also guards against label drift: increments via `kind.label()`.
+        let mut counts = Counts::default();
+        for k in [
+            IssueKind::OrphanedBranchConfig,
+            IssueKind::OrphanedBranchConfig,
+            IssueKind::AliasShadowsBuiltin,
+        ] {
+            counts.increment(k.label());
+        }
+        assert_eq!(counts.get("orphaned_branch_config"), 2);
+        assert_eq!(counts.get("alias_shadows_builtin"), 1);
         assert_eq!(counts.total(), 3);
     }
 

--- a/crates/git-config-tidy/tests/integration_fix.rs
+++ b/crates/git-config-tidy/tests/integration_fix.rs
@@ -83,10 +83,7 @@ fn fix_removes_orphaned_config() {
             issues,
         }],
         total_scanned: 1,
-        counts: git_config_tidy::types::IssueCounts {
-            orphaned_branch_config: 1,
-            ..Default::default()
-        },
+        counts: git_tidy_core::counts::Counts::from_pairs(&[("orphaned_branch_config", 1)]),
         warnings: vec![],
     };
 
@@ -120,10 +117,7 @@ fn fix_dry_run_preserves_config() {
             issues,
         }],
         total_scanned: 1,
-        counts: git_config_tidy::types::IssueCounts {
-            orphaned_branch_config: 1,
-            ..Default::default()
-        },
+        counts: git_tidy_core::counts::Counts::from_pairs(&[("orphaned_branch_config", 1)]),
         warnings: vec![],
     };
 

--- a/crates/git-lfs-tidy/src/clean.rs
+++ b/crates/git-lfs-tidy/src/clean.rs
@@ -171,6 +171,7 @@ pub fn run_clean(
 mod tests {
     use std::path::PathBuf;
 
+    use git_tidy_core::counts::Counts;
     use git_tidy_core::testutil::MockGitBuilder;
 
     use super::*;
@@ -181,9 +182,9 @@ mod tests {
     }
 
     fn make_scan_result(items: Vec<LfsInfo>) -> LfsScanResult {
-        let mut counts = LfsCounts::default();
+        let mut counts = Counts::default();
         for item in &items {
-            counts.increment(item.classification);
+            counts.increment(item.classification.label());
         }
         LfsScanResult {
             repos: vec![LfsRepoGroup {

--- a/crates/git-lfs-tidy/src/output.rs
+++ b/crates/git-lfs-tidy/src/output.rs
@@ -108,17 +108,22 @@ pub fn write_human(out: &mut dyn Write, result: &LfsScanResult) -> std::io::Resu
     Ok(())
 }
 
+/// Ordered `(display, count key)` pairs for the LFS summary breakdown.
+const LFS_SUMMARY: &[(&str, &str)] = &[
+    ("untracked", "untracked"),
+    ("missing", "missing"),
+    ("orphaned", "orphaned"),
+    ("healthy", "healthy"),
+];
+
 /// Write the LFS-specific summary line.
 fn write_lfs_summary(out: &mut dyn Write, result: &LfsScanResult) -> std::io::Result<()> {
-    let c = &result.counts;
-    writeln!(
+    shared::write_summary_line(
         out,
-        "\n{} items scanned: {} untracked, {} missing, {} orphaned, {} healthy",
         result.total_scanned,
-        c.get("untracked"),
-        c.get("missing"),
-        c.get("orphaned"),
-        c.get("healthy"),
+        &result.counts,
+        "items",
+        LFS_SUMMARY,
     )
 }
 

--- a/crates/git-lfs-tidy/src/output.rs
+++ b/crates/git-lfs-tidy/src/output.rs
@@ -114,7 +114,11 @@ fn write_lfs_summary(out: &mut dyn Write, result: &LfsScanResult) -> std::io::Re
     writeln!(
         out,
         "\n{} items scanned: {} untracked, {} missing, {} orphaned, {} healthy",
-        result.total_scanned, c.untracked, c.missing, c.orphaned, c.healthy,
+        result.total_scanned,
+        c.get("untracked"),
+        c.get("missing"),
+        c.get("orphaned"),
+        c.get("healthy"),
     )
 }
 
@@ -144,6 +148,7 @@ mod tests {
 
     use super::*;
     use crate::types::*;
+    use git_tidy_core::counts::Counts;
 
     // --- format_bytes tests ---
 
@@ -208,12 +213,7 @@ mod tests {
                 track_patterns: vec!["*.bin".to_string(), "*.zip".to_string()],
             }],
             total_scanned: 3,
-            counts: LfsCounts {
-                untracked: 1,
-                missing: 1,
-                orphaned: 0,
-                healthy: 1,
-            },
+            counts: Counts::from_pairs(&[("untracked", 1), ("missing", 1), ("healthy", 1)]),
             warnings: vec![],
             lfs_installed: true,
         }
@@ -248,7 +248,7 @@ mod tests {
         let result = LfsScanResult {
             repos: vec![],
             total_scanned: 0,
-            counts: LfsCounts::default(),
+            counts: Counts::default(),
             warnings: vec!["git-lfs is not installed".to_string()],
             lfs_installed: false,
         };
@@ -277,10 +277,7 @@ mod tests {
                 track_patterns: vec![],
             }],
             total_scanned: 1,
-            counts: LfsCounts {
-                healthy: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("healthy", 1)]),
             warnings: vec![],
             lfs_installed: true,
         };
@@ -311,10 +308,7 @@ mod tests {
                 track_patterns: vec![],
             }],
             total_scanned: 1,
-            counts: LfsCounts {
-                missing: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("missing", 1)]),
             warnings: vec![],
             lfs_installed: true,
         };

--- a/crates/git-lfs-tidy/src/scan.rs
+++ b/crates/git-lfs-tidy/src/scan.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use git_tidy_core::counts::Counts;
 use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
 use git_tidy_core::filter::{NameFilter, filter_paths};
@@ -9,7 +10,7 @@ use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
 use git_tidy_core::scan::parallel_classify;
 
-use crate::types::{LfsClassification, LfsCounts, LfsInfo, LfsRepoGroup, LfsScanResult};
+use crate::types::{LfsClassification, LfsInfo, LfsRepoGroup, LfsScanResult};
 
 /// Parse a human-readable size string into bytes.
 ///
@@ -203,11 +204,11 @@ pub fn run_scan_repos(
     );
     warnings.extend(scan_warnings);
 
-    let mut counts = LfsCounts::default();
+    let mut counts = Counts::default();
     let mut total_scanned = 0;
     for g in &repos {
         for item in &g.items {
-            counts.increment(item.classification);
+            counts.increment(item.classification.label());
         }
         total_scanned += g.items.len();
     }
@@ -471,6 +472,6 @@ mod tests {
         let p = Progress::disabled();
         let result = run_scan_repos(&git, &[repo()], 1_000_000, 1000, false, &p).unwrap();
         assert_eq!(result.total_scanned, 1);
-        assert_eq!(result.counts.healthy, 1);
+        assert_eq!(result.counts.get("healthy"), 1);
     }
 }

--- a/crates/git-lfs-tidy/src/types.rs
+++ b/crates/git-lfs-tidy/src/types.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use git_tidy_core::counts::Counts;
 use serde::Serialize;
 
 /// Classification of an LFS item.
@@ -69,30 +70,6 @@ pub struct LfsRepoGroup {
 }
 
 /// Summary counts for an LFS scan.
-#[derive(Debug, Clone, Default, Serialize)]
-pub struct LfsCounts {
-    pub untracked: usize,
-    pub missing: usize,
-    pub orphaned: usize,
-    pub healthy: usize,
-}
-
-impl LfsCounts {
-    pub fn increment(&mut self, classification: LfsClassification) {
-        match classification {
-            LfsClassification::Untracked => self.untracked += 1,
-            LfsClassification::Missing => self.missing += 1,
-            LfsClassification::Orphaned => self.orphaned += 1,
-            LfsClassification::Healthy => self.healthy += 1,
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn total(&self) -> usize {
-        self.untracked + self.missing + self.orphaned + self.healthy
-    }
-}
-
 /// Result of a full LFS scan.
 #[derive(Debug, Clone, Serialize)]
 pub struct LfsScanResult {
@@ -101,7 +78,7 @@ pub struct LfsScanResult {
     /// Total items scanned.
     pub total_scanned: usize,
     /// Summary counts by classification.
-    pub counts: LfsCounts,
+    pub counts: Counts,
     /// Warnings encountered during scanning.
     pub warnings: Vec<String>,
     /// Whether git-lfs is installed globally.
@@ -151,16 +128,21 @@ mod tests {
 
     #[test]
     fn counts_increment_and_total() {
-        let mut counts = LfsCounts::default();
-        counts.increment(LfsClassification::Untracked);
-        counts.increment(LfsClassification::Missing);
-        counts.increment(LfsClassification::Orphaned);
-        counts.increment(LfsClassification::Healthy);
-        counts.increment(LfsClassification::Healthy);
-        assert_eq!(counts.untracked, 1);
-        assert_eq!(counts.missing, 1);
-        assert_eq!(counts.orphaned, 1);
-        assert_eq!(counts.healthy, 2);
+        // Also guards against label drift: increments via `classification.label()`.
+        let mut counts = Counts::default();
+        for c in [
+            LfsClassification::Untracked,
+            LfsClassification::Missing,
+            LfsClassification::Orphaned,
+            LfsClassification::Healthy,
+            LfsClassification::Healthy,
+        ] {
+            counts.increment(c.label());
+        }
+        assert_eq!(counts.get("untracked"), 1);
+        assert_eq!(counts.get("missing"), 1);
+        assert_eq!(counts.get("orphaned"), 1);
+        assert_eq!(counts.get("healthy"), 2);
         assert_eq!(counts.total(), 5);
     }
 

--- a/crates/git-lfs-tidy/src/types.rs
+++ b/crates/git-lfs-tidy/src/types.rs
@@ -69,7 +69,6 @@ pub struct LfsRepoGroup {
     pub track_patterns: Vec<String>,
 }
 
-/// Summary counts for an LFS scan.
 /// Result of a full LFS scan.
 #[derive(Debug, Clone, Serialize)]
 pub struct LfsScanResult {

--- a/crates/git-remote-tidy/src/clean.rs
+++ b/crates/git-remote-tidy/src/clean.rs
@@ -141,7 +141,9 @@ fn should_clean(classification: &RemoteClassification, options: &CleanOptions) -
 mod tests {
     use std::path::PathBuf;
 
+    use git_tidy_core::counts::Counts;
     use git_tidy_core::testutil::MockGitBuilder;
+    use git_tidy_core::types::ClassificationLabel;
 
     use super::*;
     use crate::types::*;
@@ -151,9 +153,9 @@ mod tests {
     }
 
     fn make_scan_result(remotes: Vec<RemoteInfo>) -> RemoteScanResult {
-        let mut counts = RemoteCounts::default();
+        let mut counts = Counts::default();
         for r in &remotes {
-            counts.increment(&r.classification);
+            counts.increment(r.classification.label());
         }
         RemoteScanResult {
             repos: vec![RemoteRepoGroup {

--- a/crates/git-remote-tidy/src/output.rs
+++ b/crates/git-remote-tidy/src/output.rs
@@ -78,7 +78,10 @@ fn write_remote_summary(out: &mut dyn Write, result: &RemoteScanResult) -> std::
     writeln!(
         out,
         "\n{} remotes scanned: {} unreachable, {} orphaned, {} active",
-        result.total_scanned, c.unreachable, c.orphaned, c.active,
+        result.total_scanned,
+        c.get("unreachable"),
+        c.get("orphaned"),
+        c.get("active"),
     )
 }
 
@@ -101,6 +104,7 @@ mod tests {
 
     use super::*;
     use crate::types::*;
+    use git_tidy_core::counts::Counts;
 
     fn make_scan_result() -> RemoteScanResult {
         RemoteScanResult {
@@ -127,11 +131,7 @@ mod tests {
                 ],
             }],
             total_scanned: 2,
-            counts: RemoteCounts {
-                unreachable: 1,
-                orphaned: 0,
-                active: 1,
-            },
+            counts: Counts::from_pairs(&[("unreachable", 1), ("active", 1)]),
             warnings: vec![],
         }
     }
@@ -163,7 +163,7 @@ mod tests {
         let result = RemoteScanResult {
             repos: vec![],
             total_scanned: 0,
-            counts: RemoteCounts::default(),
+            counts: Counts::default(),
             warnings: vec!["could not list remotes for /repo/Foo".to_string()],
         };
 
@@ -208,10 +208,7 @@ mod tests {
                 }],
             }],
             total_scanned: 1,
-            counts: RemoteCounts {
-                orphaned: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("orphaned", 1)]),
             warnings: vec![],
         };
 
@@ -334,10 +331,7 @@ mod tests {
                 ],
             }],
             total_scanned: 2,
-            counts: RemoteCounts {
-                active: 2,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("active", 2)]),
             warnings: vec![],
         };
 
@@ -392,10 +386,7 @@ mod tests {
                 }],
             }],
             total_scanned: 1,
-            counts: RemoteCounts {
-                active: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("active", 1)]),
             warnings: vec![],
         };
 

--- a/crates/git-remote-tidy/src/output.rs
+++ b/crates/git-remote-tidy/src/output.rs
@@ -72,16 +72,21 @@ pub fn write_human(out: &mut dyn Write, result: &RemoteScanResult) -> std::io::R
     Ok(())
 }
 
+/// Ordered `(display, count key)` pairs for the remote summary breakdown.
+const REMOTE_SUMMARY: &[(&str, &str)] = &[
+    ("unreachable", "unreachable"),
+    ("orphaned", "orphaned"),
+    ("active", "active"),
+];
+
 /// Write the remote-specific summary line.
 fn write_remote_summary(out: &mut dyn Write, result: &RemoteScanResult) -> std::io::Result<()> {
-    let c = &result.counts;
-    writeln!(
+    shared::write_summary_line(
         out,
-        "\n{} remotes scanned: {} unreachable, {} orphaned, {} active",
         result.total_scanned,
-        c.get("unreachable"),
-        c.get("orphaned"),
-        c.get("active"),
+        &result.counts,
+        "remotes",
+        REMOTE_SUMMARY,
     )
 }
 

--- a/crates/git-remote-tidy/src/scan.rs
+++ b/crates/git-remote-tidy/src/scan.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+use git_tidy_core::counts::Counts;
 use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
 use git_tidy_core::filter::{NameFilter, filter_paths};
@@ -10,9 +11,7 @@ use git_tidy_core::progress::Progress;
 use git_tidy_core::scan::parallel_classify;
 use git_tidy_core::types::ClassificationLabel;
 
-use crate::types::{
-    RemoteClassification, RemoteCounts, RemoteInfo, RemoteRepoGroup, RemoteScanResult,
-};
+use crate::types::{RemoteClassification, RemoteInfo, RemoteRepoGroup, RemoteScanResult};
 
 /// Classify a single remote.
 ///
@@ -185,11 +184,11 @@ pub fn run_scan_repos(
     );
     warnings.extend(scan_warnings);
 
-    let mut counts = RemoteCounts::default();
+    let mut counts = Counts::default();
     let mut total_scanned = 0;
     for g in &repos {
         for r in &g.remotes {
-            counts.increment(&r.classification);
+            counts.increment(r.classification.label());
         }
         total_scanned += g.remotes.len();
     }
@@ -279,7 +278,7 @@ mod tests {
         let filter = NameFilter::default();
         let result = run_scan_repos(&git, &[repo()], false, false, &filter, &p).unwrap();
         assert_eq!(result.total_scanned, 1);
-        assert_eq!(result.counts.active, 1);
+        assert_eq!(result.counts.get("active"), 1);
     }
 
     #[test]

--- a/crates/git-remote-tidy/src/types.rs
+++ b/crates/git-remote-tidy/src/types.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use git_tidy_core::counts::Counts;
 use git_tidy_core::types::ClassificationLabel;
 use serde::Serialize;
 
@@ -61,12 +62,6 @@ pub struct RemoteRepoGroup {
     pub remotes: Vec<RemoteInfo>,
 }
 
-git_tidy_core::define_counts!(RemoteCounts, RemoteClassification, {
-    RemoteClassification::Unreachable => unreachable,
-    RemoteClassification::Orphaned => orphaned,
-    RemoteClassification::Active => active,
-});
-
 /// Result of a full remote scan.
 #[derive(Debug, Clone, Serialize)]
 pub struct RemoteScanResult {
@@ -75,7 +70,7 @@ pub struct RemoteScanResult {
     /// Total remotes scanned.
     pub total_scanned: usize,
     /// Summary counts by classification.
-    pub counts: RemoteCounts,
+    pub counts: Counts,
     /// Warnings encountered during scanning.
     pub warnings: Vec<String>,
 }
@@ -140,14 +135,19 @@ mod tests {
 
     #[test]
     fn counts_increment_and_total() {
-        let mut counts = RemoteCounts::default();
-        counts.increment(&RemoteClassification::Unreachable);
-        counts.increment(&RemoteClassification::Orphaned);
-        counts.increment(&RemoteClassification::Active);
-        counts.increment(&RemoteClassification::Active);
-        assert_eq!(counts.unreachable, 1);
-        assert_eq!(counts.orphaned, 1);
-        assert_eq!(counts.active, 2);
+        // Also guards against label drift: increments via `classification.label()`.
+        let mut counts = Counts::default();
+        for c in [
+            RemoteClassification::Unreachable,
+            RemoteClassification::Orphaned,
+            RemoteClassification::Active,
+            RemoteClassification::Active,
+        ] {
+            counts.increment(c.label());
+        }
+        assert_eq!(counts.get("unreachable"), 1);
+        assert_eq!(counts.get("orphaned"), 1);
+        assert_eq!(counts.get("active"), 2);
         assert_eq!(counts.total(), 4);
     }
 

--- a/crates/git-repo-tidy/src/clean.rs
+++ b/crates/git-repo-tidy/src/clean.rs
@@ -139,6 +139,7 @@ mod tests {
 
     use super::*;
     use crate::types::*;
+    use git_tidy_core::counts::Counts;
 
     fn make_repo(name: &str, classification: RepoClassification, is_dirty: bool) -> RepoInfo {
         RepoInfo {
@@ -157,11 +158,15 @@ mod tests {
     }
 
     fn make_scan_result(repos: Vec<RepoInfo>) -> RepoScanResult {
-        let mut counts = RepoCounts::default();
+        let mut counts = Counts::default();
+        let mut dirty = 0usize;
         let mut reclaimable = 0u64;
         let mut total_disk = 0u64;
         for r in &repos {
-            counts.increment(r.classification, r.is_dirty);
+            counts.increment(r.classification.label());
+            if r.is_dirty {
+                dirty += 1;
+            }
             total_disk += r.disk_usage_bytes;
             if matches!(
                 r.classification,
@@ -174,6 +179,7 @@ mod tests {
             total_scanned: repos.len(),
             repos,
             counts,
+            dirty,
             warnings: vec![],
             total_disk_usage_bytes: total_disk,
             reclaimable_bytes: reclaimable,

--- a/crates/git-repo-tidy/src/output.rs
+++ b/crates/git-repo-tidy/src/output.rs
@@ -82,8 +82,8 @@ pub fn write_human(out: &mut dyn Write, result: &RepoScanResult) -> std::io::Res
 /// Write the repo-specific summary lines.
 fn write_summary(out: &mut dyn Write, result: &RepoScanResult) -> std::io::Result<()> {
     let c = &result.counts;
-    let dirty_note = if c.dirty > 0 {
-        format!(" ({} dirty)", c.dirty)
+    let dirty_note = if result.dirty > 0 {
+        format!(" ({} dirty)", result.dirty)
     } else {
         String::new()
     };
@@ -91,7 +91,10 @@ fn write_summary(out: &mut dyn Write, result: &RepoScanResult) -> std::io::Resul
     writeln!(
         out,
         "\n{} repos scanned: {} stale, {} orphaned, {} active{dirty_note}",
-        result.total_scanned, c.stale, c.orphaned, c.active,
+        result.total_scanned,
+        c.get("stale"),
+        c.get("orphaned"),
+        c.get("active"),
     )?;
 
     writeln!(
@@ -119,6 +122,7 @@ mod tests {
 
     use super::*;
     use crate::types::*;
+    use git_tidy_core::counts::Counts;
 
     fn make_scan_result() -> RepoScanResult {
         RepoScanResult {
@@ -164,12 +168,8 @@ mod tests {
                 },
             ],
             total_scanned: 3,
-            counts: RepoCounts {
-                stale: 1,
-                orphaned: 1,
-                active: 1,
-                dirty: 1,
-            },
+            counts: Counts::from_pairs(&[("stale", 1), ("orphaned", 1), ("active", 1)]),
+            dirty: 1,
             warnings: vec![],
             total_disk_usage_bytes: (142 + 89 + 256) * 1024 * 1024,
             reclaimable_bytes: (142 + 89) * 1024 * 1024,
@@ -251,7 +251,8 @@ mod tests {
         let result = RepoScanResult {
             repos: vec![],
             total_scanned: 0,
-            counts: RepoCounts::default(),
+            counts: Counts::default(),
+            dirty: 0,
             warnings: vec!["could not scan /bad/path".to_string()],
             total_disk_usage_bytes: 0,
             reclaimable_bytes: 0,
@@ -309,10 +310,8 @@ mod tests {
         let result = RepoScanResult {
             repos: vec![clean_repo("clean", RepoClassification::Active)],
             total_scanned: 1,
-            counts: RepoCounts {
-                active: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("active", 1)]),
+            dirty: 0,
             warnings: vec![],
             total_disk_usage_bytes: 100 * 1024 * 1024,
             reclaimable_bytes: 0,

--- a/crates/git-repo-tidy/src/output.rs
+++ b/crates/git-repo-tidy/src/output.rs
@@ -79,9 +79,16 @@ pub fn write_human(out: &mut dyn Write, result: &RepoScanResult) -> std::io::Res
     Ok(())
 }
 
+/// Ordered `(display, count key)` pairs for the repo summary breakdown. The
+/// cross-cutting `dirty` count is appended separately (see `dirty_note`).
+const REPO_SUMMARY: &[(&str, &str)] = &[
+    ("stale", "stale"),
+    ("orphaned", "orphaned"),
+    ("active", "active"),
+];
+
 /// Write the repo-specific summary lines.
 fn write_summary(out: &mut dyn Write, result: &RepoScanResult) -> std::io::Result<()> {
-    let c = &result.counts;
     let dirty_note = if result.dirty > 0 {
         format!(" ({} dirty)", result.dirty)
     } else {
@@ -90,11 +97,9 @@ fn write_summary(out: &mut dyn Write, result: &RepoScanResult) -> std::io::Resul
 
     writeln!(
         out,
-        "\n{} repos scanned: {} stale, {} orphaned, {} active{dirty_note}",
+        "\n{} repos scanned: {}{dirty_note}",
         result.total_scanned,
-        c.get("stale"),
-        c.get("orphaned"),
-        c.get("active"),
+        shared::format_summary_buckets(&result.counts, REPO_SUMMARY),
     )?;
 
     writeln!(

--- a/crates/git-repo-tidy/src/scan.rs
+++ b/crates/git-repo-tidy/src/scan.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use git_tidy_core::counts::Counts;
 use git_tidy_core::date::days_since_iso_date;
 use git_tidy_core::dirty::check_dirty;
 use git_tidy_core::discovery::discover_repos;
@@ -11,7 +12,7 @@ use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
 use git_tidy_core::scan::parallel_classify;
 
-use crate::types::{RepoClassification, RepoCounts, RepoInfo, RepoScanResult};
+use crate::types::{RepoClassification, RepoInfo, RepoScanResult};
 
 /// Get disk usage in bytes for a directory using `du -sk`.
 ///
@@ -211,11 +212,17 @@ pub fn run_scan_repos_with_du(
     );
 
     // Post-processing: compute counts and disk usage totals.
-    let mut counts = RepoCounts::default();
+    let mut counts = Counts::default();
+    // `dirty` is a cross-cutting count (repos with meaningful uncommitted changes),
+    // not a classification bucket, so it lives on the result rather than in `Counts`.
+    let mut dirty = 0usize;
     let mut total_disk_usage_bytes = 0u64;
     let mut reclaimable_bytes = 0u64;
     for info in &repos {
-        counts.increment(info.classification, info.is_dirty);
+        counts.increment(info.classification.label());
+        if info.is_dirty {
+            dirty += 1;
+        }
         total_disk_usage_bytes += info.disk_usage_bytes;
         if matches!(
             info.classification,
@@ -239,6 +246,7 @@ pub fn run_scan_repos_with_du(
         repos,
         total_scanned,
         counts,
+        dirty,
         warnings,
         total_disk_usage_bytes,
         reclaimable_bytes,
@@ -490,7 +498,7 @@ mod tests {
         let result =
             run_scan_repos_with_du(&git, &[r], 180, &[], false, false, &no_du, &p).unwrap();
         assert_eq!(result.total_scanned, 1);
-        assert_eq!(result.counts.active, 1);
+        assert_eq!(result.counts.get("active"), 1);
     }
 
     #[test]
@@ -538,9 +546,9 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.total_scanned, 3);
-        assert_eq!(result.counts.active, 1);
-        assert_eq!(result.counts.stale, 1);
-        assert_eq!(result.counts.orphaned, 1);
+        assert_eq!(result.counts.get("active"), 1);
+        assert_eq!(result.counts.get("stale"), 1);
+        assert_eq!(result.counts.get("orphaned"), 1);
         assert_eq!(result.total_disk_usage_bytes, 3 * 1024);
         assert_eq!(result.reclaimable_bytes, 2 * 1024); // stale + orphaned
     }

--- a/crates/git-repo-tidy/src/types.rs
+++ b/crates/git-repo-tidy/src/types.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use git_tidy_core::counts::Counts;
 use serde::Serialize;
 
 /// Classification of a repository by activity level.
@@ -61,34 +62,6 @@ pub struct RepoInfo {
     pub dirty_file_count: usize,
 }
 
-/// Summary counts for a repo scan.
-#[derive(Debug, Clone, Default, Serialize)]
-pub struct RepoCounts {
-    pub stale: usize,
-    pub orphaned: usize,
-    pub active: usize,
-    /// Cross-cutting count: repos with `is_dirty == true`.
-    pub dirty: usize,
-}
-
-impl RepoCounts {
-    pub fn increment(&mut self, classification: RepoClassification, is_dirty: bool) {
-        match classification {
-            RepoClassification::Stale => self.stale += 1,
-            RepoClassification::Orphaned => self.orphaned += 1,
-            RepoClassification::Active => self.active += 1,
-        }
-        if is_dirty {
-            self.dirty += 1;
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn total(&self) -> usize {
-        self.stale + self.orphaned + self.active
-    }
-}
-
 /// Result of a full repo scan.
 #[derive(Debug, Clone, Serialize)]
 pub struct RepoScanResult {
@@ -97,7 +70,11 @@ pub struct RepoScanResult {
     /// Total repos scanned.
     pub total_scanned: usize,
     /// Summary counts by classification.
-    pub counts: RepoCounts,
+    pub counts: Counts,
+    /// Cross-cutting count: repos with meaningful uncommitted changes
+    /// (`is_dirty == true`). Not a classification bucket, so it is tracked
+    /// separately from `counts`.
+    pub dirty: usize,
     /// Warnings encountered during scanning.
     pub warnings: Vec<String>,
     /// Total disk usage of all scanned repos in bytes.
@@ -193,15 +170,21 @@ mod tests {
 
     #[test]
     fn counts_increment_and_total() {
-        let mut counts = RepoCounts::default();
-        counts.increment(RepoClassification::Stale, false);
-        counts.increment(RepoClassification::Orphaned, true);
-        counts.increment(RepoClassification::Active, false);
-        counts.increment(RepoClassification::Active, true);
-        assert_eq!(counts.stale, 1);
-        assert_eq!(counts.orphaned, 1);
-        assert_eq!(counts.active, 2);
-        assert_eq!(counts.dirty, 2);
+        // Also guards against label drift: increments via `classification.label()`.
+        // The cross-cutting `dirty` count now lives on `RepoScanResult`, not in
+        // `Counts`; it is exercised by the scan tests.
+        let mut counts = Counts::default();
+        for c in [
+            RepoClassification::Stale,
+            RepoClassification::Orphaned,
+            RepoClassification::Active,
+            RepoClassification::Active,
+        ] {
+            counts.increment(c.label());
+        }
+        assert_eq!(counts.get("stale"), 1);
+        assert_eq!(counts.get("orphaned"), 1);
+        assert_eq!(counts.get("active"), 2);
         assert_eq!(counts.total(), 4);
     }
 

--- a/crates/git-stash-tidy/src/clean.rs
+++ b/crates/git-stash-tidy/src/clean.rs
@@ -128,7 +128,9 @@ fn parse_stash_index(stash_ref: &str) -> Option<usize> {
 mod tests {
     use std::path::PathBuf;
 
+    use git_tidy_core::counts::Counts;
     use git_tidy_core::testutil::MockGitBuilder;
+    use git_tidy_core::types::ClassificationLabel;
 
     use super::*;
     use crate::types::*;
@@ -138,9 +140,9 @@ mod tests {
     }
 
     fn make_scan_result(stashes: Vec<StashInfo>) -> StashScanResult {
-        let mut counts = StashCounts::default();
+        let mut counts = Counts::default();
         for s in &stashes {
-            counts.increment(&s.classification);
+            counts.increment(s.classification.label());
         }
         StashScanResult {
             repos: vec![StashRepoGroup {

--- a/crates/git-stash-tidy/src/output.rs
+++ b/crates/git-stash-tidy/src/output.rs
@@ -60,17 +60,22 @@ pub fn write_human(out: &mut dyn Write, result: &StashScanResult) -> std::io::Re
     Ok(())
 }
 
+/// Ordered `(display, count key)` pairs for the stash summary breakdown.
+const STASH_SUMMARY: &[(&str, &str)] = &[
+    ("committed", "committed"),
+    ("orphaned", "orphaned"),
+    ("aged", "aged"),
+    ("active", "active"),
+];
+
 /// Write the stash-specific summary line.
 fn write_stash_summary(out: &mut dyn Write, result: &StashScanResult) -> std::io::Result<()> {
-    let c = &result.counts;
-    writeln!(
+    shared::write_summary_line(
         out,
-        "\n{} stashes scanned: {} committed, {} orphaned, {} aged, {} active",
         result.total_scanned,
-        c.get("committed"),
-        c.get("orphaned"),
-        c.get("aged"),
-        c.get("active"),
+        &result.counts,
+        "stashes",
+        STASH_SUMMARY,
     )
 }
 

--- a/crates/git-stash-tidy/src/output.rs
+++ b/crates/git-stash-tidy/src/output.rs
@@ -66,7 +66,11 @@ fn write_stash_summary(out: &mut dyn Write, result: &StashScanResult) -> std::io
     writeln!(
         out,
         "\n{} stashes scanned: {} committed, {} orphaned, {} aged, {} active",
-        result.total_scanned, c.committed, c.orphaned, c.aged, c.active,
+        result.total_scanned,
+        c.get("committed"),
+        c.get("orphaned"),
+        c.get("aged"),
+        c.get("active"),
     )
 }
 
@@ -89,6 +93,7 @@ mod tests {
 
     use super::*;
     use crate::types::*;
+    use git_tidy_core::counts::Counts;
 
     fn make_scan_result() -> StashScanResult {
         StashScanResult {
@@ -123,12 +128,7 @@ mod tests {
                 ],
             }],
             total_scanned: 3,
-            counts: StashCounts {
-                committed: 1,
-                orphaned: 1,
-                aged: 0,
-                active: 1,
-            },
+            counts: Counts::from_pairs(&[("committed", 1), ("orphaned", 1), ("active", 1)]),
             warnings: vec![],
         }
     }
@@ -161,7 +161,7 @@ mod tests {
         let result = StashScanResult {
             repos: vec![],
             total_scanned: 0,
-            counts: StashCounts::default(),
+            counts: Counts::default(),
             warnings: vec!["could not list stashes for /repo/Foo".to_string()],
         };
 

--- a/crates/git-stash-tidy/src/scan.rs
+++ b/crates/git-stash-tidy/src/scan.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use git_tidy_core::counts::Counts;
 use git_tidy_core::date::days_since_iso_date;
 use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
@@ -12,8 +13,7 @@ use git_tidy_core::scan::parallel_classify;
 use git_tidy_core::types::ClassificationLabel;
 
 use crate::types::{
-    StashClassification, StashCounts, StashInfo, StashRepoGroup, StashScanResult,
-    parse_stash_branch,
+    StashClassification, StashInfo, StashRepoGroup, StashScanResult, parse_stash_branch,
 };
 
 /// Classify a single stash entry.
@@ -183,11 +183,11 @@ pub fn run_scan_repos(
     );
     warnings.extend(scan_warnings);
 
-    let mut counts = StashCounts::default();
+    let mut counts = Counts::default();
     let mut total_scanned = 0;
     for g in &repos {
         for s in &g.stashes {
-            counts.increment(&s.classification);
+            counts.increment(s.classification.label());
         }
         total_scanned += g.stashes.len();
     }
@@ -433,7 +433,7 @@ mod tests {
         let filter = NameFilter::default();
         let result = run_scan_repos(&git, &[repo()], 90, false, &filter, &p).unwrap();
         assert_eq!(result.total_scanned, 1);
-        assert_eq!(result.counts.orphaned, 1);
+        assert_eq!(result.counts.get("orphaned"), 1);
     }
 
     #[test]

--- a/crates/git-stash-tidy/src/types.rs
+++ b/crates/git-stash-tidy/src/types.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use git_tidy_core::counts::Counts;
 use git_tidy_core::types::ClassificationLabel;
 use serde::Serialize;
 
@@ -65,13 +66,6 @@ pub struct StashRepoGroup {
     pub stashes: Vec<StashInfo>,
 }
 
-git_tidy_core::define_counts!(StashCounts, StashClassification, {
-    StashClassification::Committed => committed,
-    StashClassification::Orphaned => orphaned,
-    StashClassification::Aged => aged,
-    StashClassification::Active => active,
-});
-
 /// Result of a full stash scan.
 #[derive(Debug, Clone, Serialize)]
 pub struct StashScanResult {
@@ -80,7 +74,7 @@ pub struct StashScanResult {
     /// Total stashes scanned.
     pub total_scanned: usize,
     /// Summary counts by classification.
-    pub counts: StashCounts,
+    pub counts: Counts,
     /// Warnings encountered during scanning.
     pub warnings: Vec<String>,
 }
@@ -185,13 +179,17 @@ mod tests {
 
     #[test]
     fn counts_increment_and_total() {
-        let mut counts = StashCounts::default();
-        counts.increment(&StashClassification::Committed);
-        counts.increment(&StashClassification::Orphaned);
-        counts.increment(&StashClassification::Active);
-        assert_eq!(counts.committed, 1);
-        assert_eq!(counts.orphaned, 1);
-        assert_eq!(counts.active, 1);
+        let mut counts = Counts::default();
+        for c in [
+            StashClassification::Committed,
+            StashClassification::Orphaned,
+            StashClassification::Active,
+        ] {
+            counts.increment(c.label());
+        }
+        assert_eq!(counts.get("committed"), 1);
+        assert_eq!(counts.get("orphaned"), 1);
+        assert_eq!(counts.get("active"), 1);
         assert_eq!(counts.total(), 3);
     }
 }

--- a/crates/git-tag-tidy/src/clean.rs
+++ b/crates/git-tag-tidy/src/clean.rs
@@ -186,7 +186,9 @@ fn should_clean(classification: &TagClassification, options: &CleanOptions) -> b
 mod tests {
     use std::path::PathBuf;
 
+    use git_tidy_core::counts::Counts;
     use git_tidy_core::testutil::MockGitBuilder;
+    use git_tidy_core::types::ClassificationLabel;
 
     use super::*;
     use crate::types::*;
@@ -196,9 +198,9 @@ mod tests {
     }
 
     fn make_scan_result(tags: Vec<TagInfo>) -> TagScanResult {
-        let mut counts = TagCounts::default();
+        let mut counts = Counts::default();
         for t in &tags {
-            counts.increment(&t.classification);
+            counts.increment(t.classification.label());
         }
         TagScanResult {
             repos: vec![TagRepoGroup {

--- a/crates/git-tag-tidy/src/output.rs
+++ b/crates/git-tag-tidy/src/output.rs
@@ -69,7 +69,11 @@ fn write_tag_summary(out: &mut dyn Write, result: &TagScanResult) -> std::io::Re
     writeln!(
         out,
         "\n{} tags scanned: {} stale, {} local_only, {} remote_only, {} synced",
-        result.total_scanned, c.stale, c.local_only, c.remote_only, c.synced,
+        result.total_scanned,
+        c.get("stale"),
+        c.get("local_only"),
+        c.get("remote_only"),
+        c.get("synced"),
     )
 }
 
@@ -92,6 +96,7 @@ mod tests {
 
     use super::*;
     use crate::types::*;
+    use git_tidy_core::counts::Counts;
 
     fn make_scan_result() -> TagScanResult {
         TagScanResult {
@@ -132,12 +137,7 @@ mod tests {
                 ],
             }],
             total_scanned: 3,
-            counts: TagCounts {
-                stale: 1,
-                local_only: 1,
-                remote_only: 0,
-                synced: 1,
-            },
+            counts: Counts::from_pairs(&[("stale", 1), ("local_only", 1), ("synced", 1)]),
             warnings: vec![],
         }
     }
@@ -172,7 +172,7 @@ mod tests {
         let result = TagScanResult {
             repos: vec![],
             total_scanned: 0,
-            counts: TagCounts::default(),
+            counts: Counts::default(),
             warnings: vec!["could not list tags for /repo/Foo".to_string()],
         };
 
@@ -242,10 +242,7 @@ mod tests {
                 }],
             }],
             total_scanned: 1,
-            counts: TagCounts {
-                synced: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("synced", 1)]),
             warnings: vec![],
         };
 
@@ -287,11 +284,7 @@ mod tests {
                 ],
             }],
             total_scanned: 2,
-            counts: TagCounts {
-                stale: 1,
-                synced: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("stale", 1), ("synced", 1)]),
             warnings: vec![],
         };
 
@@ -336,11 +329,7 @@ mod tests {
                 ],
             }],
             total_scanned: 2,
-            counts: TagCounts {
-                stale: 1,
-                synced: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("stale", 1), ("synced", 1)]),
             warnings: vec![],
         };
 

--- a/crates/git-tag-tidy/src/output.rs
+++ b/crates/git-tag-tidy/src/output.rs
@@ -63,17 +63,22 @@ pub fn write_human(out: &mut dyn Write, result: &TagScanResult) -> std::io::Resu
     Ok(())
 }
 
+/// Ordered `(display, count key)` pairs for the tag summary breakdown.
+const TAG_SUMMARY: &[(&str, &str)] = &[
+    ("stale", "stale"),
+    ("local_only", "local_only"),
+    ("remote_only", "remote_only"),
+    ("synced", "synced"),
+];
+
 /// Write the tag-specific summary line.
 fn write_tag_summary(out: &mut dyn Write, result: &TagScanResult) -> std::io::Result<()> {
-    let c = &result.counts;
-    writeln!(
+    shared::write_summary_line(
         out,
-        "\n{} tags scanned: {} stale, {} local_only, {} remote_only, {} synced",
         result.total_scanned,
-        c.get("stale"),
-        c.get("local_only"),
-        c.get("remote_only"),
-        c.get("synced"),
+        &result.counts,
+        "tags",
+        TAG_SUMMARY,
     )
 }
 

--- a/crates/git-tag-tidy/src/scan.rs
+++ b/crates/git-tag-tidy/src/scan.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+use git_tidy_core::counts::Counts;
 use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
 use git_tidy_core::filter::{NameFilter, filter_paths};
@@ -10,9 +11,7 @@ use git_tidy_core::progress::Progress;
 use git_tidy_core::scan::parallel_classify;
 use git_tidy_core::types::ClassificationLabel;
 
-use crate::types::{
-    TagClassification, TagCounts, TagInfo, TagRepoGroup, TagScanResult, is_release_tag_name,
-};
+use crate::types::{TagClassification, TagInfo, TagRepoGroup, TagScanResult, is_release_tag_name};
 
 /// Classify a single tag.
 ///
@@ -207,11 +206,11 @@ pub fn run_scan_repos(
     );
     warnings.extend(scan_warnings);
 
-    let mut counts = TagCounts::default();
+    let mut counts = Counts::default();
     let mut total_scanned = 0;
     for g in &repos {
         for t in &g.tags {
-            counts.increment(&t.classification);
+            counts.increment(t.classification.label());
         }
         total_scanned += g.tags.len();
     }
@@ -381,6 +380,6 @@ mod tests {
         let filter = NameFilter::default();
         let result = run_scan_repos(&git, &[repo()], true, false, &filter, &p).unwrap();
         assert_eq!(result.total_scanned, 1);
-        assert_eq!(result.counts.synced, 1);
+        assert_eq!(result.counts.get("synced"), 1);
     }
 }

--- a/crates/git-tag-tidy/src/types.rs
+++ b/crates/git-tag-tidy/src/types.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use git_tidy_core::counts::Counts;
 use git_tidy_core::types::ClassificationLabel;
 use serde::Serialize;
 
@@ -69,13 +70,6 @@ pub struct TagRepoGroup {
     pub tags: Vec<TagInfo>,
 }
 
-git_tidy_core::define_counts!(TagCounts, TagClassification, {
-    TagClassification::Stale => stale,
-    TagClassification::LocalOnly => local_only,
-    TagClassification::RemoteOnly => remote_only,
-    TagClassification::Synced => synced,
-});
-
 /// Result of a full tag scan.
 #[derive(Debug, Clone, Serialize)]
 pub struct TagScanResult {
@@ -84,7 +78,7 @@ pub struct TagScanResult {
     /// Total tags scanned.
     pub total_scanned: usize,
     /// Summary counts by classification.
-    pub counts: TagCounts,
+    pub counts: Counts,
     /// Warnings encountered during scanning.
     pub warnings: Vec<String>,
 }
@@ -171,16 +165,22 @@ mod tests {
 
     #[test]
     fn counts_increment_and_total() {
-        let mut counts = TagCounts::default();
-        counts.increment(&TagClassification::Stale);
-        counts.increment(&TagClassification::LocalOnly);
-        counts.increment(&TagClassification::RemoteOnly);
-        counts.increment(&TagClassification::Synced);
-        counts.increment(&TagClassification::Synced);
-        assert_eq!(counts.stale, 1);
-        assert_eq!(counts.local_only, 1);
-        assert_eq!(counts.remote_only, 1);
-        assert_eq!(counts.synced, 2);
+        // Also guards against label drift: increments via the production path
+        // (`classification.label()`) and asserts the resulting map keys.
+        let mut counts = Counts::default();
+        for c in [
+            TagClassification::Stale,
+            TagClassification::LocalOnly,
+            TagClassification::RemoteOnly,
+            TagClassification::Synced,
+            TagClassification::Synced,
+        ] {
+            counts.increment(c.label());
+        }
+        assert_eq!(counts.get("stale"), 1);
+        assert_eq!(counts.get("local_only"), 1);
+        assert_eq!(counts.get("remote_only"), 1);
+        assert_eq!(counts.get("synced"), 2);
         assert_eq!(counts.total(), 5);
     }
 

--- a/crates/git-tidy-core/src/counts.rs
+++ b/crates/git-tidy-core/src/counts.rs
@@ -1,0 +1,123 @@
+//! Generic classification counts shared by every scan-shaped tool.
+//!
+//! Replaces the per-tool `*Counts` structs (`ScanCounts`, `TagCounts`,
+//! `RemoteCounts`, …). A `Counts` is a map keyed by classification **label** — the
+//! exact strings each tool's `label()` returns, which are also the keys the audit
+//! runner emits as JSON. Keying by label keeps the audit output byte-identical
+//! while collapsing eight near-duplicate structs into one.
+//!
+//! A label with zero occurrences is simply absent (it is never inserted), so
+//! [`Counts::iter`] yields only non-zero buckets — matching the audit runner's
+//! historical `filter(count > 0)`. Human summary lines that need to print explicit
+//! zeros use [`Counts::get`], which returns 0 for absent labels.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+/// Summary counts keyed by classification label.
+///
+/// Serializes as the inner map (serde represents a newtype struct as its wrapped
+/// value), e.g. `{"active": 2, "landed": 1}`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct Counts(BTreeMap<String, usize>);
+
+impl Counts {
+    /// Increment the count for `label` by one.
+    pub fn increment(&mut self, label: &str) {
+        *self.0.entry(label.to_string()).or_default() += 1;
+    }
+
+    /// Count for `label`, or 0 if the label was never incremented.
+    pub fn get(&self, label: &str) -> usize {
+        self.0.get(label).copied().unwrap_or(0)
+    }
+
+    /// Total across all labels.
+    pub fn total(&self) -> usize {
+        self.0.values().sum()
+    }
+
+    /// Whether no labels have been counted.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Iterate `(label, count)` pairs in sorted key order. Only non-zero buckets
+    /// are present.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, usize)> {
+        self.0.iter().map(|(k, v)| (k.as_str(), *v))
+    }
+}
+
+#[cfg(any(test, feature = "testutil"))]
+impl Counts {
+    /// Build a `Counts` from `(label, count)` pairs. Test helper for terse setup
+    /// in place of the former `XCounts { field: n, .. }` struct literals.
+    pub fn from_pairs(pairs: &[(&str, usize)]) -> Self {
+        let mut c = Self::default();
+        for (label, n) in pairs {
+            for _ in 0..*n {
+                c.increment(label);
+            }
+        }
+        c
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn increment_accumulates_per_label() {
+        let mut c = Counts::default();
+        c.increment("active");
+        c.increment("active");
+        c.increment("stale");
+        assert_eq!(c.get("active"), 2);
+        assert_eq!(c.get("stale"), 1);
+    }
+
+    #[test]
+    fn get_returns_zero_for_absent_label() {
+        let c = Counts::default();
+        assert_eq!(c.get("never-seen"), 0);
+    }
+
+    #[test]
+    fn total_sums_all_buckets() {
+        let mut c = Counts::default();
+        c.increment("a");
+        c.increment("b");
+        c.increment("b");
+        assert_eq!(c.total(), 3);
+    }
+
+    #[test]
+    fn iter_yields_only_nonzero_buckets_in_sorted_order() {
+        let mut c = Counts::default();
+        c.increment("zeta");
+        c.increment("alpha");
+        c.increment("alpha");
+        let pairs: Vec<(&str, usize)> = c.iter().collect();
+        assert_eq!(pairs, vec![("alpha", 2), ("zeta", 1)]);
+    }
+
+    #[test]
+    fn is_empty_tracks_presence() {
+        let mut c = Counts::default();
+        assert!(c.is_empty());
+        c.increment("x");
+        assert!(!c.is_empty());
+    }
+
+    #[test]
+    fn serializes_as_inner_map() {
+        let mut c = Counts::default();
+        c.increment("active");
+        c.increment("landed-content");
+        let json = serde_json::to_string(&c).unwrap();
+        assert_eq!(json, r#"{"active":1,"landed-content":1}"#);
+    }
+}

--- a/crates/git-tidy-core/src/counts.rs
+++ b/crates/git-tidy-core/src/counts.rs
@@ -38,11 +38,6 @@ impl Counts {
         self.0.values().sum()
     }
 
-    /// Whether no labels have been counted.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
     /// Iterate `(label, count)` pairs in sorted key order. Only non-zero buckets
     /// are present.
     pub fn iter(&self) -> impl Iterator<Item = (&str, usize)> {
@@ -54,6 +49,11 @@ impl Counts {
 impl Counts {
     /// Build a `Counts` from `(label, count)` pairs. Test helper for terse setup
     /// in place of the former `XCounts { field: n, .. }` struct literals.
+    ///
+    /// Routes through `increment` rather than inserting directly so it honors the
+    /// "only non-zero buckets" invariant (a `("x", 0)` pair inserts nothing, just
+    /// as the production scan path never counts an absent classification) and so a
+    /// repeated label accumulates exactly as a real scan would.
     pub fn from_pairs(pairs: &[(&str, usize)]) -> Self {
         let mut c = Self::default();
         for (label, n) in pairs {
@@ -105,11 +105,14 @@ mod tests {
     }
 
     #[test]
-    fn is_empty_tracks_presence() {
-        let mut c = Counts::default();
-        assert!(c.is_empty());
-        c.increment("x");
-        assert!(!c.is_empty());
+    fn from_pairs_drops_zero_and_accumulates_duplicates() {
+        // A zero-count pair must not create a bucket (preserves the non-zero
+        // invariant), and a repeated label accumulates like the scan path would.
+        let c = Counts::from_pairs(&[("kept", 2), ("zero", 0), ("kept", 3)]);
+        assert_eq!(c.get("kept"), 5);
+        assert_eq!(c.get("zero"), 0);
+        let labels: Vec<&str> = c.iter().map(|(k, _)| k).collect();
+        assert_eq!(labels, vec!["kept"]); // "zero" absent, not present-with-0
     }
 
     #[test]

--- a/crates/git-tidy-core/src/lib.rs
+++ b/crates/git-tidy-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod caching;
 pub mod classification;
 pub mod cli;
 pub mod config;
+pub mod counts;
 pub mod date;
 pub mod dirty;
 pub mod discovery;

--- a/crates/git-tidy-core/src/output.rs
+++ b/crates/git-tidy-core/src/output.rs
@@ -16,22 +16,47 @@ fn display_width(s: &str) -> usize {
     UnicodeWidthStr::width(s)
 }
 
-/// Write the summary line: "N {item_noun} scanned: X landed, Y content, ..."
+/// Ordered `(display word, count key)` pairs for the landed-classification summary
+/// shared by worktree-tidy and branch-tidy. The display word is what the human sees
+/// (`content`); the key is the classification label the count is stored under
+/// (`landed-content`).
+pub const LANDED_SUMMARY: &[(&str, &str)] = &[
+    ("landed", "landed"),
+    ("stale", "landed-stale"),
+    ("content", "landed-content"),
+    ("partial", "partial"),
+    ("active", "active"),
+    ("local", "local"),
+];
+
+/// Format a summary breakdown — `"{n0} {disp0}, {n1} {disp1}, …"` — from a `Counts`
+/// and an ordered `(display, key)` spec. Each entry reads `counts.get(key)` (0 when
+/// absent, so explicit zeros still print) and pairs it with the human display word.
+///
+/// Centralizes the breakdown so the scan tools don't each hand-roll the same
+/// `writeln!`. Tools whose summary is a single standard line call
+/// [`write_summary_line`]; repo-tidy, which appends a dirty note and a second line,
+/// calls this directly.
+pub fn format_summary_buckets(counts: &Counts, spec: &[(&str, &str)]) -> String {
+    spec.iter()
+        .map(|(display, key)| format!("{} {display}", counts.get(key)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Write a standard summary line: `"\n{total} {item_noun} scanned: {breakdown}"`,
+/// where the breakdown is built from `spec` (see [`format_summary_buckets`]).
 pub fn write_summary_line(
     out: &mut dyn Write,
     total: usize,
     counts: &Counts,
     item_noun: &str,
+    spec: &[(&str, &str)],
 ) -> std::io::Result<()> {
     writeln!(
         out,
-        "\n{total} {item_noun} scanned: {} landed, {} stale, {} content, {} partial, {} active, {} local",
-        counts.get("landed"),
-        counts.get("landed-stale"),
-        counts.get("landed-content"),
-        counts.get("partial"),
-        counts.get("active"),
-        counts.get("local"),
+        "\n{total} {item_noun} scanned: {}",
+        format_summary_buckets(counts, spec)
     )
 }
 
@@ -473,7 +498,7 @@ mod tests {
             ("local", 1),
         ]);
         let mut buf = Vec::new();
-        write_summary_line(&mut buf, 7, &counts, "branches").unwrap();
+        write_summary_line(&mut buf, 7, &counts, "branches", LANDED_SUMMARY).unwrap();
         let output = String::from_utf8(buf).unwrap();
         assert_eq!(
             output,
@@ -485,7 +510,7 @@ mod tests {
     fn summary_line_worktrees() {
         let counts = Counts::from_pairs(&[("landed", 1)]);
         let mut buf = Vec::new();
-        write_summary_line(&mut buf, 1, &counts, "worktrees").unwrap();
+        write_summary_line(&mut buf, 1, &counts, "worktrees", LANDED_SUMMARY).unwrap();
         let output = String::from_utf8(buf).unwrap();
         assert!(output.contains("1 worktrees scanned"));
     }

--- a/crates/git-tidy-core/src/output.rs
+++ b/crates/git-tidy-core/src/output.rs
@@ -7,7 +7,8 @@ use std::path::Path;
 use serde::Serialize;
 use unicode_width::UnicodeWidthStr;
 
-use crate::types::{Classification, ClassificationLabel, ScanCounts, WorktreeInfo};
+use crate::counts::Counts;
+use crate::types::{Classification, ClassificationLabel, WorktreeInfo};
 
 /// Terminal display width in cells (codepoint width per Unicode UAX-11).
 /// Used by `format_table` so multi-byte / wide-character cells stay aligned.
@@ -19,18 +20,18 @@ fn display_width(s: &str) -> usize {
 pub fn write_summary_line(
     out: &mut dyn Write,
     total: usize,
-    counts: &ScanCounts,
+    counts: &Counts,
     item_noun: &str,
 ) -> std::io::Result<()> {
     writeln!(
         out,
         "\n{total} {item_noun} scanned: {} landed, {} stale, {} content, {} partial, {} active, {} local",
-        counts.landed,
-        counts.landed_stale,
-        counts.landed_content,
-        counts.partial,
-        counts.active,
-        counts.local,
+        counts.get("landed"),
+        counts.get("landed-stale"),
+        counts.get("landed-content"),
+        counts.get("partial"),
+        counts.get("active"),
+        counts.get("local"),
     )
 }
 
@@ -465,14 +466,12 @@ mod tests {
 
     #[test]
     fn summary_line_format() {
-        let counts = ScanCounts {
-            landed: 3,
-            landed_stale: 0,
-            landed_content: 1,
-            partial: 0,
-            active: 2,
-            local: 1,
-        };
+        let counts = Counts::from_pairs(&[
+            ("landed", 3),
+            ("landed-content", 1),
+            ("active", 2),
+            ("local", 1),
+        ]);
         let mut buf = Vec::new();
         write_summary_line(&mut buf, 7, &counts, "branches").unwrap();
         let output = String::from_utf8(buf).unwrap();
@@ -484,10 +483,7 @@ mod tests {
 
     #[test]
     fn summary_line_worktrees() {
-        let counts = ScanCounts {
-            landed: 1,
-            ..Default::default()
-        };
+        let counts = Counts::from_pairs(&[("landed", 1)]);
         let mut buf = Vec::new();
         write_summary_line(&mut buf, 1, &counts, "worktrees").unwrap();
         let output = String::from_utf8(buf).unwrap();

--- a/crates/git-tidy-core/src/types.rs
+++ b/crates/git-tidy-core/src/types.rs
@@ -2,31 +2,7 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
-/// Define a counts struct with `increment` and `total` methods.
-///
-/// Generates a `#[derive(Debug, Clone, Default, Serialize)]` struct with `usize` fields,
-/// an `increment(&mut self, classification: &$classification)` method, and a `total(&self) -> usize` method.
-#[macro_export]
-macro_rules! define_counts {
-    ($name:ident, $classification:ty, { $($variant:pat => $field:ident),+ $(,)? }) => {
-        #[derive(Debug, Clone, Default, serde::Serialize)]
-        pub struct $name {
-            $(pub $field: usize,)+
-        }
-
-        impl $name {
-            pub fn increment(&mut self, classification: &$classification) {
-                match classification {
-                    $($variant => self.$field += 1,)+
-                }
-            }
-
-            pub fn total(&self) -> usize {
-                0 $(+ self.$field)+
-            }
-        }
-    };
-}
+use crate::counts::Counts;
 
 /// Shared interface for classification enums across all git-tidy tools.
 pub trait ClassificationLabel {
@@ -222,15 +198,6 @@ pub struct RepoGroup {
     pub worktrees: Vec<WorktreeInfo>,
 }
 
-define_counts!(ScanCounts, Classification, {
-    Classification::Landed => landed,
-    Classification::LandedStale => landed_stale,
-    Classification::LandedByContent { .. } => landed_content,
-    Classification::LandedPartial { .. } => partial,
-    Classification::Active => active,
-    Classification::Local => local,
-});
-
 /// Flat JSON representation of a worktree matching the spec.
 #[derive(Debug, Serialize)]
 pub struct JsonWorktree {
@@ -285,7 +252,7 @@ pub struct ScanResult {
     /// Total worktrees scanned.
     pub total_scanned: usize,
     /// Summary counts by classification.
-    pub counts: ScanCounts,
+    pub counts: Counts,
     /// Repos that were skipped (e.g. no default branch).
     pub warnings: Vec<String>,
 }

--- a/crates/git-tidy/src/inprocess.rs
+++ b/crates/git-tidy/src/inprocess.rs
@@ -378,9 +378,10 @@ mod tests {
 
     #[test]
     fn scan_to_result_omits_zero_counts() {
-        // `Counts` only ever holds non-zero buckets, so a never-incremented label
-        // (e.g. "landed") is simply absent from the audit's counts map.
-        let counts = Counts::from_pairs(&[("active", 5), ("stale", 2)]);
+        // The `("landed", 0)` pair is dropped by `from_pairs` (it never increments),
+        // so the bucket is absent from `Counts` and therefore from the audit map —
+        // exercising the zero-omission contract end to end through `scan_to_result`.
+        let counts = Counts::from_pairs(&[("active", 5), ("landed", 0), ("stale", 2)]);
         let ok: Result<Counts, git_tidy_core::error::Error> = Ok(counts);
         let spec = spec_for("git-branch-tidy");
         let result = scan_to_result(ok, spec, |c| c);

--- a/crates/git-tidy/src/inprocess.rs
+++ b/crates/git-tidy/src/inprocess.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use git_tidy_core::caching::CachingGitOps;
 use git_tidy_core::config;
+use git_tidy_core::counts::Counts;
 use git_tidy_core::discovery;
 use git_tidy_core::filter::NameFilter;
 use git_tidy_core::git::GitOps;
@@ -218,18 +219,22 @@ fn resolve_noise_patterns() -> Vec<String> {
     noise_config.resolve()
 }
 
-/// Convert a tool scan/lint `Result` into a `ToolResult`, extracting counts
-/// via a closure. Handles the Ok→counts and Err→error paths uniformly.
+/// Convert a tool scan/lint `Result` into a `ToolResult`, reading the result's
+/// generic `Counts`. Handles the Ok→counts and Err→error paths uniformly.
+///
+/// Every scan-shaped tool now exposes its summary as `git_tidy_core::counts::Counts`,
+/// keyed by the same classification labels the audit emits as JSON keys, so each
+/// `get_counts` accessor is simply `|r| &r.counts`. `Counts` only ever holds
+/// non-zero buckets, so no `> 0` filtering is needed.
 fn scan_to_result<T>(
     scan_result: Result<T, git_tidy_core::error::Error>,
     spec: &ToolSpec,
-    extract_counts: impl FnOnce(&T) -> Vec<(&str, usize)>,
+    get_counts: impl FnOnce(&T) -> &Counts,
 ) -> ToolResult {
     match scan_result {
         Ok(r) => {
-            let counts: BTreeMap<String, usize> = extract_counts(&r)
-                .into_iter()
-                .filter(|(_, count)| *count > 0)
+            let counts: BTreeMap<String, usize> = get_counts(&r)
+                .iter()
                 .map(|(label, count)| (label.to_string(), count))
                 .collect();
             let total: usize = counts.values().sum();
@@ -280,16 +285,7 @@ fn run_tool_scan(
                 progress,
             ),
             spec,
-            |r| {
-                vec![
-                    ("landed", r.counts.landed),
-                    ("landed-stale", r.counts.landed_stale),
-                    ("landed-content", r.counts.landed_content),
-                    ("partial", r.counts.partial),
-                    ("active", r.counts.active),
-                    ("local", r.counts.local),
-                ]
-            },
+            |r| &r.counts,
         ),
         "git-branch-tidy" => scan_to_result(
             git_branch_tidy::scan::run_scan_repos(
@@ -302,16 +298,7 @@ fn run_tool_scan(
                 progress,
             ),
             spec,
-            |r| {
-                vec![
-                    ("landed", r.counts.landed),
-                    ("landed-stale", r.counts.landed_stale),
-                    ("landed-content", r.counts.landed_content),
-                    ("partial", r.counts.partial),
-                    ("active", r.counts.active),
-                    ("local", r.counts.local),
-                ]
-            },
+            |r| &r.counts,
         ),
         "git-stash-tidy" => scan_to_result(
             git_stash_tidy::scan::run_scan_repos(
@@ -323,39 +310,19 @@ fn run_tool_scan(
                 progress,
             ),
             spec,
-            |r| {
-                vec![
-                    ("committed", r.counts.committed),
-                    ("orphaned", r.counts.orphaned),
-                    ("aged", r.counts.aged),
-                    ("active", r.counts.active),
-                ]
-            },
+            |r| &r.counts,
         ),
         "git-remote-tidy" => scan_to_result(
             git_remote_tidy::scan::run_scan_repos(
                 git, repo_paths, false, verbose, &filter, progress,
             ),
             spec,
-            |r| {
-                vec![
-                    ("unreachable", r.counts.unreachable),
-                    ("orphaned", r.counts.orphaned),
-                    ("active", r.counts.active),
-                ]
-            },
+            |r| &r.counts,
         ),
         "git-tag-tidy" => scan_to_result(
             git_tag_tidy::scan::run_scan_repos(git, repo_paths, false, verbose, &filter, progress),
             spec,
-            |r| {
-                vec![
-                    ("stale", r.counts.stale),
-                    ("local_only", r.counts.local_only),
-                    ("remote_only", r.counts.remote_only),
-                    ("synced", r.counts.synced),
-                ]
-            },
+            |r| &r.counts,
         ),
         "git-repo-tidy" => scan_to_result(
             git_repo_tidy::scan::run_scan_repos(
@@ -368,23 +335,12 @@ fn run_tool_scan(
                 progress,
             ),
             spec,
-            |r| {
-                vec![
-                    ("stale", r.counts.stale),
-                    ("orphaned", r.counts.orphaned),
-                    ("active", r.counts.active),
-                ]
-            },
+            |r| &r.counts,
         ),
         "git-config-tidy" => scan_to_result(
             git_config_tidy::lint::run_lint_repos(git, repo_paths, verbose, progress),
             spec,
-            |r| {
-                vec![
-                    ("orphaned_branch_config", r.counts.orphaned_branch_config),
-                    ("alias_shadows_builtin", r.counts.alias_shadows_builtin),
-                ]
-            },
+            |r| &r.counts,
         ),
         "git-lfs-tidy" => scan_to_result(
             git_lfs_tidy::scan::run_scan_repos(
@@ -396,14 +352,7 @@ fn run_tool_scan(
                 progress,
             ),
             spec,
-            |r| {
-                vec![
-                    ("untracked", r.counts.untracked),
-                    ("missing", r.counts.missing),
-                    ("orphaned", r.counts.orphaned),
-                    ("healthy", r.counts.healthy),
-                ]
-            },
+            |r| &r.counts,
         ),
         _ => ToolResult {
             name: spec.binary.to_string(),
@@ -429,10 +378,12 @@ mod tests {
 
     #[test]
     fn scan_to_result_omits_zero_counts() {
-        let ok: Result<Vec<(&str, usize)>, git_tidy_core::error::Error> =
-            Ok(vec![("active", 5), ("landed", 0), ("stale", 2)]);
+        // `Counts` only ever holds non-zero buckets, so a never-incremented label
+        // (e.g. "landed") is simply absent from the audit's counts map.
+        let counts = Counts::from_pairs(&[("active", 5), ("stale", 2)]);
+        let ok: Result<Counts, git_tidy_core::error::Error> = Ok(counts);
         let spec = spec_for("git-branch-tidy");
-        let result = scan_to_result(ok, spec, |entries| entries.clone());
+        let result = scan_to_result(ok, spec, |c| c);
         assert_eq!(result.counts.len(), 2);
         assert_eq!(result.counts["active"], 5);
         assert_eq!(result.counts["stale"], 2);
@@ -443,11 +394,11 @@ mod tests {
 
     #[test]
     fn scan_to_result_captures_error() {
-        let err: Result<(), _> = Err(git_tidy_core::error::Error::DirectoryNotFound {
+        let err: Result<Counts, _> = Err(git_tidy_core::error::Error::DirectoryNotFound {
             path: "/test".into(),
         });
         let spec = spec_for("git-branch-tidy");
-        let result = scan_to_result(err, spec, |_| vec![]);
+        let result = scan_to_result(err, spec, |c| c);
         assert_eq!(result.name, "git-branch-tidy");
         assert_eq!(result.total, 0);
         assert!(

--- a/crates/git-worktree-tidy/src/clean.rs
+++ b/crates/git-worktree-tidy/src/clean.rs
@@ -229,8 +229,9 @@ fn remove_worktree(
 mod tests {
     use std::path::PathBuf;
 
+    use git_tidy_core::counts::Counts;
     use git_tidy_core::testutil::MockGitBuilder;
-    use git_tidy_core::types::{Annotations, RepoGroup, ScanCounts, WorktreeInfo};
+    use git_tidy_core::types::{Annotations, ClassificationLabel, RepoGroup, WorktreeInfo};
 
     use super::*;
 
@@ -255,9 +256,9 @@ mod tests {
     }
 
     fn make_scan(worktrees: Vec<WorktreeInfo>) -> ScanResult {
-        let mut counts = ScanCounts::default();
+        let mut counts = Counts::default();
         for wt in &worktrees {
-            counts.increment(&wt.classification);
+            counts.increment(wt.classification.label());
         }
         let total = worktrees.len();
         ScanResult {

--- a/crates/git-worktree-tidy/src/output.rs
+++ b/crates/git-worktree-tidy/src/output.rs
@@ -20,7 +20,13 @@ pub fn write_human(out: &mut dyn Write, result: &ScanResult) -> std::io::Result<
         shared::format_table(out, &group.worktrees)?;
     }
 
-    shared::write_summary_line(out, result.total_scanned, &result.counts, "worktrees")?;
+    shared::write_summary_line(
+        out,
+        result.total_scanned,
+        &result.counts,
+        "worktrees",
+        shared::LANDED_SUMMARY,
+    )?;
     shared::write_explain_hint(out)?;
 
     Ok(())

--- a/crates/git-worktree-tidy/src/output.rs
+++ b/crates/git-worktree-tidy/src/output.rs
@@ -44,6 +44,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
+    use git_tidy_core::counts::Counts;
     use git_tidy_core::types::*;
 
     fn make_scan_result() -> ScanResult {
@@ -81,11 +82,7 @@ mod tests {
                 ],
             }],
             total_scanned: 2,
-            counts: ScanCounts {
-                landed: 1,
-                active: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("landed", 1), ("active", 1)]),
             warnings: vec![],
         }
     }
@@ -147,10 +144,7 @@ mod tests {
                 }],
             }],
             total_scanned: 1,
-            counts: ScanCounts {
-                partial: 1,
-                ..Default::default()
-            },
+            counts: Counts::from_pairs(&[("partial", 1)]),
             warnings: vec![],
         };
         let mut buf = Vec::new();
@@ -169,7 +163,7 @@ mod tests {
         let result = ScanResult {
             repos: vec![],
             total_scanned: 0,
-            counts: ScanCounts::default(),
+            counts: Counts::default(),
             warnings: vec!["could not determine default branch for /repo/Foo".to_string()],
         };
         let mut buf = Vec::new();

--- a/crates/git-worktree-tidy/src/scan.rs
+++ b/crates/git-worktree-tidy/src/scan.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use git_tidy_core::classification;
+use git_tidy_core::counts::Counts;
 use git_tidy_core::discovery;
 use git_tidy_core::error::Error;
 use git_tidy_core::filter::{NameFilter, filter_paths};
@@ -9,7 +10,7 @@ use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
 use git_tidy_core::scan::parallel_classify;
-use git_tidy_core::types::{ClassificationLabel, RepoGroup, ScanCounts, ScanResult};
+use git_tidy_core::types::{ClassificationLabel, RepoGroup, ScanResult};
 
 use crate::discovery::{self as wt_discovery, DiscoveredWorktree};
 
@@ -175,11 +176,11 @@ pub fn run_scan_repos(
     );
     warnings.extend(scan_warnings);
 
-    let mut counts = ScanCounts::default();
+    let mut counts = Counts::default();
     let mut total_scanned = 0;
     for g in &repos {
         for wt in &g.worktrees {
-            counts.increment(&wt.classification);
+            counts.increment(wt.classification.label());
         }
         total_scanned += g.worktrees.len();
     }

--- a/crates/git-worktree-tidy/tests/integration_git.rs
+++ b/crates/git-worktree-tidy/tests/integration_git.rs
@@ -175,5 +175,5 @@ fn worktree_with_deleted_branch_classifies_as_landed_stale() {
         "worktree with deleted branch ref should be classified as LandedStale"
     );
     assert_eq!(wt_info.branch.as_deref(), Some("feature/stale-branch"));
-    assert_eq!(result.counts.landed_stale, 1);
+    assert_eq!(result.counts.get("landed-stale"), 1);
 }


### PR DESCRIPTION
## What

Collapses the eight near-identical counts structs — `ScanCounts`, `TagCounts`, `RemoteCounts`, `StashCounts`, `LfsCounts`, `RepoCounts` (and config-tidy's `IssueCounts`), generated by the `define_counts!` macro or written by hand — into one `git_tidy_core::counts::Counts`: a `BTreeMap<String, usize>` keyed by classification label, with `increment` / `get` / `total` / `iter` and a `testutil`-gated `from_pairs` test constructor.

## Why this preserves all output

- The map key is the exact string each classification's `label()` already returns, which is also the key the audit runner emits as JSON — so audit JSON is byte-identical.
- Per-tool `--json` never serialized counts (it emits the flat item array via `FlatJsonItems`), so no serialized output changes anywhere.
- Human summary lines are preserved verbatim by reading `counts.get("<label>")` (which returns 0 for absent labels, so explicit zeros still print).
- A label is only inserted when incremented, so the map holds only non-zero buckets — matching the audit's former `filter(count > 0)`.

## Notable design point

`repo-tidy`'s cross-cutting `dirty` count is *not* a classification bucket (the audit deliberately excludes it, and the per-repo total must stay equal to `stale + orphaned + active`), so it moves to a dedicated `RepoScanResult.dirty` field rather than into the map.

The audit runner's seven per-tool count-extraction closures in `inprocess.rs` collapse to `|r| &r.counts`. Per-tool `counts_increment_and_total` tests now increment via `classification.label()`, doubling as a guard against label drift.

## Verification

- `cargo test --workspace` — all green
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D clippy::all` — clean
- Net **-165 lines** across 38 files (plus the new `counts.rs`).

## Context

First of the chained PRs for #117 (unify the scan pipeline behind one interface). This lands the generic `Counts` so the upcoming `ScanResult<T>` / `run_pipeline` work has a settled count representation. Does not close #117.

Part of #117.