### PR TITLE
Migrate tag-tidy and stash-tidy onto run_pipeline scan seam

### DIFF
--- a/crates/git-stash-tidy/src/clean.rs
+++ b/crates/git-stash-tidy/src/clean.rs
@@ -44,7 +44,7 @@ pub fn run_clean(
         // Collect stashes to drop, along with their parsed indices
         let mut to_drop: Vec<(usize, &str, &StashClassification)> = Vec::new();
 
-        for stash in &group.stashes {
+        for stash in &group.items {
             if !should_clean(&stash.classification, options) {
                 skipped += 1;
                 continue;
@@ -129,6 +129,7 @@ mod tests {
     use std::path::PathBuf;
 
     use git_tidy_core::counts::Counts;
+    use git_tidy_core::scan::RepoGroup;
     use git_tidy_core::testutil::MockGitBuilder;
     use git_tidy_core::types::ClassificationLabel;
 
@@ -145,10 +146,10 @@ mod tests {
             counts.increment(s.classification.label());
         }
         StashScanResult {
-            repos: vec![StashRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: repo(),
                 name: "my-repo".to_string(),
-                stashes,
+                items: stashes,
             }],
             total_scanned: 0,
             counts,

--- a/crates/git-stash-tidy/src/output.rs
+++ b/crates/git-stash-tidy/src/output.rs
@@ -50,8 +50,8 @@ pub fn write_human(out: &mut dyn Write, result: &StashScanResult) -> std::io::Re
     shared::write_warnings(out, &result.warnings)?;
 
     for group in &result.repos {
-        writeln!(out, "\n{} ({} stashes)", group.name, group.stashes.len())?;
-        shared::format_table(out, &group.stashes)?;
+        writeln!(out, "\n{} ({} stashes)", group.name, group.items.len())?;
+        shared::format_table(out, &group.items)?;
     }
 
     write_stash_summary(out, result)?;
@@ -87,7 +87,7 @@ pub fn write_json(out: &mut dyn Write, result: &StashScanResult) -> std::io::Res
 /// Write porcelain (machine-readable, tab-delimited) scan output.
 pub fn write_porcelain(out: &mut dyn Write, result: &StashScanResult) -> std::io::Result<()> {
     for group in &result.repos {
-        shared::format_porcelain(out, &group.stashes)?;
+        shared::format_porcelain(out, &group.items)?;
     }
     Ok(())
 }
@@ -99,13 +99,14 @@ mod tests {
     use super::*;
     use crate::types::*;
     use git_tidy_core::counts::Counts;
+    use git_tidy_core::scan::RepoGroup;
 
     fn make_scan_result() -> StashScanResult {
         StashScanResult {
-            repos: vec![StashRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: PathBuf::from("/repos/my-repo"),
                 name: "my-repo".to_string(),
-                stashes: vec![
+                items: vec![
                     StashInfo {
                         repo_path: PathBuf::from("/repos/my-repo"),
                         stash_ref: "stash@{0}".to_string(),

--- a/crates/git-stash-tidy/src/scan.rs
+++ b/crates/git-stash-tidy/src/scan.rs
@@ -1,6 +1,5 @@
 use std::path::{Path, PathBuf};
 
-use git_tidy_core::counts::Counts;
 use git_tidy_core::date::days_since_iso_date;
 use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
@@ -9,12 +8,10 @@ use git_tidy_core::git::GitOps;
 use git_tidy_core::landed::diff_similarity;
 use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
-use git_tidy_core::scan::parallel_classify;
+use git_tidy_core::scan::{ScanOptions, run_pipeline};
 use git_tidy_core::types::ClassificationLabel;
 
-use crate::types::{
-    StashClassification, StashInfo, StashRepoGroup, StashScanResult, parse_stash_branch,
-};
+use crate::types::{StashClassification, StashInfo, StashScanResult, parse_stash_branch};
 
 /// Classify a single stash entry.
 ///
@@ -102,10 +99,12 @@ pub fn run_scan_repos(
     entity_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<StashScanResult, Error> {
-    let mut warnings = Vec::new();
-
-    let (repos, scan_warnings) = parallel_classify(
+    let result = run_pipeline(
+        git,
         repo_paths,
+        &ScanOptions { fetch: false },
+        "Scanning stashes",
+        progress,
         |repo_path| {
             let mut local_warnings = Vec::new();
 
@@ -116,18 +115,18 @@ pub fn run_scan_repos(
                         "could not list stashes for {}: {e}",
                         repo_path.display()
                     ));
-                    return (None, local_warnings);
+                    return (Vec::new(), local_warnings);
                 }
             };
 
             if stashes.is_empty() {
-                return (None, local_warnings);
+                return (Vec::new(), local_warnings);
             }
 
-            let repo_name = repo_display_name(repo_path);
             let local_branches = git.list_local_branches(repo_path).unwrap_or_default();
 
             if verbose {
+                let repo_name = repo_display_name(repo_path);
                 eprintln!("{repo_name}: {} stash entries", stashes.len());
             }
 
@@ -170,34 +169,11 @@ pub fn run_scan_repos(
 
             classified.sort_by_key(|s| s.classification.priority());
 
-            let group = StashRepoGroup {
-                repo_path: repo_path.to_path_buf(),
-                name: repo_name,
-                stashes: classified,
-            };
-
-            (Some(group), local_warnings)
+            (classified, local_warnings)
         },
-        "Scanning stashes",
-        progress,
     );
-    warnings.extend(scan_warnings);
 
-    let mut counts = Counts::default();
-    let mut total_scanned = 0;
-    for g in &repos {
-        for s in &g.stashes {
-            counts.increment(s.classification.label());
-        }
-        total_scanned += g.stashes.len();
-    }
-
-    Ok(StashScanResult {
-        repos,
-        total_scanned,
-        counts,
-        warnings,
-    })
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -434,6 +410,33 @@ mod tests {
         let result = run_scan_repos(&git, &[repo()], 90, false, &filter, &p).unwrap();
         assert_eq!(result.total_scanned, 1);
         assert_eq!(result.counts.get("orphaned"), 1);
+    }
+
+    #[test]
+    fn run_scan_repos_skips_repo_when_entity_filter_excludes_all_stashes() {
+        // The shared pipeline drops empty groups: a repo whose every stash is
+        // filtered out by `--match` produces no `RepoGroup` at all (rather than an
+        // empty-bodied group). Guards the one intentional behavior unification from
+        // routing stash-tidy through `run_pipeline`.
+        let git = MockGitBuilder::new()
+            .with_stash_list(
+                &repo(),
+                vec![(
+                    "stash@{0}".to_string(),
+                    "WIP on feature-x: abc Fix".to_string(),
+                    "2020-01-01T12:00:00+00:00".to_string(),
+                )],
+            )
+            .with_local_branches(&repo(), vec!["main".to_string()])
+            .build();
+
+        let p = Progress::disabled();
+        // Include only "other", which the stash's branch "feature-x" does not match.
+        let filter = NameFilter::new(&["other".to_string()], &[]);
+        let result = run_scan_repos(&git, &[repo()], 90, false, &filter, &p).unwrap();
+
+        assert!(result.repos.is_empty());
+        assert_eq!(result.total_scanned, 0);
     }
 
     #[test]

--- a/crates/git-stash-tidy/src/types.rs
+++ b/crates/git-stash-tidy/src/types.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use git_tidy_core::counts::Counts;
+use git_tidy_core::scan::{Classified, ScanResult};
 use git_tidy_core::types::ClassificationLabel;
 use serde::Serialize;
 
@@ -55,39 +55,23 @@ pub struct StashInfo {
     pub message: String,
 }
 
-/// A group of stashes in the same repo.
-#[derive(Debug, Clone, Serialize)]
-pub struct StashRepoGroup {
-    /// Path to the repo.
-    pub repo_path: PathBuf,
-    /// Display name (directory basename).
-    pub name: String,
-    /// Stashes belonging to this repo, sorted by classification priority.
-    pub stashes: Vec<StashInfo>,
+impl Classified for StashInfo {
+    fn classification_label(&self) -> &str {
+        self.classification.label()
+    }
 }
 
 /// Result of a full stash scan.
-#[derive(Debug, Clone, Serialize)]
-pub struct StashScanResult {
-    /// Stashes grouped by repo.
-    pub repos: Vec<StashRepoGroup>,
-    /// Total stashes scanned.
-    pub total_scanned: usize,
-    /// Summary counts by classification.
-    pub counts: Counts,
-    /// Warnings encountered during scanning.
-    pub warnings: Vec<String>,
-}
+///
+/// Stashes are grouped per repo in `repos` as `RepoGroup<StashInfo>` (the generic
+/// core group type); each group's `items` are sorted by classification priority.
+pub type StashScanResult = ScanResult<StashInfo>;
 
-impl git_tidy_core::output::FlatJsonItems for StashScanResult {
+impl git_tidy_core::output::IntoJsonItem for StashInfo {
     type JsonItem = JsonStash;
 
-    fn to_json_items(&self) -> Vec<JsonStash> {
-        self.repos
-            .iter()
-            .flat_map(|g| g.stashes.iter())
-            .map(JsonStash::from)
-            .collect()
+    fn to_json_item(&self) -> JsonStash {
+        JsonStash::from(self)
     }
 }
 
@@ -140,6 +124,8 @@ pub fn parse_stash_branch(message: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use git_tidy_core::counts::Counts;
+
     use super::*;
 
     #[test]

--- a/crates/git-stash-tidy/tests/integration_scan.rs
+++ b/crates/git-stash-tidy/tests/integration_scan.rs
@@ -30,7 +30,7 @@ fn scan_real_repo_with_stashes() {
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     assert_eq!(result.total_scanned, 1);
 
-    let stash = &result.repos[0].stashes[0];
+    let stash = &result.repos[0].items[0];
     assert_eq!(stash.stash_ref, "stash@{0}");
     assert!(stash.branch.as_deref() == Some("main"));
     // Stash is recent and branch exists, so should be Active
@@ -66,7 +66,7 @@ fn scan_repo_with_orphaned_stash() {
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     assert_eq!(result.total_scanned, 1);
 
-    let stash = &result.repos[0].stashes[0];
+    let stash = &result.repos[0].items[0];
     assert_eq!(stash.classification, StashClassification::Orphaned);
     assert_eq!(stash.branch.as_deref(), Some("temp-feature"));
 }
@@ -108,7 +108,7 @@ fn scan_entity_filter_includes_matching_stashes() {
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     assert_eq!(result.total_scanned, 1);
     assert_eq!(
-        result.repos[0].stashes[0].branch.as_deref(),
+        result.repos[0].items[0].branch.as_deref(),
         Some("feature-alpha")
     );
 }
@@ -151,7 +151,7 @@ fn scan_entity_filter_exclude_takes_precedence() {
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     assert_eq!(result.total_scanned, 1);
     assert_eq!(
-        result.repos[0].stashes[0].branch.as_deref(),
+        result.repos[0].items[0].branch.as_deref(),
         Some("feature-login")
     );
 }

--- a/crates/git-tag-tidy/src/clean.rs
+++ b/crates/git-tag-tidy/src/clean.rs
@@ -35,7 +35,7 @@ pub fn run_clean(
     let mut skipped = 0;
 
     for group in &scan_result.repos {
-        for tag in &group.tags {
+        for tag in &group.items {
             if !should_clean(&tag.classification, options) {
                 skipped += 1;
                 continue;
@@ -187,6 +187,7 @@ mod tests {
     use std::path::PathBuf;
 
     use git_tidy_core::counts::Counts;
+    use git_tidy_core::scan::RepoGroup;
     use git_tidy_core::testutil::MockGitBuilder;
     use git_tidy_core::types::ClassificationLabel;
 
@@ -203,10 +204,10 @@ mod tests {
             counts.increment(t.classification.label());
         }
         TagScanResult {
-            repos: vec![TagRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: repo(),
                 name: "my-repo".to_string(),
-                tags,
+                items: tags,
             }],
             total_scanned: 0,
             counts,

--- a/crates/git-tag-tidy/src/output.rs
+++ b/crates/git-tag-tidy/src/output.rs
@@ -52,9 +52,13 @@ pub fn write_human(out: &mut dyn Write, result: &TagScanResult) -> std::io::Resu
     shared::write_warnings(out, &result.warnings)?;
 
     for group in &result.repos {
-        let noun = if group.tags.len() == 1 { "tag" } else { "tags" };
-        writeln!(out, "\n{} ({} {noun})", group.name, group.tags.len())?;
-        shared::format_table(out, &group.tags)?;
+        let noun = if group.items.len() == 1 {
+            "tag"
+        } else {
+            "tags"
+        };
+        writeln!(out, "\n{} ({} {noun})", group.name, group.items.len())?;
+        shared::format_table(out, &group.items)?;
     }
 
     write_tag_summary(out, result)?;
@@ -90,7 +94,7 @@ pub fn write_json(out: &mut dyn Write, result: &TagScanResult) -> std::io::Resul
 /// Write porcelain (machine-readable, tab-delimited) scan output.
 pub fn write_porcelain(out: &mut dyn Write, result: &TagScanResult) -> std::io::Result<()> {
     for group in &result.repos {
-        shared::format_porcelain(out, &group.tags)?;
+        shared::format_porcelain(out, &group.items)?;
     }
     Ok(())
 }
@@ -102,13 +106,14 @@ mod tests {
     use super::*;
     use crate::types::*;
     use git_tidy_core::counts::Counts;
+    use git_tidy_core::scan::RepoGroup;
 
     fn make_scan_result() -> TagScanResult {
         TagScanResult {
-            repos: vec![TagRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: PathBuf::from("/repos/backend"),
                 name: "backend".to_string(),
-                tags: vec![
+                items: vec![
                     TagInfo {
                         repo_path: PathBuf::from("/repos/backend"),
                         name: "old-experiment".to_string(),
@@ -232,10 +237,10 @@ mod tests {
     #[test]
     fn human_output_single_tag_noun() {
         let result = TagScanResult {
-            repos: vec![TagRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: PathBuf::from("/repos/test"),
                 name: "test".to_string(),
-                tags: vec![TagInfo {
+                items: vec![TagInfo {
                     repo_path: PathBuf::from("/repos/test"),
                     name: "v1.0".to_string(),
                     classification: TagClassification::Synced,
@@ -262,10 +267,10 @@ mod tests {
         // When no tag in the group carries a tagger_date, format_table's
         // all-None auto-hide rule should drop the DATE column entirely.
         let result = TagScanResult {
-            repos: vec![TagRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: PathBuf::from("/repos/r"),
                 name: "r".to_string(),
-                tags: vec![
+                items: vec![
                     TagInfo {
                         repo_path: PathBuf::from("/repos/r"),
                         name: "a".to_string(),
@@ -307,10 +312,10 @@ mod tests {
         // When at least one tag has a tagger_date, the DATE column appears,
         // and rows without a date should still render cleanly.
         let result = TagScanResult {
-            repos: vec![TagRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: PathBuf::from("/repos/r"),
                 name: "r".to_string(),
-                tags: vec![
+                items: vec![
                     TagInfo {
                         repo_path: PathBuf::from("/repos/r"),
                         name: "lightweight-undated".to_string(),

--- a/crates/git-tag-tidy/src/scan.rs
+++ b/crates/git-tag-tidy/src/scan.rs
@@ -1,17 +1,16 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use git_tidy_core::counts::Counts;
 use git_tidy_core::discovery::discover_repos;
 use git_tidy_core::error::Error;
 use git_tidy_core::filter::{NameFilter, filter_paths};
 use git_tidy_core::git::GitOps;
 use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
-use git_tidy_core::scan::parallel_classify;
+use git_tidy_core::scan::{ScanOptions, run_pipeline};
 use git_tidy_core::types::ClassificationLabel;
 
-use crate::types::{TagClassification, TagInfo, TagRepoGroup, TagScanResult, is_release_tag_name};
+use crate::types::{TagClassification, TagInfo, TagScanResult, is_release_tag_name};
 
 /// Classify a single tag.
 ///
@@ -59,10 +58,12 @@ pub fn run_scan_repos(
     entity_filter: &NameFilter,
     progress: &Progress,
 ) -> Result<TagScanResult, Error> {
-    let mut warnings = Vec::new();
-
-    let (repos, scan_warnings) = parallel_classify(
+    let result = run_pipeline(
+        git,
         repo_paths,
+        &ScanOptions { fetch: false },
+        "Scanning tags",
+        progress,
         |repo_path| {
             let mut local_warnings = Vec::new();
 
@@ -73,7 +74,7 @@ pub fn run_scan_repos(
                         "could not list tags for {}: {e}",
                         repo_path.display()
                     ));
-                    return (None, local_warnings);
+                    return (Vec::new(), local_warnings);
                 }
             };
 
@@ -110,12 +111,11 @@ pub fn run_scan_repos(
                 .collect();
 
             if all_tag_names.is_empty() {
-                return (None, local_warnings);
+                return (Vec::new(), local_warnings);
             }
 
-            let repo_name = repo_display_name(repo_path);
-
             if verbose {
+                let repo_name = repo_display_name(repo_path);
                 eprintln!(
                     "{repo_name}: {} local, {} remote tags",
                     local_tags.len(),
@@ -193,34 +193,11 @@ pub fn run_scan_repos(
                     .then_with(|| a.name.cmp(&b.name))
             });
 
-            let group = TagRepoGroup {
-                repo_path: repo_path.to_path_buf(),
-                name: repo_name,
-                tags: classified,
-            };
-
-            (Some(group), local_warnings)
+            (classified, local_warnings)
         },
-        "Scanning tags",
-        progress,
     );
-    warnings.extend(scan_warnings);
 
-    let mut counts = Counts::default();
-    let mut total_scanned = 0;
-    for g in &repos {
-        for t in &g.tags {
-            counts.increment(t.classification.label());
-        }
-        total_scanned += g.tags.len();
-    }
-
-    Ok(TagScanResult {
-        repos,
-        total_scanned,
-        counts,
-        warnings,
-    })
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -381,5 +358,29 @@ mod tests {
         let result = run_scan_repos(&git, &[repo()], true, false, &filter, &p).unwrap();
         assert_eq!(result.total_scanned, 1);
         assert_eq!(result.counts.get("synced"), 1);
+    }
+
+    #[test]
+    fn run_scan_repos_skips_repo_when_entity_filter_excludes_all_tags() {
+        // The shared pipeline drops empty groups: a repo whose every tag is
+        // filtered out by `--match` produces no `RepoGroup` at all (rather than an
+        // empty-bodied group). Guards the one intentional behavior unification from
+        // routing tag-tidy through `run_pipeline`.
+        let git = MockGitBuilder::new()
+            .with_local_tags(&repo(), vec!["v1.0".to_string()])
+            .with_list_remotes(&repo(), vec![])
+            .with_tag_commit(&repo(), "v1.0", "abc123")
+            .with_is_commit_reachable(&repo(), "abc123", true)
+            .with_is_tag_annotated(&repo(), "v1.0", true)
+            .with_tag_date(&repo(), "v1.0", Some("2024-06-15T10:00:00+00:00"))
+            .build();
+
+        let p = Progress::disabled();
+        // Include only "v2", which this repo's "v1.0" tag does not match -> filtered out.
+        let filter = NameFilter::new(&["v2".to_string()], &[]);
+        let result = run_scan_repos(&git, &[repo()], true, false, &filter, &p).unwrap();
+
+        assert!(result.repos.is_empty());
+        assert_eq!(result.total_scanned, 0);
     }
 }

--- a/crates/git-tag-tidy/src/types.rs
+++ b/crates/git-tag-tidy/src/types.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use git_tidy_core::counts::Counts;
+use git_tidy_core::scan::{Classified, ScanResult};
 use git_tidy_core::types::ClassificationLabel;
 use serde::Serialize;
 
@@ -59,39 +59,23 @@ pub struct TagInfo {
     pub remote_names: Vec<String>,
 }
 
-/// A group of tags in the same repo.
-#[derive(Debug, Clone, Serialize)]
-pub struct TagRepoGroup {
-    /// Path to the repo.
-    pub repo_path: PathBuf,
-    /// Display name (directory basename).
-    pub name: String,
-    /// Tags belonging to this repo, sorted by classification priority.
-    pub tags: Vec<TagInfo>,
+impl Classified for TagInfo {
+    fn classification_label(&self) -> &str {
+        self.classification.label()
+    }
 }
 
 /// Result of a full tag scan.
-#[derive(Debug, Clone, Serialize)]
-pub struct TagScanResult {
-    /// Tags grouped by repo.
-    pub repos: Vec<TagRepoGroup>,
-    /// Total tags scanned.
-    pub total_scanned: usize,
-    /// Summary counts by classification.
-    pub counts: Counts,
-    /// Warnings encountered during scanning.
-    pub warnings: Vec<String>,
-}
+///
+/// Tags are grouped per repo in `repos` as `RepoGroup<TagInfo>` (the generic core
+/// group type); each group's `items` are sorted by classification priority.
+pub type TagScanResult = ScanResult<TagInfo>;
 
-impl git_tidy_core::output::FlatJsonItems for TagScanResult {
+impl git_tidy_core::output::IntoJsonItem for TagInfo {
     type JsonItem = JsonTag;
 
-    fn to_json_items(&self) -> Vec<JsonTag> {
-        self.repos
-            .iter()
-            .flat_map(|g| g.tags.iter())
-            .map(JsonTag::from)
-            .collect()
+    fn to_json_item(&self) -> JsonTag {
+        JsonTag::from(self)
     }
 }
 
@@ -146,6 +130,8 @@ pub fn is_release_tag_name(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use git_tidy_core::counts::Counts;
+
     use super::*;
 
     #[test]

--- a/crates/git-tag-tidy/tests/integration_scan.rs
+++ b/crates/git-tag-tidy/tests/integration_scan.rs
@@ -37,7 +37,7 @@ fn scan_synced_tag() {
     assert!(result.total_scanned >= 1);
 
     let synced: Vec<_> = result.repos[0]
-        .tags
+        .items
         .iter()
         .filter(|t| t.name == "v1.0.0")
         .collect();
@@ -77,7 +77,7 @@ fn scan_local_only_tag() {
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
 
     let local: Vec<_> = result.repos[0]
-        .tags
+        .items
         .iter()
         .filter(|t| t.name == "local-only-tag")
         .collect();
@@ -115,7 +115,7 @@ fn scan_stale_tag() {
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
 
     let stale: Vec<_> = result.repos[0]
-        .tags
+        .items
         .iter()
         .filter(|t| t.name == "stale-tag")
         .collect();
@@ -146,7 +146,7 @@ fn scan_annotated_tag() {
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
 
     let annotated: Vec<_> = result.repos[0]
-        .tags
+        .items
         .iter()
         .filter(|t| t.name == "v2.0.0")
         .collect();
@@ -183,7 +183,7 @@ fn scan_entity_filter_includes_matching_tags() {
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     let names: Vec<&str> = result.repos[0]
-        .tags
+        .items
         .iter()
         .map(|t| t.name.as_str())
         .collect();
@@ -220,7 +220,7 @@ fn scan_entity_filter_exclude_takes_precedence() {
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     let names: Vec<&str> = result.repos[0]
-        .tags
+        .items
         .iter()
         .map(|t| t.name.as_str())
         .collect();


### PR DESCRIPTION
## Summary

Migrates `git-tag-tidy` and `git-stash-tidy` (both uniform, both offline → `fetch: false`) onto the shared `run_pipeline` scan seam added in PR B (#195), exactly as that PR did for `git-remote-tidy`.

Each tool's hand-rolled `*RepoGroup` / `*ScanResult` / orchestration is replaced with the generic core `RepoGroup<T>` / `ScanResult<T>` plus a thin per-repo classifier closure. Each tool now declares `Classified` and `IntoJsonItem` on its item type and relies on the core blanket `FlatJsonItems` impl (the orphan-rule workaround), so the per-tool `--json` (flat item array), porcelain field count/order, and human summary line remain byte-identical.

## Behavior change (intentional, matches PR B)

When an entity filter (`--match`) excludes every item in a repo, the pipeline now drops the empty group rather than emitting a `name (0 items)` header. `total_scanned`, `counts`, and JSON are unchanged; only `repos.len()` differs. A per-tool test (`run_scan_repos_skips_repo_when_entity_filter_excludes_all_tags` / `..._stashes`) pins this.

## Notes

- `repo_display_name` now binds inside the `if verbose` block in both tools so it is not a dead allocation on quiet runs (`run_pipeline` computes the group name itself).
- Stash clean still drops in descending index order — that logic lives in `clean.rs`, not the scan path, and is unaffected; the classifier still returns stashes in their existing order (run_pipeline preserves classifier order).
- No audit-runner change: `inprocess.rs` calls the same `run_scan_repos` signatures and reads `|r| &r.counts`; the type aliases preserve all four `ScanResult` fields, so audit JSON keys are identical.
- CLAUDE.md left as-is (the stale `TagRepoGroup`/`StashRepoGroup` doc lines are updated in PR G, per the plan).

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D clippy::all`, `cargo test --workspace`, and `cargo +1.93.0 check --workspace` (MSRV) all pass locally.
- Existing output unit tests (exact-string assertions) pass unchanged aside from the `.tags`/`.stashes` → `.items` field rename.

Part of #117