### PR TITLE
Migrate branch-tidy onto core run_pipeline scan seam

### DIFF
--- a/crates/git-branch-tidy/src/clean.rs
+++ b/crates/git-branch-tidy/src/clean.rs
@@ -32,7 +32,7 @@ pub fn run_clean(
     let mut skipped = 0;
 
     for group in &scan_result.repos {
-        for branch in &group.branches {
+        for branch in &group.items {
             // Never delete the currently checked-out branch
             if branch.is_current {
                 skipped += 1;
@@ -196,11 +196,12 @@ mod tests {
     use std::path::PathBuf;
 
     use git_tidy_core::counts::Counts;
+    use git_tidy_core::scan::RepoGroup;
     use git_tidy_core::testutil::MockGitBuilder;
     use git_tidy_core::types::ClassificationLabel;
 
     use super::*;
-    use crate::types::{BranchInfo, BranchRepoGroup, BranchScanResult};
+    use crate::types::{BranchInfo, BranchScanResult};
 
     fn repo() -> PathBuf {
         PathBuf::from("/repo")
@@ -212,10 +213,10 @@ mod tests {
             counts.increment(b.classification.label());
         }
         BranchScanResult {
-            repos: vec![BranchRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: repo(),
                 name: "my-repo".to_string(),
-                branches,
+                items: branches,
             }],
             total_scanned: 0,
             counts,

--- a/crates/git-branch-tidy/src/output.rs
+++ b/crates/git-branch-tidy/src/output.rs
@@ -99,8 +99,8 @@ pub fn write_human(out: &mut dyn Write, result: &BranchScanResult) -> std::io::R
     shared::write_warnings(out, &result.warnings)?;
 
     for group in &result.repos {
-        writeln!(out, "\n{} ({} branches)", group.name, group.branches.len())?;
-        shared::format_table(out, &group.branches)?;
+        writeln!(out, "\n{} ({} branches)", group.name, group.items.len())?;
+        shared::format_table(out, &group.items)?;
     }
 
     shared::write_summary_line(
@@ -123,7 +123,7 @@ pub fn write_json(out: &mut dyn Write, result: &BranchScanResult) -> std::io::Re
 /// Write porcelain (machine-readable, tab-delimited) scan output.
 pub fn write_porcelain(out: &mut dyn Write, result: &BranchScanResult) -> std::io::Result<()> {
     for group in &result.repos {
-        shared::format_porcelain(out, &group.branches)?;
+        shared::format_porcelain(out, &group.items)?;
     }
     Ok(())
 }
@@ -135,14 +135,15 @@ mod tests {
     use super::*;
     use crate::types::*;
     use git_tidy_core::counts::Counts;
+    use git_tidy_core::scan::RepoGroup;
     use git_tidy_core::types::*;
 
     fn make_scan_result() -> BranchScanResult {
         BranchScanResult {
-            repos: vec![BranchRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: PathBuf::from("/repos/Backend"),
                 name: "Backend".to_string(),
-                branches: vec![
+                items: vec![
                     BranchInfo {
                         repo_path: PathBuf::from("/repos/Backend"),
                         name: "fix/skip-db-init".to_string(),
@@ -219,10 +220,10 @@ mod tests {
     #[test]
     fn human_output_with_partial() {
         let result = BranchScanResult {
-            repos: vec![BranchRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: PathBuf::from("/repos/App"),
                 name: "App".to_string(),
-                branches: vec![BranchInfo {
+                items: vec![BranchInfo {
                     repo_path: PathBuf::from("/repos/App"),
                     name: "alternate-icons".to_string(),
                     default_branch: "main".to_string(),
@@ -306,10 +307,10 @@ mod tests {
     #[test]
     fn human_output_remote_only_annotation() {
         let result = BranchScanResult {
-            repos: vec![BranchRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: PathBuf::from("/repos/App"),
                 name: "App".to_string(),
-                branches: vec![BranchInfo {
+                items: vec![BranchInfo {
                     repo_path: PathBuf::from("/repos/App"),
                     name: "feature/stale".to_string(),
                     default_branch: "main".to_string(),
@@ -338,10 +339,10 @@ mod tests {
     #[test]
     fn porcelain_output_remote_only_annotation() {
         let result = BranchScanResult {
-            repos: vec![BranchRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: PathBuf::from("/repos/App"),
                 name: "App".to_string(),
-                branches: vec![BranchInfo {
+                items: vec![BranchInfo {
                     repo_path: PathBuf::from("/repos/App"),
                     name: "feature/stale-remote".to_string(),
                     default_branch: "main".to_string(),
@@ -370,10 +371,10 @@ mod tests {
     #[test]
     fn json_output_includes_remote_only_field() {
         let result = BranchScanResult {
-            repos: vec![BranchRepoGroup {
+            repos: vec![RepoGroup {
                 repo_path: PathBuf::from("/repos/App"),
                 name: "App".to_string(),
-                branches: vec![BranchInfo {
+                items: vec![BranchInfo {
                     repo_path: PathBuf::from("/repos/App"),
                     name: "feature/stale-remote".to_string(),
                     default_branch: "main".to_string(),

--- a/crates/git-branch-tidy/src/scan.rs
+++ b/crates/git-branch-tidy/src/scan.rs
@@ -4,18 +4,17 @@ use std::path::{Path, PathBuf};
 use rayon::prelude::*;
 
 use git_tidy_core::classification;
-use git_tidy_core::counts::Counts;
 use git_tidy_core::error::Error;
 use git_tidy_core::filter::{NameFilter, filter_paths};
 use git_tidy_core::git::GitOps;
 use git_tidy_core::landed::{LandedCache, LandedOptions};
 use git_tidy_core::output::repo_display_name;
 use git_tidy_core::progress::Progress;
-use git_tidy_core::scan::parallel_classify;
+use git_tidy_core::scan::{ScanOptions, run_pipeline};
 use git_tidy_core::types::ClassificationLabel;
 
 use crate::discovery;
-use crate::types::{BranchInfo, BranchRepoGroup, BranchScanResult};
+use crate::types::{BranchInfo, BranchScanResult};
 
 /// Scan all repos in `directory` for stale branches.
 ///
@@ -61,15 +60,12 @@ pub fn run_scan_repos(
     include_remote: bool,
     progress: &Progress,
 ) -> Result<BranchScanResult, Error> {
-    let repo_paths_owned: Vec<PathBuf> = repo_paths.to_vec();
-    let fetch_paths: Vec<&Path> = repo_paths_owned
-        .iter()
-        .map(|p: &PathBuf| p.as_path())
-        .collect();
-    let mut warnings = git_tidy_core::fetch::parallel_fetch(git, &fetch_paths, progress);
-
-    let (repos, scan_warnings) = parallel_classify(
-        &repo_paths_owned,
+    let result = run_pipeline(
+        git,
+        repo_paths,
+        &ScanOptions { fetch: true },
+        "Scanning branches",
+        progress,
         |repo_path| {
             let mut local_warnings = Vec::new();
 
@@ -80,7 +76,7 @@ pub fn run_scan_repos(
                         "could not determine default branch for {} -- skipping",
                         repo_path.display()
                     ));
-                    return (None, local_warnings);
+                    return (Vec::new(), local_warnings);
                 }
             };
 
@@ -91,7 +87,7 @@ pub fn run_scan_repos(
                         "could not list branches for {}: {e}",
                         repo_path.display()
                     ));
-                    return (None, local_warnings);
+                    return (Vec::new(), local_warnings);
                 }
             };
 
@@ -104,14 +100,14 @@ pub fn run_scan_repos(
                         "could not determine current branch for {}: {e}",
                         repo_path.display()
                     ));
-                    return (None, local_warnings);
+                    return (Vec::new(), local_warnings);
                 }
             };
-            let repo_name = repo_display_name(repo_path);
 
             if verbose {
                 eprintln!(
-                    "{repo_name}: {} branches (default_branch={default_branch})",
+                    "{}: {} branches (default_branch={default_branch})",
+                    repo_display_name(repo_path),
                     branches.len() - 1,
                 );
             }
@@ -207,7 +203,8 @@ pub fn run_scan_repos(
 
                     if verbose && !remote_only_names.is_empty() {
                         eprintln!(
-                            "{repo_name}: {} remote-only branches",
+                            "{}: {} remote-only branches",
+                            repo_display_name(repo_path),
                             remote_only_names.len(),
                         );
                     }
@@ -267,38 +264,11 @@ pub fn run_scan_repos(
 
             classified.sort_by_key(|b| b.classification.priority());
 
-            let group = if classified.is_empty() {
-                None
-            } else {
-                Some(BranchRepoGroup {
-                    repo_path: repo_path.to_path_buf(),
-                    name: repo_name,
-                    branches: classified,
-                })
-            };
-
-            (group, local_warnings)
+            (classified, local_warnings)
         },
-        "Scanning branches",
-        progress,
     );
-    warnings.extend(scan_warnings);
 
-    let mut counts = Counts::default();
-    let mut total_scanned = 0;
-    for g in &repos {
-        for b in &g.branches {
-            counts.increment(b.classification.label());
-        }
-        total_scanned += g.branches.len();
-    }
-
-    Ok(BranchScanResult {
-        repos,
-        total_scanned,
-        counts,
-        warnings,
-    })
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -454,6 +424,31 @@ mod tests {
     }
 
     #[test]
+    fn run_scan_repos_skips_repo_when_entity_filter_excludes_all_branches() {
+        // Regression guard confirming preserved behavior: branch-tidy already
+        // dropped empty groups (its closure returned None when nothing classified),
+        // so routing through `run_pipeline` -- which also drops empty groups -- is a
+        // no-op for this case. A repo whose only candidate branch is excluded by the
+        // entity filter yields no `RepoGroup` at all.
+        // The candidate branch `feature/x` is dropped by the entity filter before
+        // it reaches classification, so no rev-parse/rev-list mock setup is needed
+        // (mirrors the stash-tidy sibling test).
+        let git = MockGitBuilder::new()
+            .with_symbolic_ref(&repo(), Some("main"))
+            .with_local_branches(&repo(), vec!["main".to_string(), "feature/x".to_string()])
+            .with_current_branch(&repo(), Some("main"))
+            .build();
+
+        let p = Progress::disabled();
+        // Include only "other", which the candidate branch "feature/x" does not match.
+        let filter = NameFilter::new(&["other".to_string()], &[]);
+        let result = run_scan_repos(&git, &[repo()], 100, false, &filter, false, &p).unwrap();
+
+        assert!(result.repos.is_empty());
+        assert_eq!(result.total_scanned, 0);
+    }
+
+    #[test]
     fn scan_marks_current_branch() {
         let git = MockGitBuilder::new()
             .with_symbolic_ref(&repo(), Some("main"))
@@ -518,7 +513,7 @@ mod tests {
         let result = run_scan_repos(&git, &[repo()], 100, false, &filter, true, &p).unwrap();
         assert_eq!(result.total_scanned, 1);
         assert_eq!(result.counts.get("landed"), 1);
-        let branch = &result.repos[0].branches[0];
+        let branch = &result.repos[0].items[0];
         assert_eq!(branch.name, "feature/remote-only");
         assert!(branch.remote_only);
         assert!(branch.remote_tracking);

--- a/crates/git-branch-tidy/src/types.rs
+++ b/crates/git-branch-tidy/src/types.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use git_tidy_core::counts::Counts;
+use git_tidy_core::scan::{Classified, ScanResult};
 use git_tidy_core::types::{
     Classification, ClassificationLabel, UnmatchedCommit, extract_landed_fields,
 };
@@ -33,39 +33,24 @@ pub struct BranchInfo {
     pub remote_only: bool,
 }
 
-/// A group of branches in the same repo.
-#[derive(Debug, Clone, Serialize)]
-pub struct BranchRepoGroup {
-    /// Path to the repo.
-    pub repo_path: PathBuf,
-    /// Display name (directory basename).
-    pub name: String,
-    /// Branches belonging to this repo, sorted by classification priority.
-    pub branches: Vec<BranchInfo>,
+impl Classified for BranchInfo {
+    fn classification_label(&self) -> &str {
+        self.classification.label()
+    }
 }
 
 /// Result of a full branch scan.
-#[derive(Debug, Clone, Serialize)]
-pub struct BranchScanResult {
-    /// Branches grouped by repo.
-    pub repos: Vec<BranchRepoGroup>,
-    /// Total branches scanned (excluding default branches).
-    pub total_scanned: usize,
-    /// Summary counts by classification.
-    pub counts: Counts,
-    /// Warnings encountered during scanning.
-    pub warnings: Vec<String>,
-}
+///
+/// Branches are grouped per repo in `repos` as `RepoGroup<BranchInfo>` (the
+/// generic core group type); each group's `items` are sorted by classification
+/// priority.
+pub type BranchScanResult = ScanResult<BranchInfo>;
 
-impl git_tidy_core::output::FlatJsonItems for BranchScanResult {
+impl git_tidy_core::output::IntoJsonItem for BranchInfo {
     type JsonItem = JsonBranch;
 
-    fn to_json_items(&self) -> Vec<JsonBranch> {
-        self.repos
-            .iter()
-            .flat_map(|g| g.branches.iter())
-            .map(JsonBranch::from)
-            .collect()
+    fn to_json_item(&self) -> JsonBranch {
+        JsonBranch::from(self)
     }
 }
 

--- a/crates/git-branch-tidy/tests/integration_scan.rs
+++ b/crates/git-branch-tidy/tests/integration_scan.rs
@@ -37,11 +37,11 @@ fn scan_real_repo_with_mixed_branches() {
     let repo_group = &result.repos[0];
 
     // Default branch (main) should be excluded, so we get feature/done and feature/wip
-    assert_eq!(repo_group.branches.len(), 2);
+    assert_eq!(repo_group.items.len(), 2);
 
     // feature/done should be merged (it's at same commit as main)
     let done = repo_group
-        .branches
+        .items
         .iter()
         .find(|b| b.name == "feature/done")
         .expect("should find feature/done");
@@ -49,15 +49,15 @@ fn scan_real_repo_with_mixed_branches() {
 
     // feature/wip should be local (no remote tracking, has unique commits)
     let wip = repo_group
-        .branches
+        .items
         .iter()
         .find(|b| b.name == "feature/wip")
         .expect("should find feature/wip");
     assert_eq!(wip.classification, Classification::Local);
 
     // Sorted by priority: merged first, then local
-    assert_eq!(repo_group.branches[0].name, "feature/done");
-    assert_eq!(repo_group.branches[1].name, "feature/wip");
+    assert_eq!(repo_group.items[0].name, "feature/done");
+    assert_eq!(repo_group.items[1].name, "feature/wip");
 
     // Counts
     assert_eq!(result.total_scanned, 2);
@@ -91,7 +91,7 @@ fn scan_marks_current_branch_in_real_repo() {
     .unwrap();
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
-    let branch = &result.repos[0].branches[0];
+    let branch = &result.repos[0].items[0];
     assert_eq!(branch.name, "my-feature");
     assert!(branch.is_current);
 }
@@ -124,7 +124,7 @@ fn scan_entity_filter_includes_matching_branches() {
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     let names: Vec<&str> = result.repos[0]
-        .branches
+        .items
         .iter()
         .map(|b| b.name.as_str())
         .collect();
@@ -162,7 +162,7 @@ fn scan_entity_filter_exclude_takes_precedence() {
 
     assert_eq!(result.repos.len(), 1, "warnings: {:?}", result.warnings);
     let names: Vec<&str> = result.repos[0]
-        .branches
+        .items
         .iter()
         .map(|b| b.name.as_str())
         .collect();


### PR DESCRIPTION
Migrates `git-branch-tidy` onto the shared `run_pipeline` scan seam (core PR B), the first non-trivial tool: it is `fetch: true`, owns its fetch today, runs nested parallelism, discovers remote-only branches under `--include-remote`, and carries a per-repo `LandedCache`. The seam absorbs the orchestration; the domain logic stays in the closure.

## What changed

- `types.rs`: delete `BranchRepoGroup`; `BranchScanResult` becomes `ScanResult<BranchInfo>` (the core generic). `BranchInfo` now implements `Classified` and `IntoJsonItem`, replacing the hand-rolled `FlatJsonItems for BranchScanResult` (the orphan-rule-safe shape). `JsonBranch` and its `From<&BranchInfo>` are untouched, so the public JSON is identical.
- `scan.rs`: `run_scan_repos` hands its fetch to the seam via `ScanOptions { fetch: true }` and delegates to `run_pipeline`. The closure returns `Vec<BranchInfo>` (empty on skip); the manual `parallel_fetch` setup, counts/`total_scanned` fold, and group assembly are gone. `--include-remote` discovery, `LandedCache`, the entity filter, and the inner per-branch `par_iter` stay inside the closure.
- `output.rs` / `clean.rs` / `tests/integration_scan.rs`: `.branches` → `.items` field rename; test fixtures use the generic `RepoGroup`.

## Behavior preservation

- **Fetch parity:** `run_pipeline` fetches every repo before classifying and orders fetch warnings ahead of classify warnings — identical to the old `parallel_fetch(...)` + `warnings.extend(scan_warnings)`. Covered by core seam tests from PR B.
- **Byte-identical output:** `--json` flat array (incl. `landed_ratio`/`landed_total`/`unmatched_commits`), 8-field porcelain rows, and the `LANDED_SUMMARY` human summary are unchanged; the existing `output.rs` string-assertion tests pass unchanged save the `.branches`→`.items` fixture rename.
- **Empty groups already dropped today** (the closure returned `None` when nothing classified), so routing through `run_pipeline` is a no-op for that case — not the intentional behavior change the offline tools carried. A regression-guard test (`run_scan_repos_skips_repo_when_entity_filter_excludes_all_branches`) pins the preserved behavior.
- **Item ordering:** the closure still `sort_by_key(classification.priority())`; the seam does not reorder.
- **Audit runner unchanged:** `inprocess.rs` calls the same 7-arg `run_scan_repos` and reads `.counts`; the type alias keeps `repos`/`total_scanned`/`counts`/`warnings`, so audit JSON keys are identical.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D clippy::all`, `cargo test --workspace`, and `cargo +1.93.0 check --workspace` (MSRV) all pass locally.

Net −20 lines (deleting the manual fetch setup + counts fold + group assembly, minus the added regression test).

Part of #117