### PR TITLE
Unify repo-tidy and lfs-tidy JSON emit onto the shared write_json_flat path

### DIFF
--- a/crates/git-lfs-tidy/src/output.rs
+++ b/crates/git-lfs-tidy/src/output.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use git_tidy_core::output as shared;
 use git_tidy_core::output::{Cell, ColumnSpec, TidyItem};
 
-use crate::types::{JsonLfsItem, LfsClassification, LfsInfo, LfsScanResult};
+use crate::types::{LfsClassification, LfsInfo, LfsScanResult};
 
 /// Format bytes into a human-readable string.
 pub fn format_bytes(bytes: u64) -> String {
@@ -129,14 +129,7 @@ fn write_lfs_summary(out: &mut dyn Write, result: &LfsScanResult) -> std::io::Re
 
 /// Write JSON scan output using the flat spec format.
 pub fn write_json(out: &mut dyn Write, result: &LfsScanResult) -> std::io::Result<()> {
-    let all_items: Vec<JsonLfsItem> = result
-        .repos
-        .iter()
-        .flat_map(|g| g.items.iter())
-        .map(JsonLfsItem::from)
-        .collect();
-
-    shared::write_json_pretty(out, &all_items)
+    shared::write_json_flat(out, result)
 }
 
 /// Write porcelain (machine-readable, tab-delimited) scan output.

--- a/crates/git-lfs-tidy/src/scan.rs
+++ b/crates/git-lfs-tidy/src/scan.rs
@@ -304,17 +304,6 @@ mod tests {
     // --- run_scan tests ---
 
     #[test]
-    fn scan_empty_repo_no_lfs() {
-        let _git = MockGitBuilder::new()
-            .with_lfs_installed(false)
-            .with_find_large_blobs(&repo(), vec![])
-            .build();
-
-        // discover_repos needs a real directory -- tested in integration tests
-        // Here we test the logic with mock by calling directly
-    }
-
-    #[test]
     fn scan_with_healthy_lfs_files() {
         let git = MockGitBuilder::new()
             .with_lfs_installed(true)

--- a/crates/git-lfs-tidy/src/types.rs
+++ b/crates/git-lfs-tidy/src/types.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use git_tidy_core::counts::Counts;
+use git_tidy_core::output::{FlatJsonItems, IntoJsonItem};
 use serde::Serialize;
 
 /// Classification of an LFS item.
@@ -103,6 +104,29 @@ impl From<&LfsInfo> for JsonLfsItem {
             oid: info.oid.clone(),
             size_bytes: info.size_bytes,
         }
+    }
+}
+
+impl IntoJsonItem for LfsInfo {
+    type JsonItem = JsonLfsItem;
+
+    fn to_json_item(&self) -> JsonLfsItem {
+        JsonLfsItem::from(self)
+    }
+}
+
+/// `LfsScanResult` is bespoke (it carries the result-level `lfs_installed`
+/// flag), so it cannot use the blanket `FlatJsonItems for ScanResult<T>` impl in
+/// core; it flattens its groups' items the same way, via [`IntoJsonItem`].
+impl FlatJsonItems for LfsScanResult {
+    type JsonItem = JsonLfsItem;
+
+    fn to_json_items(&self) -> Vec<JsonLfsItem> {
+        self.repos
+            .iter()
+            .flat_map(|g| g.items.iter())
+            .map(IntoJsonItem::to_json_item)
+            .collect()
     }
 }
 

--- a/crates/git-repo-tidy/src/output.rs
+++ b/crates/git-repo-tidy/src/output.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use git_tidy_core::output as shared;
 use git_tidy_core::output::{Cell, ColumnSpec, TidyItem};
 
-use crate::types::{JsonRepo, RepoInfo, RepoScanResult, format_disk_size, format_last_commit_age};
+use crate::types::{RepoInfo, RepoScanResult, format_disk_size, format_last_commit_age};
 
 impl TidyItem for RepoInfo {
     const COLUMNS: &'static [ColumnSpec] = &[
@@ -112,8 +112,7 @@ fn write_summary(out: &mut dyn Write, result: &RepoScanResult) -> std::io::Resul
 
 /// Write JSON scan output using the flat format.
 pub fn write_json(out: &mut dyn Write, result: &RepoScanResult) -> std::io::Result<()> {
-    let all_repos: Vec<JsonRepo> = result.repos.iter().map(JsonRepo::from).collect();
-    shared::write_json_pretty(out, &all_repos)
+    shared::write_json_flat(out, result)
 }
 
 /// Write porcelain (machine-readable, tab-delimited) scan output.

--- a/crates/git-repo-tidy/src/types.rs
+++ b/crates/git-repo-tidy/src/types.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use git_tidy_core::counts::Counts;
+use git_tidy_core::output::{FlatJsonItems, IntoJsonItem};
 use serde::Serialize;
 
 /// Classification of a repository by activity level.
@@ -114,6 +115,26 @@ impl From<&RepoInfo> for JsonRepo {
             is_dirty: r.is_dirty,
             dirty_file_count: r.dirty_file_count,
         }
+    }
+}
+
+impl IntoJsonItem for RepoInfo {
+    type JsonItem = JsonRepo;
+
+    fn to_json_item(&self) -> JsonRepo {
+        JsonRepo::from(self)
+    }
+}
+
+/// `RepoScanResult` is bespoke (flat — no `RepoGroup` — and carries result-level
+/// disk metrics and the cross-cutting `dirty` count), so it cannot use the
+/// blanket `FlatJsonItems for ScanResult<T>` impl in core; it maps its flat
+/// `repos` directly via [`IntoJsonItem`].
+impl FlatJsonItems for RepoScanResult {
+    type JsonItem = JsonRepo;
+
+    fn to_json_items(&self) -> Vec<JsonRepo> {
+        self.repos.iter().map(IntoJsonItem::to_json_item).collect()
     }
 }
 


### PR DESCRIPTION
## Summary

repo-tidy and lfs-tidy were the **last two scan tools** still emitting `--json` via a hand-rolled `result.repos…map(JsonX::from).collect()` + `shared::write_json_pretty`. Every uniform tool (remote/tag/stash/branch/worktree) already routes through the shared `IntoJsonItem` + `write_json_flat` mechanism. This change moves the two remaining tools onto it, so **all seven scan-shaped tools share one JSON-emit path**.

## Why these two are different

They are the plan's structural exceptions ([#117](https://github.com/jakebromberg/git-tidy/issues/117) §4): they keep their **bespoke** result types — repo-tidy's flat `RepoScanResult` (disk metrics + the cross-cutting `dirty` count) and lfs-tidy's `LfsScanResult` (the `lfs_installed` flag) — and stay on Layer 1 (`parallel_classify`), **not** `run_pipeline`. Because their results are bespoke, they cannot use the blanket `impl<T: IntoJsonItem> FlatJsonItems for ScanResult<T>` in core. So each tool:
- implements `IntoJsonItem` on its item row type (`RepoInfo` / `LfsInfo`), delegating to the existing `From`, matching the convention of the 5 migrated tools; and
- hand-writes a `FlatJsonItems` impl on its bespoke result (lfs flattens `repos → items`; repo maps its flat `repos` directly, since it has no `RepoGroup`).

`write_json` then collapses to `shared::write_json_flat(out, result)`.

## Output is byte-identical

The same `JsonRepo`/`JsonLfsItem` values, in the same order, serialized by the same `write_json_pretty` underneath `write_json_flat`. The existing `json_output_valid` and `json_*_from_info` tests pass unchanged. No result/group types, classification folds, or orchestration change; the audit runner (`|r| &r.counts`) is untouched.

## Also

Drops the dead `scan_empty_repo_no_lfs` lfs test stub, which built a mock and then asserted nothing (its real coverage lives in the integration tests).

Local gate jobs green: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D clippy::all`, `cargo test --workspace`, `cargo +1.93.0 check --workspace` (MSRV).

Part of #117