### PR TITLE
Migrate branch-tidy and worktree-tidy onto the CleanPipeline seam

### DIFF
--- a/crates/git-branch-tidy/src/clean.rs
+++ b/crates/git-branch-tidy/src/clean.rs
@@ -1,5 +1,7 @@
 use std::io::Write;
 
+use git_tidy_core::classification::should_clean_landed;
+use git_tidy_core::clean::{Decision, Outcome, run_clean as core_run_clean};
 use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
 use git_tidy_core::types::{Classification, CleanResult, FailedItem, RemovedRef};
@@ -21,6 +23,11 @@ pub struct CleanOptions {
 }
 
 /// Run the clean operation on a scan result.
+///
+/// Calls the shared [`core_run_clean`] pipeline once per repo group so each
+/// group's `name` is in scope for the per-item wording and output stays
+/// per-repo-contiguous, accumulating each group's [`CleanResult`] into the
+/// overall succeeded / failed / skipped totals.
 pub fn run_clean(
     git: &dyn GitOps,
     scan_result: &BranchScanResult,
@@ -32,129 +39,135 @@ pub fn run_clean(
     let mut skipped = 0;
 
     for group in &scan_result.repos {
-        for branch in &group.items {
-            // Never delete the currently checked-out branch
-            if branch.is_current {
-                skipped += 1;
-                continue;
-            }
-
-            // Filter by classification
-            if !should_clean(&branch.classification, options) {
-                skipped += 1;
-                continue;
-            }
-
-            // Remote-only branches: delete from origin directly, skip local deletion
-            if branch.remote_only {
-                if options.dry_run {
-                    writeln!(out, "would delete remote {} in {}", branch.name, group.name)?;
-                    succeeded.push(RemovedRef {
-                        repo: branch.repo_path.clone(),
-                        name: branch.name.clone(),
-                        remote_deleted: true,
-                    });
-                    continue;
+        let result = core_run_clean(
+            &group.items,
+            |branch| {
+                // Never delete the currently checked-out branch, then filter by
+                // classification. Both rejections are silent skips.
+                if !branch.is_current
+                    && should_clean_landed(&branch.classification, options.all, options.strict)
+                {
+                    Decision::Clean
+                } else {
+                    Decision::Skip
                 }
-
-                match git.delete_remote_branch(&branch.repo_path, "origin", &branch.name) {
-                    Ok(()) => {
-                        writeln!(out, "deleted remote {}", branch.name)?;
-                        succeeded.push(RemovedRef {
+            },
+            |branch, out| {
+                // Remote-only branches: delete from origin directly, skip local deletion
+                if branch.remote_only {
+                    if options.dry_run {
+                        writeln!(out, "would delete remote {} in {}", branch.name, group.name)?;
+                        return Ok(Outcome::Cleaned(RemovedRef {
                             repo: branch.repo_path.clone(),
                             name: branch.name.clone(),
                             remote_deleted: true,
-                        });
+                        }));
+                    }
+
+                    return match git.delete_remote_branch(&branch.repo_path, "origin", &branch.name)
+                    {
+                        Ok(()) => {
+                            writeln!(out, "deleted remote {}", branch.name)?;
+                            Ok(Outcome::Cleaned(RemovedRef {
+                                repo: branch.repo_path.clone(),
+                                name: branch.name.clone(),
+                                remote_deleted: true,
+                            }))
+                        }
+                        Err(e) => {
+                            writeln!(out, "error: could not delete remote {}: {e}", branch.name)?;
+                            Ok(Outcome::Failed(FailedItem {
+                                repo: branch.repo_path.clone(),
+                                name: branch.name.clone(),
+                                reason: e.to_string(),
+                            }))
+                        }
+                    };
+                }
+
+                if options.dry_run {
+                    write!(out, "would delete {}", branch.name)?;
+                    if options.include_remote && branch.remote_tracking && !branch.remote_deleted {
+                        write!(out, " (and remote)")?;
+                    }
+                    writeln!(out, " in {}", group.name)?;
+                    return Ok(Outcome::Cleaned(RemovedRef {
+                        repo: branch.repo_path.clone(),
+                        name: branch.name.clone(),
+                        remote_deleted: false,
+                    }));
+                }
+
+                // Delete the local branch.
+                // Use force-delete for branches our analysis has confirmed as landed,
+                // since git's built-in merge check doesn't understand squash merges.
+                let force_delete = options.force
+                    || matches!(
+                        branch.classification,
+                        Classification::Landed
+                            | Classification::LandedStale
+                            | Classification::LandedByContent { .. }
+                    );
+                let delete_result = if force_delete {
+                    git.branch_delete(&branch.repo_path, &branch.name)
+                } else {
+                    git.branch_delete_safe(&branch.repo_path, &branch.name)
+                };
+
+                match delete_result {
+                    Ok(()) => {
+                        let mut remote_deleted = false;
+
+                        // Delete remote branch if requested
+                        if options.include_remote
+                            && branch.remote_tracking
+                            && !branch.remote_deleted
+                            && let Some(remote) =
+                                derive_remote_name(git, &branch.repo_path, &branch.name)
+                        {
+                            match git.delete_remote_branch(&branch.repo_path, &remote, &branch.name)
+                            {
+                                Ok(()) => {
+                                    remote_deleted = true;
+                                }
+                                Err(e) => {
+                                    writeln!(
+                                        out,
+                                        "warning: could not delete remote branch {}/{}: {e}",
+                                        remote, branch.name
+                                    )?;
+                                }
+                            }
+                        }
+
+                        writeln!(
+                            out,
+                            "deleted {}{}",
+                            branch.name,
+                            if remote_deleted { " (and remote)" } else { "" }
+                        )?;
+                        Ok(Outcome::Cleaned(RemovedRef {
+                            repo: branch.repo_path.clone(),
+                            name: branch.name.clone(),
+                            remote_deleted,
+                        }))
                     }
                     Err(e) => {
-                        writeln!(out, "error: could not delete remote {}: {e}", branch.name)?;
-                        failed.push(FailedItem {
+                        writeln!(out, "error: could not delete {}: {e}", branch.name)?;
+                        Ok(Outcome::Failed(FailedItem {
                             repo: branch.repo_path.clone(),
                             name: branch.name.clone(),
                             reason: e.to_string(),
-                        });
+                        }))
                     }
                 }
-                continue;
-            }
+            },
+            out,
+        )?;
 
-            if options.dry_run {
-                write!(out, "would delete {}", branch.name)?;
-                if options.include_remote && branch.remote_tracking && !branch.remote_deleted {
-                    write!(out, " (and remote)")?;
-                }
-                writeln!(out, " in {}", group.name)?;
-                succeeded.push(RemovedRef {
-                    repo: branch.repo_path.clone(),
-                    name: branch.name.clone(),
-                    remote_deleted: false,
-                });
-                continue;
-            }
-
-            // Delete the local branch.
-            // Use force-delete for branches our analysis has confirmed as landed,
-            // since git's built-in merge check doesn't understand squash merges.
-            let force_delete = options.force
-                || matches!(
-                    branch.classification,
-                    Classification::Landed
-                        | Classification::LandedStale
-                        | Classification::LandedByContent { .. }
-                );
-            let delete_result = if force_delete {
-                git.branch_delete(&branch.repo_path, &branch.name)
-            } else {
-                git.branch_delete_safe(&branch.repo_path, &branch.name)
-            };
-
-            match delete_result {
-                Ok(()) => {
-                    let mut remote_deleted = false;
-
-                    // Delete remote branch if requested
-                    if options.include_remote
-                        && branch.remote_tracking
-                        && !branch.remote_deleted
-                        && let Some(remote) =
-                            derive_remote_name(git, &branch.repo_path, &branch.name)
-                    {
-                        match git.delete_remote_branch(&branch.repo_path, &remote, &branch.name) {
-                            Ok(()) => {
-                                remote_deleted = true;
-                            }
-                            Err(e) => {
-                                writeln!(
-                                    out,
-                                    "warning: could not delete remote branch {}/{}: {e}",
-                                    remote, branch.name
-                                )?;
-                            }
-                        }
-                    }
-
-                    writeln!(
-                        out,
-                        "deleted {}{}",
-                        branch.name,
-                        if remote_deleted { " (and remote)" } else { "" }
-                    )?;
-                    succeeded.push(RemovedRef {
-                        repo: branch.repo_path.clone(),
-                        name: branch.name.clone(),
-                        remote_deleted,
-                    });
-                }
-                Err(e) => {
-                    writeln!(out, "error: could not delete {}: {e}", branch.name)?;
-                    failed.push(FailedItem {
-                        repo: branch.repo_path.clone(),
-                        name: branch.name.clone(),
-                        reason: e.to_string(),
-                    });
-                }
-            }
-        }
+        succeeded.extend(result.succeeded);
+        failed.extend(result.failed);
+        skipped += result.skipped;
     }
 
     Ok(CleanResult {
@@ -162,25 +175,6 @@ pub fn run_clean(
         failed,
         skipped,
     })
-}
-
-/// Determine if a branch should be cleaned based on its classification and options.
-fn should_clean(classification: &Classification, options: &CleanOptions) -> bool {
-    if options.all {
-        return true;
-    }
-
-    if options.strict {
-        return matches!(classification, Classification::Landed);
-    }
-
-    // Default: landed (structural) + landed-stale + landed-by-content
-    matches!(
-        classification,
-        Classification::Landed
-            | Classification::LandedStale
-            | Classification::LandedByContent { .. }
-    )
 }
 
 /// Derive the remote name from a branch's upstream tracking info.

--- a/crates/git-tidy-core/src/classification.rs
+++ b/crates/git-tidy-core/src/classification.rs
@@ -8,6 +8,31 @@ use crate::types::{
     Annotations, BranchClassification, Classification, ClassificationLabel, WorktreeInfo,
 };
 
+/// Decide whether a branch/worktree classification is eligible for cleanup,
+/// given the shared `--all` / `--strict` flags.
+///
+/// This is the pure classification filter shared verbatim by branch-tidy and
+/// worktree-tidy (each tool's former `should_clean`): `--all` admits everything;
+/// `--strict` admits only structurally-proven [`Classification::Landed`];
+/// otherwise the default admits landed, landed-stale, and landed-by-content.
+pub fn should_clean_landed(classification: &Classification, all: bool, strict: bool) -> bool {
+    if all {
+        return true;
+    }
+
+    if strict {
+        return matches!(classification, Classification::Landed);
+    }
+
+    // Default: landed (structural) + landed-stale + landed-by-content
+    matches!(
+        classification,
+        Classification::Landed
+            | Classification::LandedStale
+            | Classification::LandedByContent { .. }
+    )
+}
+
 /// Detect the default branch for a repo.
 /// 1. Try `git symbolic-ref refs/remotes/origin/HEAD`
 /// 2. Probe for `origin/main`, then `origin/master`

--- a/crates/git-worktree-tidy/src/clean.rs
+++ b/crates/git-worktree-tidy/src/clean.rs
@@ -1,6 +1,8 @@
 use std::io::Write;
 use std::path::PathBuf;
 
+use git_tidy_core::classification::should_clean_landed;
+use git_tidy_core::clean::{Decision, Outcome, run_clean as core_run_clean};
 use git_tidy_core::error::Error;
 use git_tidy_core::git::GitOps;
 use git_tidy_core::types::{
@@ -32,6 +34,11 @@ pub struct RemovedWorktree {
 }
 
 /// Run the clean operation on a scan result.
+///
+/// Calls the shared [`core_run_clean`] pipeline once per repo group so each
+/// group's `name` is in scope for the per-item wording and output stays
+/// per-repo-contiguous, accumulating each group's [`CleanResult`] into the
+/// overall succeeded / failed / skipped totals.
 pub fn run_clean(
     git: &dyn GitOps,
     scan_result: &WorktreeScanResult,
@@ -43,81 +50,86 @@ pub fn run_clean(
     let mut skipped = 0;
 
     for group in &scan_result.repos {
-        for wt in &group.items {
-            // Filter by classification
-            if !should_clean(&wt.classification, options) {
-                skipped += 1;
-                continue;
-            }
-
-            let dir_name = worktree_display_name(wt);
-
-            // Check if dirty and not forced
-            if wt.annotations.dirty && !options.force {
-                // LandedStale dirty is always a stale-index artifact — safe to clean
-                if matches!(wt.classification, Classification::LandedStale) {
-                    // Fall through to removal
+        let result = core_run_clean(
+            &group.items,
+            |wt| {
+                if should_clean(&wt.classification, options) {
+                    Decision::Clean
                 } else {
-                    // Check if working tree matches default branch
-                    let diff_ref = format!("origin/{}", wt.default_branch);
-                    let diff_files = git
-                        .diff_working_tree_files(&wt.path, &diff_ref)
-                        .or_else(|_| git.diff_working_tree_files(&wt.path, &wt.default_branch));
+                    Decision::Skip
+                }
+            },
+            |wt, out| {
+                let dir_name = worktree_display_name(wt);
 
-                    match diff_files {
-                        Ok(files) if files.is_empty() => {
-                            // Working tree matches main — dirty is informational
-                        }
-                        _ => {
-                            writeln!(
-                                out,
-                                "skipped {dir_name}: dirty ({} files), use --force to remove",
-                                wt.annotations.dirty_file_count
-                            )?;
-                            skipped += 1;
-                            continue;
+                // Check if dirty and not forced
+                if wt.annotations.dirty && !options.force {
+                    // LandedStale dirty is always a stale-index artifact — safe to clean
+                    if matches!(wt.classification, Classification::LandedStale) {
+                        // Fall through to removal
+                    } else {
+                        // Check if working tree matches default branch
+                        let diff_ref = format!("origin/{}", wt.default_branch);
+                        let diff_files = git
+                            .diff_working_tree_files(&wt.path, &diff_ref)
+                            .or_else(|_| git.diff_working_tree_files(&wt.path, &wt.default_branch));
+
+                        match diff_files {
+                            Ok(files) if files.is_empty() => {
+                                // Working tree matches main — dirty is informational
+                            }
+                            _ => {
+                                writeln!(
+                                    out,
+                                    "skipped {dir_name}: dirty ({} files), use --force to remove",
+                                    wt.annotations.dirty_file_count
+                                )?;
+                                return Ok(Outcome::Skipped);
+                            }
                         }
                     }
                 }
-            }
 
-            if options.dry_run {
-                write!(out, "would remove {dir_name}")?;
-                if options.delete_branches
-                    && let Some(branch) = &wt.branch
-                {
-                    write!(out, " (and branch {branch})")?;
+                if options.dry_run {
+                    write!(out, "would remove {dir_name}")?;
+                    if options.delete_branches
+                        && let Some(branch) = &wt.branch
+                    {
+                        write!(out, " (and branch {branch})")?;
+                    }
+                    writeln!(out, " in {}", group.name)?;
+                    return Ok(Outcome::Cleaned(RemovedWorktree {
+                        repo: wt.parent_repo.clone(),
+                        path: wt.path.clone(),
+                        branch: wt.branch.clone(),
+                        branch_deleted: false,
+                    }));
                 }
-                writeln!(out, " in {}", group.name)?;
-                succeeded.push(RemovedWorktree {
-                    repo: wt.parent_repo.clone(),
-                    path: wt.path.clone(),
-                    branch: wt.branch.clone(),
-                    branch_deleted: false,
-                });
-                continue;
-            }
 
-            // Three-tier removal strategy
-            match remove_worktree(git, wt, options, out) {
-                Ok(branch_deleted) => {
-                    succeeded.push(RemovedWorktree {
+                // Three-tier removal strategy
+                match remove_worktree(git, wt, options, out) {
+                    Ok(branch_deleted) => Ok(Outcome::Cleaned(RemovedWorktree {
                         repo: wt.parent_repo.clone(),
                         path: wt.path.clone(),
                         branch: wt.branch.clone(),
                         branch_deleted,
-                    });
+                    })),
+                    Err(e) => {
+                        writeln!(out, "error: could not remove {dir_name}: {e}")?;
+                        Ok(Outcome::Failed(FailedItem {
+                            repo: wt.parent_repo.clone(),
+                            name: dir_name,
+                            reason: e.to_string(),
+                        }))
+                    }
                 }
-                Err(e) => {
-                    writeln!(out, "error: could not remove {dir_name}: {e}")?;
-                    failed.push(FailedItem {
-                        repo: wt.parent_repo.clone(),
-                        name: dir_name,
-                        reason: e.to_string(),
-                    });
-                }
-            }
-        }
+            },
+            out,
+        )?;
+
+        succeeded.extend(result.succeeded);
+        failed.extend(result.failed);
+        skipped += result.skipped;
     }
 
     Ok(CleanResult {
@@ -128,22 +140,10 @@ pub fn run_clean(
 }
 
 /// Determine if a worktree should be cleaned based on its classification and options.
+///
+/// Thin wrapper over the shared [`should_clean_landed`] filter.
 fn should_clean(classification: &Classification, options: &CleanOptions) -> bool {
-    if options.all {
-        return true;
-    }
-
-    if options.strict {
-        return matches!(classification, Classification::Landed);
-    }
-
-    // Default: landed (structural) + landed-stale + landed-by-content
-    matches!(
-        classification,
-        Classification::Landed
-            | Classification::LandedStale
-            | Classification::LandedByContent { .. }
-    )
+    should_clean_landed(classification, options.all, options.strict)
 }
 
 /// Extract the directory basename for display.


### PR DESCRIPTION
Step 3 of #118 (1 of 5 tool-migration PRs). Moves `git-branch-tidy` and `git-worktree-tidy` off their hand-rolled clean loops and onto the shared `git_tidy_core::clean::run_clean` seam, and deduplicates the byte-identical `should_clean` the two shared.

- Each tool calls `run_clean` once per repo group; `decide` is the pure silent filter, `act` owns dry-run/wording/guards/delete/record. Public signatures and return types unchanged.
- branch: `decide` also silently skips the current branch; `act` preserves the remote-only path, force-vs-safe local delete, `include_remote` soft-warning, and all wording.
- worktree: `act` preserves the dirty guard (LandedStale fall-through + working-tree diff-check), the three-tier `remove_worktree`, and the `delete_branches` fail-closed guard.
- New `git_tidy_core::classification::should_clean_landed(c, all, strict)` is the one shared filter; worktree keeps a thin wrapper so its existing unit tests still exercise it.

Behavior-preserving: all existing unit + integration tests pass unchanged. Local CI green (fmt, clippy -D, test).

Refs #118