### PR TITLE
Add core run_pipeline scan seam; migrate remote-tidy onto it

### DIFF
--- a/crates/git-remote-tidy/src/clean.rs
+++ b/crates/git-remote-tidy/src/clean.rs
@@ -39,7 +39,7 @@ pub fn run_clean(
     let mut skipped = 0;
 
     for group in &scan_result.repos {
-        for remote in &group.remotes {
+        for remote in &group.items {
             if !should_clean(&remote.classification, options) {
                 skipped += 1;
                 continue;
@@ -142,6 +142,7 @@ mod tests {
     use std::path::PathBuf;
 
     use git_tidy_core::counts::Counts;
+    use git_tidy_core::scan::RepoGroup;
     use git_tidy_core::testutil::MockGitBuilder;
     use git_tidy_core::types::ClassificationLabel;
 
@@ -158,10 +159,10 @@ mod tests {
             counts.increment(r.classification.label());
         }
         RemoteScanResult {
-            repos: vec![RemoteRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: repo(),
                 name: "my-repo".to_string(),
-                remotes,
+                items: remotes,
             }],
             total_scanned: 0,
             counts,

--- a/crates/git-remote-tidy/src/output.rs
+++ b/crates/git-remote-tidy/src/output.rs
@@ -57,13 +57,13 @@ pub fn write_human(out: &mut dyn Write, result: &RemoteScanResult) -> std::io::R
     shared::write_warnings(out, &result.warnings)?;
 
     for group in &result.repos {
-        let noun = if group.remotes.len() == 1 {
+        let noun = if group.items.len() == 1 {
             "remote"
         } else {
             "remotes"
         };
-        writeln!(out, "\n{} ({} {noun})", group.name, group.remotes.len())?;
-        shared::format_table(out, &group.remotes)?;
+        writeln!(out, "\n{} ({} {noun})", group.name, group.items.len())?;
+        shared::format_table(out, &group.items)?;
     }
 
     write_remote_summary(out, result)?;
@@ -98,7 +98,7 @@ pub fn write_json(out: &mut dyn Write, result: &RemoteScanResult) -> std::io::Re
 /// Write porcelain (machine-readable, tab-delimited) scan output.
 pub fn write_porcelain(out: &mut dyn Write, result: &RemoteScanResult) -> std::io::Result<()> {
     for group in &result.repos {
-        shared::format_porcelain(out, &group.remotes)?;
+        shared::format_porcelain(out, &group.items)?;
     }
     Ok(())
 }
@@ -110,13 +110,14 @@ mod tests {
     use super::*;
     use crate::types::*;
     use git_tidy_core::counts::Counts;
+    use git_tidy_core::scan::RepoGroup;
 
     fn make_scan_result() -> RemoteScanResult {
         RemoteScanResult {
-            repos: vec![RemoteRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: PathBuf::from("/repos/backend"),
                 name: "backend".to_string(),
-                remotes: vec![
+                items: vec![
                     RemoteInfo {
                         repo_path: PathBuf::from("/repos/backend"),
                         name: "origin".to_string(),
@@ -200,10 +201,10 @@ mod tests {
     #[test]
     fn json_output_orphaned_null_url() {
         let result = RemoteScanResult {
-            repos: vec![RemoteRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: PathBuf::from("/repos/test"),
                 name: "test".to_string(),
-                remotes: vec![RemoteInfo {
+                items: vec![RemoteInfo {
                     repo_path: PathBuf::from("/repos/test"),
                     name: "stale".to_string(),
                     classification: RemoteClassification::Orphaned,
@@ -313,10 +314,10 @@ mod tests {
     #[test]
     fn human_output_hides_tracking_column_when_all_zero() {
         let result = RemoteScanResult {
-            repos: vec![RemoteRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: PathBuf::from("/repos/r"),
                 name: "r".to_string(),
-                remotes: vec![
+                items: vec![
                     RemoteInfo {
                         repo_path: PathBuf::from("/repos/r"),
                         name: "a".to_string(),
@@ -378,10 +379,10 @@ mod tests {
     #[test]
     fn human_output_single_remote_noun() {
         let result = RemoteScanResult {
-            repos: vec![RemoteRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: PathBuf::from("/repos/test"),
                 name: "test".to_string(),
-                remotes: vec![RemoteInfo {
+                items: vec![RemoteInfo {
                     repo_path: PathBuf::from("/repos/test"),
                     name: "origin".to_string(),
                     classification: RemoteClassification::Active,

--- a/crates/git-remote-tidy/src/scan.rs
+++ b/crates/git-remote-tidy/src/scan.rs
@@ -1,17 +1,16 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use git_tidy_core::counts::Counts;
 use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
 use git_tidy_core::filter::{NameFilter, filter_paths};
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
-use git_tidy_core::scan::parallel_classify;
+use git_tidy_core::scan::{ScanOptions, run_pipeline};
 use git_tidy_core::types::ClassificationLabel;
 
-use crate::types::{RemoteClassification, RemoteInfo, RemoteRepoGroup, RemoteScanResult};
+use crate::types::{RemoteClassification, RemoteInfo, RemoteScanResult};
 
 /// Classify a single remote.
 ///
@@ -66,10 +65,12 @@ pub fn run_scan_repos(
     entity_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<RemoteScanResult, Error> {
-    let mut warnings = Vec::new();
-
-    let (repos, scan_warnings) = parallel_classify(
+    let result = run_pipeline(
+        git,
         repo_paths,
+        &ScanOptions { fetch: false },
+        "Scanning remotes",
+        progress,
         |repo_path| {
             let mut local_warnings = Vec::new();
 
@@ -80,7 +81,7 @@ pub fn run_scan_repos(
                         "could not list remotes for {}: {e}",
                         repo_path.display()
                     ));
-                    return (None, local_warnings);
+                    return (Vec::new(), local_warnings);
                 }
             };
 
@@ -122,12 +123,11 @@ pub fn run_scan_repos(
             all_remote_names.extend(orphaned);
 
             if all_remote_names.is_empty() {
-                return (None, local_warnings);
+                return (Vec::new(), local_warnings);
             }
 
-            let repo_name = repo_display_name(repo_path);
-
             if verbose {
+                let repo_name = repo_display_name(repo_path);
                 eprintln!(
                     "{repo_name}: {configured_count} configured, {} orphaned",
                     all_remote_names.len() - configured_count
@@ -171,34 +171,11 @@ pub fn run_scan_repos(
 
             classified.sort_by_key(|r| r.classification.priority());
 
-            let group = RemoteRepoGroup {
-                repo_path: repo_path.to_path_buf(),
-                name: repo_name,
-                remotes: classified,
-            };
-
-            (Some(group), local_warnings)
+            (classified, local_warnings)
         },
-        "Scanning remotes",
-        progress,
     );
-    warnings.extend(scan_warnings);
 
-    let mut counts = Counts::default();
-    let mut total_scanned = 0;
-    for g in &repos {
-        for r in &g.remotes {
-            counts.increment(r.classification.label());
-        }
-        total_scanned += g.remotes.len();
-    }
-
-    Ok(RemoteScanResult {
-        repos,
-        total_scanned,
-        counts,
-        warnings,
-    })
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -279,6 +256,27 @@ mod tests {
         let result = run_scan_repos(&git, &[repo()], false, false, &filter, &p).unwrap();
         assert_eq!(result.total_scanned, 1);
         assert_eq!(result.counts.get("active"), 1);
+    }
+
+    #[test]
+    fn run_scan_repos_skips_repo_when_entity_filter_excludes_all_remotes() {
+        // The shared pipeline drops empty groups: a repo whose every remote is
+        // filtered out by `--match` produces no `RepoGroup` at all (rather than an
+        // empty-bodied group). Guards the one intentional behavior unification from
+        // routing remote-tidy through `run_pipeline`.
+        let git = MockGitBuilder::new()
+            .with_list_remotes(&repo(), vec!["origin".to_string()])
+            .with_ls_remote_check(&repo(), "origin", true)
+            .with_remote_url(&repo(), "origin", "https://example.com/repo.git")
+            .build();
+
+        let p = Progress::disabled();
+        // Include only "upstream", which this repo does not have -> "origin" is filtered out.
+        let filter = NameFilter::new(&["upstream".to_string()], &[]);
+        let result = run_scan_repos(&git, &[repo()], true, false, &filter, &p).unwrap();
+
+        assert!(result.repos.is_empty());
+        assert_eq!(result.total_scanned, 0);
     }
 
     #[test]

--- a/crates/git-remote-tidy/src/types.rs
+++ b/crates/git-remote-tidy/src/types.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use git_tidy_core::counts::Counts;
+use git_tidy_core::scan::{Classified, ScanResult};
 use git_tidy_core::types::ClassificationLabel;
 use serde::Serialize;
 
@@ -51,39 +51,24 @@ pub struct RemoteInfo {
     pub is_origin: bool,
 }
 
-/// A group of remotes in the same repo.
-#[derive(Debug, Clone, Serialize)]
-pub struct RemoteRepoGroup {
-    /// Path to the repo.
-    pub repo_path: PathBuf,
-    /// Display name (directory basename).
-    pub name: String,
-    /// Remotes belonging to this repo, sorted by classification priority.
-    pub remotes: Vec<RemoteInfo>,
+impl Classified for RemoteInfo {
+    fn classification_label(&self) -> &str {
+        self.classification.label()
+    }
 }
 
 /// Result of a full remote scan.
-#[derive(Debug, Clone, Serialize)]
-pub struct RemoteScanResult {
-    /// Remotes grouped by repo.
-    pub repos: Vec<RemoteRepoGroup>,
-    /// Total remotes scanned.
-    pub total_scanned: usize,
-    /// Summary counts by classification.
-    pub counts: Counts,
-    /// Warnings encountered during scanning.
-    pub warnings: Vec<String>,
-}
+///
+/// Remotes are grouped per repo in `repos` as `RepoGroup<RemoteInfo>` (the
+/// generic core group type); each group's `items` are sorted by classification
+/// priority.
+pub type RemoteScanResult = ScanResult<RemoteInfo>;
 
-impl git_tidy_core::output::FlatJsonItems for RemoteScanResult {
+impl git_tidy_core::output::IntoJsonItem for RemoteInfo {
     type JsonItem = JsonRemote;
 
-    fn to_json_items(&self) -> Vec<JsonRemote> {
-        self.repos
-            .iter()
-            .flat_map(|g| g.remotes.iter())
-            .map(JsonRemote::from)
-            .collect()
+    fn to_json_item(&self) -> JsonRemote {
+        JsonRemote::from(self)
     }
 }
 
@@ -113,6 +98,8 @@ impl From<&RemoteInfo> for JsonRemote {
 
 #[cfg(test)]
 mod tests {
+    use git_tidy_core::counts::Counts;
+
     use super::*;
 
     #[test]

--- a/crates/git-remote-tidy/tests/integration_scan.rs
+++ b/crates/git-remote-tidy/tests/integration_scan.rs
@@ -32,7 +32,7 @@ fn scan_real_repo_with_reachable_remote() {
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     assert_eq!(result.total_scanned, 1);
 
-    let remote = &result.repos[0].remotes[0];
+    let remote = &result.repos[0].items[0];
     assert_eq!(remote.name, "origin");
     assert_eq!(remote.classification, RemoteClassification::Active);
     assert!(remote.is_origin);
@@ -65,7 +65,7 @@ fn scan_repo_with_unreachable_remote() {
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     assert_eq!(result.total_scanned, 1);
 
-    let remote = &result.repos[0].remotes[0];
+    let remote = &result.repos[0].items[0];
     assert_eq!(remote.name, "origin");
     assert_eq!(remote.classification, RemoteClassification::Unreachable);
 }
@@ -98,7 +98,7 @@ fn scan_repo_with_orphaned_refs() {
 
     // Should detect the orphaned remote
     let orphaned: Vec<_> = result.repos[0]
-        .remotes
+        .items
         .iter()
         .filter(|r| r.classification == RemoteClassification::Orphaned)
         .collect();
@@ -141,7 +141,7 @@ fn scan_entity_filter_includes_matching_remotes() {
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     let names: Vec<&str> = result.repos[0]
-        .remotes
+        .items
         .iter()
         .map(|r| r.name.as_str())
         .collect();
@@ -184,7 +184,7 @@ fn scan_entity_filter_exclude_takes_precedence() {
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     let names: Vec<&str> = result.repos[0]
-        .remotes
+        .items
         .iter()
         .map(|r| r.name.as_str())
         .collect();
@@ -241,7 +241,7 @@ fn scan_offline_mode() {
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
 
-    let remote = &result.repos[0].remotes[0];
+    let remote = &result.repos[0].items[0];
     assert_eq!(remote.name, "origin");
     // In offline mode, configured remotes default to Active
     assert_eq!(remote.classification, RemoteClassification::Active);

--- a/crates/git-tidy-core/src/output.rs
+++ b/crates/git-tidy-core/src/output.rs
@@ -99,6 +99,22 @@ pub trait FlatJsonItems {
     fn to_json_items(&self) -> Vec<Self::JsonItem>;
 }
 
+/// Conversion from a scan item to its flat JSON representation.
+///
+/// This is the per-item half of the generic `FlatJsonItems` impl for
+/// [`crate::scan::ScanResult`]: a `ScanResult<T>` can flatten itself into JSON
+/// whenever its item type `T` declares how one item becomes a JSON row. The
+/// orphan rule forbids a tool crate from implementing the foreign `FlatJsonItems`
+/// trait for the foreign `ScanResult<T>` type directly, so each tool implements
+/// this local-friendly per-item trait on its own `*Info` type instead.
+pub trait IntoJsonItem {
+    /// The JSON-serializable representation of this item.
+    type JsonItem: Serialize;
+
+    /// Build the JSON representation of this item.
+    fn to_json_item(&self) -> Self::JsonItem;
+}
+
 /// Flatten a scan result into JSON items and write as pretty-printed JSON.
 pub fn write_json_flat<T: FlatJsonItems>(out: &mut dyn Write, result: &T) -> std::io::Result<()> {
     let items = result.to_json_items();

--- a/crates/git-tidy-core/src/scan.rs
+++ b/crates/git-tidy-core/src/scan.rs
@@ -1,7 +1,12 @@
 use std::path::{Path, PathBuf};
 
 use rayon::prelude::*;
+use serde::Serialize;
 
+use crate::counts::Counts;
+use crate::fetch::parallel_fetch;
+use crate::git::GitOps;
+use crate::output::{FlatJsonItems, IntoJsonItem, repo_display_name};
 use crate::progress::Progress;
 
 /// Run a per-repo classification function in parallel across a set of repo paths.
@@ -38,4 +43,304 @@ pub fn parallel_classify<G: Send>(
         }
     }
     (groups, warnings)
+}
+
+/// A group of classified items sharing the same repo.
+///
+/// The generic counterpart to each tool's hand-rolled `*RepoGroup`
+/// (`TagRepoGroup`, `StashRepoGroup`, …). `items` holds the repo's classified
+/// rows, sorted by the tool's classification priority before assembly.
+#[derive(Debug, Clone, Serialize)]
+pub struct RepoGroup<T> {
+    /// Path to the repo.
+    pub repo_path: PathBuf,
+    /// Display name (directory basename).
+    pub name: String,
+    /// Items belonging to this repo.
+    pub items: Vec<T>,
+}
+
+/// Result of a full scan, shared by every uniform scan-shaped tool.
+///
+/// The generic counterpart to each tool's hand-rolled `*ScanResult`
+/// (`RemoteScanResult`, `TagScanResult`, …). Per-tool `--json` serializes only
+/// the flat item array (via `FlatJsonItems`), never this struct whole, so the
+/// `Serialize` derive here does not define any tool's public JSON.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScanResult<T> {
+    /// Items grouped by repo (empty groups omitted).
+    pub repos: Vec<RepoGroup<T>>,
+    /// Total items scanned across all groups.
+    pub total_scanned: usize,
+    /// Summary counts keyed by classification label.
+    pub counts: Counts,
+    /// Warnings accumulated during fetch and classification.
+    pub warnings: Vec<String>,
+}
+
+/// Flatten any `ScanResult<T>` into JSON items, provided each item knows how to
+/// become one (`T: IntoJsonItem`). This is the generic counterpart to each tool's
+/// former hand-rolled `impl FlatJsonItems for *ScanResult`, and the reason tools
+/// implement [`IntoJsonItem`] on their item type rather than `FlatJsonItems` on
+/// the foreign `ScanResult<T>` (which the orphan rule forbids).
+impl<T: IntoJsonItem> FlatJsonItems for ScanResult<T> {
+    type JsonItem = T::JsonItem;
+
+    fn to_json_items(&self) -> Vec<Self::JsonItem> {
+        self.repos
+            .iter()
+            .flat_map(|g| g.items.iter())
+            .map(IntoJsonItem::to_json_item)
+            .collect()
+    }
+}
+
+/// The one fact `run_pipeline` needs from an item to aggregate counts: its
+/// classification label (the same string the tool's `label()` returns and the
+/// audit runner emits as a JSON key).
+pub trait Classified {
+    /// Classification label used as the [`Counts`] bucket key.
+    fn classification_label(&self) -> &str;
+}
+
+/// Options controlling the shared scan pipeline.
+#[derive(Debug, Clone, Default)]
+pub struct ScanOptions {
+    /// Fetch (`git fetch --prune`) every repo before classifying. Worktree- and
+    /// branch-tidy set this; the offline-by-default tools (remote, tag, stash)
+    /// leave it false.
+    pub fetch: bool,
+}
+
+/// Run the shared scan pipeline over a set of pre-discovered repos.
+///
+/// Layer 2 of the scan stack: the high-level seam for the uniform tools. Given a
+/// per-repo `classify_one` closure that returns this repo's classified items and
+/// any per-repo warnings, the pipeline:
+///
+/// 1. optionally `parallel_fetch`es every repo (when `options.fetch`),
+/// 2. dispatches `classify_one` across repos via [`parallel_classify`], wrapping
+///    each non-empty `Vec<T>` into a [`RepoGroup`] (empty groups are dropped),
+/// 3. folds [`Counts`] by [`Classified::classification_label`] and sums
+///    `total_scanned`, and
+/// 4. assembles the [`ScanResult`].
+///
+/// Discovery and the per-tool entity filter (`--match`, name filters) stay
+/// *outside* this seam — in the tool's thin `run_scan` and inside `classify_one`
+/// respectively — because their granularity differs per tool and the audit
+/// runner discovers once and shares `repo_paths` across tools.
+pub fn run_pipeline<T: Classified + Send>(
+    git: &dyn GitOps,
+    repo_paths: &[PathBuf],
+    options: &ScanOptions,
+    label: &str,
+    progress: &Progress,
+    classify_one: impl Fn(&Path) -> (Vec<T>, Vec<String>) + Sync + Send,
+) -> ScanResult<T> {
+    let mut warnings = Vec::new();
+
+    if options.fetch {
+        let path_refs: Vec<&Path> = repo_paths.iter().map(PathBuf::as_path).collect();
+        warnings.extend(parallel_fetch(git, &path_refs, progress));
+    }
+
+    let (repos, classify_warnings) = parallel_classify(
+        repo_paths,
+        |repo_path| {
+            let (items, local_warnings) = classify_one(repo_path);
+            if items.is_empty() {
+                return (None, local_warnings);
+            }
+            let group = RepoGroup {
+                repo_path: repo_path.to_path_buf(),
+                name: repo_display_name(repo_path),
+                items,
+            };
+            (Some(group), local_warnings)
+        },
+        label,
+        progress,
+    );
+    warnings.extend(classify_warnings);
+
+    let mut counts = Counts::default();
+    let mut total_scanned = 0;
+    for group in &repos {
+        for item in &group.items {
+            counts.increment(item.classification_label());
+        }
+        total_scanned += group.items.len();
+    }
+
+    ScanResult {
+        repos,
+        total_scanned,
+        counts,
+        warnings,
+    }
+}
+
+#[cfg(test)]
+mod pipeline_tests {
+    use std::path::{Path, PathBuf};
+
+    use crate::progress::Progress;
+    use crate::testutil::MockGitBuilder;
+
+    use super::{Classified, RepoGroup, ScanOptions, run_pipeline};
+
+    /// Minimal `Classified` item for exercising the pipeline without dragging in a
+    /// real tool's `*Info` type.
+    struct TestItem {
+        label: &'static str,
+    }
+
+    impl Classified for TestItem {
+        fn classification_label(&self) -> &str {
+            self.label
+        }
+    }
+
+    fn opts(fetch: bool) -> ScanOptions {
+        ScanOptions { fetch }
+    }
+
+    #[test]
+    fn folds_counts_and_total_across_repos() {
+        let git = MockGitBuilder::new().build();
+        let repos = vec![PathBuf::from("/a"), PathBuf::from("/b")];
+
+        let result = run_pipeline(
+            &git,
+            &repos,
+            &opts(false),
+            "Scanning",
+            &Progress::disabled(),
+            |path| {
+                if path == Path::new("/a") {
+                    (
+                        vec![TestItem { label: "active" }, TestItem { label: "stale" }],
+                        vec![],
+                    )
+                } else {
+                    (vec![TestItem { label: "active" }], vec![])
+                }
+            },
+        );
+
+        assert_eq!(result.total_scanned, 3);
+        assert_eq!(result.counts.get("active"), 2);
+        assert_eq!(result.counts.get("stale"), 1);
+        assert_eq!(result.repos.len(), 2);
+    }
+
+    #[test]
+    fn skips_empty_groups() {
+        let git = MockGitBuilder::new().build();
+        let repos = vec![PathBuf::from("/a"), PathBuf::from("/empty")];
+
+        let result = run_pipeline(
+            &git,
+            &repos,
+            &opts(false),
+            "Scanning",
+            &Progress::disabled(),
+            |path| {
+                if path == Path::new("/empty") {
+                    (vec![], vec![])
+                } else {
+                    (vec![TestItem { label: "active" }], vec![])
+                }
+            },
+        );
+
+        assert_eq!(result.repos.len(), 1);
+        assert_eq!(result.repos[0].repo_path, PathBuf::from("/a"));
+        assert_eq!(result.total_scanned, 1);
+    }
+
+    #[test]
+    fn sets_group_name_and_path() {
+        let git = MockGitBuilder::new().build();
+        let repos = vec![PathBuf::from("/repos/my-project")];
+
+        let result: super::ScanResult<TestItem> = run_pipeline(
+            &git,
+            &repos,
+            &opts(false),
+            "Scanning",
+            &Progress::disabled(),
+            |_| (vec![TestItem { label: "active" }], vec![]),
+        );
+
+        let group: &RepoGroup<TestItem> = &result.repos[0];
+        assert_eq!(group.name, "my-project");
+        assert_eq!(group.repo_path, PathBuf::from("/repos/my-project"));
+        assert_eq!(group.items.len(), 1);
+    }
+
+    #[test]
+    fn collects_classifier_warnings() {
+        let git = MockGitBuilder::new().build();
+        let repos = vec![PathBuf::from("/a")];
+
+        let result = run_pipeline(
+            &git,
+            &repos,
+            &opts(false),
+            "Scanning",
+            &Progress::disabled(),
+            |_| {
+                (
+                    Vec::<TestItem>::new(),
+                    vec!["could not read /a".to_string()],
+                )
+            },
+        );
+
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("could not read /a"))
+        );
+        assert!(result.repos.is_empty());
+    }
+
+    #[test]
+    fn fetch_disabled_does_not_fetch() {
+        let git = MockGitBuilder::new().build();
+        let repos = vec![PathBuf::from("/a")];
+
+        let _result = run_pipeline(
+            &git,
+            &repos,
+            &opts(false),
+            "Scanning",
+            &Progress::disabled(),
+            |_| (vec![TestItem { label: "active" }], vec![]),
+        );
+
+        assert!(git.fetch_prune_calls().is_empty());
+    }
+
+    #[test]
+    fn fetch_enabled_fetches_each_repo() {
+        let git = MockGitBuilder::new().build();
+        let repos = vec![PathBuf::from("/a"), PathBuf::from("/b")];
+
+        let _result = run_pipeline(
+            &git,
+            &repos,
+            &opts(true),
+            "Scanning",
+            &Progress::disabled(),
+            |_| (vec![TestItem { label: "active" }], vec![]),
+        );
+
+        let calls = git.fetch_prune_calls();
+        assert_eq!(calls.len(), 2);
+        assert!(calls.contains(&PathBuf::from("/a")));
+        assert!(calls.contains(&PathBuf::from("/b")));
+    }
 }

--- a/crates/git-tidy-core/src/scan.rs
+++ b/crates/git-tidy-core/src/scan.rs
@@ -48,8 +48,10 @@ pub fn parallel_classify<G: Send>(
 /// A group of classified items sharing the same repo.
 ///
 /// The generic counterpart to each tool's hand-rolled `*RepoGroup`
-/// (`TagRepoGroup`, `StashRepoGroup`, …). `items` holds the repo's classified
-/// rows, sorted by the tool's classification priority before assembly.
+/// (`TagRepoGroup`, `StashRepoGroup`, …). `items` are in the order the classifier
+/// returned them — `run_pipeline` does not reorder. A tool that wants rows sorted
+/// by classification priority sorts inside its own `classify_one` closure (as
+/// remote-tidy does) before returning them.
 #[derive(Debug, Clone, Serialize)]
 pub struct RepoGroup<T> {
     /// Path to the repo.
@@ -342,5 +344,71 @@ mod pipeline_tests {
         assert_eq!(calls.len(), 2);
         assert!(calls.contains(&PathBuf::from("/a")));
         assert!(calls.contains(&PathBuf::from("/b")));
+    }
+
+    #[test]
+    fn fetch_completes_before_classify() {
+        // The seam's load-bearing ordering contract: when fetch is enabled, every
+        // repo is fetched before ANY classify closure runs (parallel_fetch blocks
+        // via thread::scope before parallel_classify dispatches). Each closure
+        // observes that all fetches are already recorded — so a refactor that moved
+        // the fetch after (or into) classification would fail here.
+        let git = MockGitBuilder::new().build();
+        let repos = vec![PathBuf::from("/a"), PathBuf::from("/b")];
+        let observed_fetch_counts = std::sync::Mutex::new(Vec::new());
+
+        let _result = run_pipeline(
+            &git,
+            &repos,
+            &opts(true),
+            "Scanning",
+            &Progress::disabled(),
+            |_| {
+                observed_fetch_counts
+                    .lock()
+                    .unwrap()
+                    .push(git.fetch_prune_calls().len());
+                (vec![TestItem { label: "active" }], vec![])
+            },
+        );
+
+        let observed = observed_fetch_counts.into_inner().unwrap();
+        assert_eq!(observed.len(), 2);
+        assert!(
+            observed.iter().all(|&n| n == 2),
+            "every classify closure should see both fetches already done, got {observed:?}"
+        );
+    }
+
+    #[test]
+    fn fetch_failure_warning_precedes_classify_warnings() {
+        // A failed fetch surfaces a warning, and run_pipeline orders fetch warnings
+        // ahead of classify warnings in the merged result.
+        let git = MockGitBuilder::new()
+            .with_fetch_prune_error(&PathBuf::from("/a"), "network down")
+            .build();
+        let repos = vec![PathBuf::from("/a")];
+
+        let result = run_pipeline(
+            &git,
+            &repos,
+            &opts(true),
+            "Scanning",
+            &Progress::disabled(),
+            |_| {
+                (
+                    vec![TestItem { label: "active" }],
+                    vec!["classify warning".to_string()],
+                )
+            },
+        );
+
+        assert_eq!(result.warnings.len(), 2, "warnings: {:?}", result.warnings);
+        assert!(
+            result.warnings[0].contains("/a") && result.warnings[0].contains("network down"),
+            "first warning should be the fetch failure, got {:?}",
+            result.warnings,
+        );
+        assert_eq!(result.warnings[1], "classify warning");
     }
 }

--- a/crates/git-tidy-core/src/testutil.rs
+++ b/crates/git-tidy-core/src/testutil.rs
@@ -40,6 +40,7 @@ pub struct MockGitBuilder {
     list_remotes_errors: HashMap<PathBuf, String>,
     list_remote_tracking_refs_errors: HashMap<PathBuf, String>,
     log_file_history: HashMap<(PathBuf, String, String), Vec<(String, String)>>,
+    fetch_prune_errors: HashMap<PathBuf, String>,
     fetch_prune_calls: std::sync::Mutex<Vec<PathBuf>>,
     remove_calls: std::sync::Mutex<Vec<(PathBuf, PathBuf)>>,
     remove_force_calls: std::sync::Mutex<Vec<(PathBuf, PathBuf)>>,
@@ -218,6 +219,12 @@ impl MockGitBuilder {
 
     pub fn with_list_remotes_error(mut self, repo: &Path, error: &str) -> Self {
         self.list_remotes_errors
+            .insert(repo.to_path_buf(), error.to_string());
+        self
+    }
+
+    pub fn with_fetch_prune_error(mut self, repo: &Path, error: &str) -> Self {
+        self.fetch_prune_errors
             .insert(repo.to_path_buf(), error.to_string());
         self
     }
@@ -603,6 +610,7 @@ impl MockGitBuilder {
             list_remotes_errors: self.list_remotes_errors,
             list_remote_tracking_refs_errors: self.list_remote_tracking_refs_errors,
             log_file_history: self.log_file_history,
+            fetch_prune_errors: self.fetch_prune_errors,
             fetch_prune_calls: self.fetch_prune_calls,
             remove_calls: self.remove_calls,
             remove_force_calls: self.remove_force_calls,
@@ -681,6 +689,7 @@ pub struct MockGit {
     list_remotes_errors: HashMap<PathBuf, String>,
     list_remote_tracking_refs_errors: HashMap<PathBuf, String>,
     log_file_history: HashMap<(PathBuf, String, String), Vec<(String, String)>>,
+    fetch_prune_errors: HashMap<PathBuf, String>,
     fetch_prune_calls: std::sync::Mutex<Vec<PathBuf>>,
     remove_calls: std::sync::Mutex<Vec<(PathBuf, PathBuf)>>,
     remove_force_calls: std::sync::Mutex<Vec<(PathBuf, PathBuf)>>,
@@ -799,6 +808,12 @@ impl GitOps for MockGit {
             .lock()
             .unwrap()
             .push(repo.to_path_buf());
+        if let Some(err) = self.fetch_prune_errors.get(&repo.to_path_buf()) {
+            return Err(Error::GitCommand {
+                command: "fetch --prune".to_string(),
+                message: err.clone(),
+            });
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

PR B of the #117 scan-pipeline migration. Hoists the `[fetch] → parallel-classify → assemble → aggregate` orchestration that each scan-shaped tool hand-rolls into one deep seam in `git-tidy-core`, then migrates one uniform tool (remote-tidy) onto it as proof. Builds on PR A's generic `Counts`.

## What lands in core

- **Layer 2 pipeline** in `git-tidy-core/src/scan.rs`: `RepoGroup<T>`, `ScanResult<T>`, the `Classified` classifier seam, `ScanOptions { fetch }`, and `run_pipeline`. `run_pipeline` optionally `parallel_fetch`es (opt-in via `ScanOptions.fetch`), dispatches a per-repo `classify_one` closure through the existing `parallel_classify` (Layer 1), wraps each non-empty `Vec<T>` into a `RepoGroup<T>` (empty groups dropped), folds `Counts` by `Classified::classification_label`, and assembles the `ScanResult<T>`.
- **`IntoJsonItem`** (`output.rs`) plus a blanket `impl FlatJsonItems for ScanResult<T> where T: IntoJsonItem`. The orphan rule forbids a tool crate from implementing the foreign `FlatJsonItems` for the foreign `ScanResult<T>` directly, so each tool implements the per-item conversion on its own local `*Info` type and the generic result flattens itself.

## Seam boundaries (deliberate, per plan §2–§3)

- Discovery stays in each tool's thin `run_scan` (preserves the audit runner's discover-once optimization — `run_pipeline` takes pre-discovered `repo_paths`).
- The entity filter (`--match`, name filters) stays inside the classifier closure.
- Fetch is opt-in via `ScanOptions.fetch` (remote/tag/stash = false; worktree/branch = true when they migrate later).
- repo-tidy and lfs-tidy are not forced onto Layer 2; they stay on `parallel_classify` with bespoke results.

## remote-tidy migration (the proof tool)

- `RemoteScanResult` is now `ScanResult<RemoteInfo>`; the group field `.remotes` becomes `.items`; the deleted public `RemoteRepoGroup` struct is replaced by `RepoGroup<RemoteInfo>`.
- `run_scan_repos` routes through `run_pipeline`, deleting its hand-rolled `parallel_classify` call and counts/total fold.
- Public `--json`, porcelain, and human-summary output are unchanged (existing `output.rs` tests pass byte-identical).

## Behavior note

One intentional unification: when an entity filter excludes **every** remote in a repo, the pipeline now drops the empty group rather than emitting a `name (0 remotes)` header. `total_scanned`, `counts`, and JSON are byte-identical (an empty group contributed nothing to any of them). Pinned by a new test.

## Testing

- 7 new core unit tests for `run_pipeline` (counts/total fold, skip-empty, group naming, warning collection, fetch wiring on/off) and 1 new remote-tidy test for the empty-group case.
- Local gates green: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D clippy::all`, `cargo test --workspace`, and `cargo +1.93.0 check` (MSRV). No dependency changes.

Part of #117.
